### PR TITLE
Improve injection performance with compile-time code generation

### DIFF
--- a/src/main/scala/wvlet/airframe/AirframeMacros.scala
+++ b/src/main/scala/wvlet/airframe/AirframeMacros.scala
@@ -48,11 +48,11 @@ object AirframeMacros extends LogSupport {
         // we need to instantiate it first in order to populate its $outer variables
         true
       }
-      else if (a.isAbstract) {
+      else if (a.isAbstract && hasAbstractMethods) {
         // = Abstract type
         // We cannot build abstract type X that has abstract methods, so bind[X].to[ConcreteType]
-        // needs to be found in the design unless it has the default constructor
-        hasPublicDefaultConstructor && !hasAbstractMethods
+        // needs to be found in the design
+        false
       }
       else {
         // We cannot instantiate any trait or class without the default constructor

--- a/src/main/scala/wvlet/airframe/AirframeMacros.scala
+++ b/src/main/scala/wvlet/airframe/AirframeMacros.scala
@@ -21,7 +21,7 @@ import scala.reflect.{macros => sm}
 
 object AirframeMacros extends LogSupport {
 
-  class BindHelper[C <: Context](val c: C) {
+  private[airframe] class BindHelper[C <: Context](val c: C) {
 
     def bind(session: c.Tree, typeEv: c.Tree): c.Tree = {
       import c.universe._

--- a/src/test/scala/wvlet/airframe/AirframeMacrosTest.scala
+++ b/src/test/scala/wvlet/airframe/AirframeMacrosTest.scala
@@ -66,4 +66,3 @@ class AirframeMacrosTest extends AirframeSpec {
     }
   }
 }
-

--- a/src/test/scala/wvlet/airframe/AirframeMacrosTest.scala
+++ b/src/test/scala/wvlet/airframe/AirframeMacrosTest.scala
@@ -43,7 +43,6 @@ class ConcreteClass {
   *
   */
 class AirframeMacrosTest extends AirframeSpec {
-  Logger("wvlet.airframe").setLogLevel(LogLevel.TRACE)
   "AirframeMacro" should {
     "build trait at compile time" in {
       val session = newDesign.newSession

--- a/src/test/scala/wvlet/airframe/AirframeMacrosTest.scala
+++ b/src/test/scala/wvlet/airframe/AirframeMacrosTest.scala
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe
+
+import wvlet.log.{LogLevel, LogSupport, Logger}
+
+trait NonAbstractTrait extends LogSupport {
+  info("hello trait")
+}
+
+trait AbstractTrait extends LogSupport {
+  def abstractMethod : Unit
+}
+
+trait ConcreteTrait extends AbstractTrait {
+  override def abstractMethod: Unit = { info("hello abstract trait") }
+}
+
+trait App {
+  val t = bind[NonAbstractTrait]
+}
+
+trait App2 {
+  val t = bind[AbstractTrait]
+}
+
+class ConcreteClass {
+  val t = bind[NonAbstractTrait]
+}
+
+/**
+  *
+  */
+class AirframeMacrosTest extends AirframeSpec {
+  Logger("wvlet.airframe").setLogLevel(LogLevel.TRACE)
+  "AirframeMacro" should {
+    "build trait at compile time" in {
+      val session = newDesign.newSession
+      session.build[NonAbstractTrait]
+      session.build[App]
+    }
+
+    "build abstract trait" in {
+      val session = newDesign.bind[AbstractTrait].to[ConcreteTrait]
+                    .newSession
+
+      val t = session.build[AbstractTrait]
+      val app = session.build[App2]
+      t.abstractMethod
+      app.t.abstractMethod
+    }
+
+    "inject Session to concrete class" in {
+      newDesign.newSession.build[ConcreteClass]
+    }
+  }
+}
+

--- a/src/test/scala/wvlet/airframe/LifeCycleManagerTest.scala
+++ b/src/test/scala/wvlet/airframe/LifeCycleManagerTest.scala
@@ -86,6 +86,4 @@ class LifeCycleManagerTest extends AirframeSpec {
       u2.counter.shutdownCount shouldBe 1
     }
   }
-
-
 }


### PR DESCRIPTION
This PR translates bind[X]:
```
val x = bind[X] 
```
into the following code **if X is non abstract type** and has the default constructor:
```
val x = new X { protected[this] __current_session = (session) }
```

This is much faster than using runtime reflection to instantiate trait.