### PR TITLE
Fix scalastyle

### DIFF
--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -28,7 +28,7 @@
  <check level="warning" class="org.scalastyle.scalariform.SpacesBeforePlusChecker" enabled="true"></check>
  <check level="warning" class="org.scalastyle.file.FileLineLengthChecker" enabled="true">
   <parameters>
-   <parameter name="maxLineLength"><![CDATA[100]]></parameter>
+   <parameter name="maxLineLength"><![CDATA[180]]></parameter>
    <parameter name="tabSize"><![CDATA[4]]></parameter>
   </parameters>
  </check>

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -60,7 +60,7 @@
  </check>
  <check level="warning" class="org.scalastyle.scalariform.MagicNumberChecker" enabled="true">
   <parameters>
-   <parameter name="ignore"><![CDATA[-1,0,1,2,3]]></parameter>
+   <parameter name="ignore"><![CDATA[-1,0,1,2,3,4,5]]></parameter>
   </parameters>
  </check>
  <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="true"></check>


### PR DESCRIPTION
There is no reason for us to restrict the line width to 100 (though this is used in Databricks). line width 100 tends to introduce unnecessary line wraps and breaks the code flow. 

And also we need to allow using 4 and 5 ass non magic number for writing provider codes. 