### PR TITLE
Add bindSingleton[X]

### DIFF
--- a/src/main/scala/wvlet/airframe/AirframeMacros.scala
+++ b/src/main/scala/wvlet/airframe/AirframeMacros.scala
@@ -131,12 +131,6 @@ private[wvlet] object AirframeMacros extends LogSupport {
       """
   }
 
-  def bindSingletonImpl[A: c.WeakTypeTag](c: sm.Context)(ev: c.Tree): c.Tree = {
-    import c.universe._
-    val h = new BindHelper[c.type](c)
-    h.bindSingleton(h.findSession, ev)
-  }
-
   def bindImpl[A: c.WeakTypeTag](c: sm.Context)(ev: c.Tree): c.Tree = {
     import c.universe._
     val h = new BindHelper[c.type](c)
@@ -233,4 +227,102 @@ private[wvlet] object AirframeMacros extends LogSupport {
         }
       """
   }
+
+  def bindSingletonImpl[A: c.WeakTypeTag](c: sm.Context)(ev: c.Tree): c.Tree = {
+    import c.universe._
+    val h = new BindHelper[c.type](c)
+    h.bindSingleton(h.findSession, ev)
+  }
+
+  def bind0SingletonImpl[A: c.WeakTypeTag](c: sm.Context)(factory: c.Tree)(a: c.Tree): c.Tree = {
+    import c.universe._
+    val h = new BindHelper[c.type](c)
+    q"""{
+         val session = ${h.findSession}
+         session.getOrElseUpdateSingleton($factory)
+        }
+      """
+  }
+
+  def bind1SingletonImpl[A: c.WeakTypeTag, D1: c.WeakTypeTag]
+  (c: sm.Context)(factory: c.Tree)(a: c.Tree, d1: c.Tree): c.Tree = {
+    import c.universe._
+    val h = new BindHelper[c.type](c)
+    val dep1 = h.newBinder(d1)
+    q"""{
+         val session = ${h.findSession}
+         session.getOrElseUpdateSingleton($factory($dep1(session)))
+        }
+      """
+  }
+
+  def bind2SingletonImpl[A: c.WeakTypeTag, D1: c.WeakTypeTag, D2: c.WeakTypeTag]
+  (c: sm.Context)(factory: c.Tree)
+  (a: c.Tree, d1: c.Tree, d2: c.Tree): c.Tree = {
+    import c.universe._
+    val h = new BindHelper[c.type](c)
+    val dep1 = h.newBinder(d1)
+    val dep2 = h.newBinder(d2)
+    q"""{
+         val session = ${h.findSession}
+         session.getOrElseUpdateSingleton($factory($dep1(session), $dep2(session)))
+        }
+      """
+  }
+
+  def bind3SingletonImpl[A: c.WeakTypeTag, D1: c.WeakTypeTag, D2: c.WeakTypeTag, D3: c.WeakTypeTag]
+  (c: sm.Context)(factory: c.Tree)
+  (a: c.Tree, d1: c.Tree, d2: c.Tree, d3: c.Tree): c.Tree = {
+    import c.universe._
+    val h = new BindHelper[c.type](c)
+    val dep1 = h.newBinder(d1)
+    val dep2 = h.newBinder(d2)
+    val dep3 = h.newBinder(d3)
+    q"""{
+         val session = ${h.findSession}
+         session.getOrElseUpdateSingleton($factory($dep1(session),$dep2(session),$dep3(session)))
+        }
+      """
+  }
+
+  def bind4SingletonImpl[A: c.WeakTypeTag, D1: c.WeakTypeTag, D2: c.WeakTypeTag,
+  D3: c.WeakTypeTag, D4: c.WeakTypeTag]
+  (c: sm.Context)(factory: c.Tree)
+  (a: c.Tree, d1: c.Tree, d2: c.Tree, d3: c.Tree, d4: c.Tree): c.Tree = {
+    import c.universe._
+    val h = new BindHelper[c.type](c)
+    val dep1 = h.newBinder(d1)
+    val dep2 = h.newBinder(d2)
+    val dep3 = h.newBinder(d3)
+    val dep4 = h.newBinder(d4)
+    q"""{
+         val session = ${h.findSession}
+         session.getOrElseUpdateSingleton(
+           $factory($dep1(session),$dep2(session),$dep3(session),$dep4(session))
+         )
+        }
+      """
+  }
+
+  def bind5SingletonImpl[A: c.WeakTypeTag, D1: c.WeakTypeTag, D2: c.WeakTypeTag,
+  D3: c.WeakTypeTag, D4: c.WeakTypeTag, D5: c.WeakTypeTag]
+  (c: sm.Context)(factory: c.Tree)
+  (a: c.Tree, d1: c.Tree, d2: c.Tree, d3: c.Tree, d4: c.Tree, d5: c.Tree): c.Tree = {
+    import c.universe._
+    import c.universe._
+    val h = new BindHelper[c.type](c)
+    val dep1 = h.newBinder(d1)
+    val dep2 = h.newBinder(d2)
+    val dep3 = h.newBinder(d3)
+    val dep4 = h.newBinder(d4)
+    val dep5 = h.newBinder(d5)
+    q"""{
+         val session = ${h.findSession}
+         session.getOrElseUpdateSingleton(
+           $factory($dep1(session),$dep2(session),$dep3(session),$dep4(session),$dep5(session))
+         )
+        }
+      """
+  }
+
 }

--- a/src/main/scala/wvlet/airframe/LazyF0.scala
+++ b/src/main/scala/wvlet/airframe/LazyF0.scala
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe
+
+
+object LazyF0 {
+  def apply[R](f: => R) : LazyF0[R] = new LazyF0(f)
+}
+
+/**
+  * This class is used to obtain the class names of the call-by-name functions (Function0[R]).
+  *
+  * This wrapper do not directly access the field f (Function0[R]) in order
+  * to avoid the evaluation of the function.
+  * @param f
+  * @tparam R
+  */
+class LazyF0[+R](f: => R) extends Serializable with Cloneable {
+
+  def copy : LazyF0[R] = clone().asInstanceOf[this.type]
+
+  /**
+    * Obtain the function class
+    *
+    * @return
+    */
+  def functionClass: Class[_] = {
+    val field = this.getClass.getDeclaredField("f")
+    field.get(this).getClass
+  }
+
+  def functionInstance: Function0[R] = {
+    this.getClass.getDeclaredField("f").get(this).asInstanceOf[Function0[R]]
+  }
+
+  /**
+    * This definition is necessary to let compiler generate the private field 'f' that
+    * holds a reference to the call-by-name function.
+    * @return
+    */
+  def eval : R = f
+
+  override def hashCode(): Int = functionClass.hashCode()
+
+  def canEqual(other: Any): Boolean = other.isInstanceOf[LazyF0[_]]
+
+  override def equals(other: Any): Boolean = other match {
+    case that: LazyF0[_] =>
+      (that canEqual this) &&
+        functionClass == that.functionClass &&
+        eval == that.eval
+    case _ => false
+  }
+}

--- a/src/main/scala/wvlet/airframe/Session.scala
+++ b/src/main/scala/wvlet/airframe/Session.scala
@@ -62,6 +62,9 @@ trait Session {
     */
   private[airframe] def getOrElseUpdate[A: ru.WeakTypeTag](obj: => A): A
 
+  private[airframe] def getSingleton[A: ru.WeakTypeTag]: A
+  private[airframe] def getOrElseUpdateSingleton[A: ru.WeakTypeTag](obj: => A): A
+
   /**
     * Get the object LifeCycleManager of this session.
     *
@@ -85,6 +88,8 @@ object Session extends LogSupport {
   implicit class SessionAccess(session: Session) {
     def get[A: ru.WeakTypeTag]: A = session.get[A]
     def getOrElseUpdate[A: ru.WeakTypeTag](obj: => A): A = session.getOrElseUpdate[A](obj)
+    def getSingleton[A: ru.WeakTypeTag](obj: => A): A = session.getSingleton[A]
+    def getOrElseUpdateSingleton[A: ru.WeakTypeTag](obj: => A): A = session.getOrElseUpdateSingleton[A](obj)
   }
 
   def getSession[A](enclosingObj: A): Option[Session] = {

--- a/src/main/scala/wvlet/airframe/package.scala
+++ b/src/main/scala/wvlet/airframe/package.scala
@@ -45,6 +45,14 @@ package object airframe {
   (factory: (D1, D2, D3, D4, D5) => A): A = macro bind5Impl[A, D1, D2, D3, D4, D5]
 
   def bindSingleton[A: ru.TypeTag]: A = macro bindSingletonImpl[A]
+  def bindSingleton[A: ru.TypeTag](factory: => A): A = macro bind0SingletonImpl[A]
+  def bindSingleton[A: ru.TypeTag, D1: ru.TypeTag](factory: D1 => A): A = macro bind1SingletonImpl[A, D1]
+  def bindSingleton[A: ru.TypeTag, D1: ru.TypeTag, D2: ru.TypeTag](factory: (D1, D2) => A): A = macro bind2SingletonImpl[A, D1, D2]
+  def bindSingleton[A: ru.TypeTag, D1: ru.TypeTag, D2: ru.TypeTag, D3: ru.TypeTag](factory: (D1, D2, D3) => A): A = macro bind3SingletonImpl[A, D1, D2, D3]
+  def bindSingleton[A: ru.TypeTag, D1: ru.TypeTag, D2: ru.TypeTag, D3: ru.TypeTag, D4: ru.TypeTag]
+  (factory: (D1, D2, D3, D4) => A): A = macro bind4SingletonImpl[A, D1, D2, D3, D4]
+  def bindSingleton[A: ru.TypeTag, D1: ru.TypeTag, D2: ru.TypeTag, D3: ru.TypeTag, D4: ru.TypeTag, D5: ru.TypeTag]
+  (factory: (D1, D2, D3, D4, D5) => A): A = macro bind5SingletonImpl[A, D1, D2, D3, D4, D5]
 
   private[airframe] val DO_NOTHING = { a: Any => }
 

--- a/src/main/scala/wvlet/airframe/package.scala
+++ b/src/main/scala/wvlet/airframe/package.scala
@@ -44,6 +44,8 @@ package object airframe {
   def bind[A: ru.TypeTag, D1: ru.TypeTag, D2: ru.TypeTag, D3: ru.TypeTag, D4: ru.TypeTag, D5: ru.TypeTag]
   (factory: (D1, D2, D3, D4, D5) => A): A = macro bind5Impl[A, D1, D2, D3, D4, D5]
 
+  def bindSingleton[A: ru.TypeTag]: A = macro bindSingletonImpl[A]
+
   private[airframe] val DO_NOTHING = { a: Any => }
 
   /**

--- a/src/test/scala/example/BindSingleton.scala
+++ b/src/test/scala/example/BindSingleton.scala
@@ -49,8 +49,8 @@ object BindSingleton {
     }
   }
 
+  // Use bindSingleton[XY] for sharing a singleton of XY between App1 and App2
   trait XYService {
-    // Sharing a singleton of XY between App1 and App2
     val service = bindSingleton[XY]
   }
 
@@ -58,9 +58,9 @@ object BindSingleton {
   trait App2 extends XYService
 
   val session = newDesign.newSession
-  val app = session.build[App1]
-  val app2 = session.build[App2]
-  session.shutdown
+  val app = session.build[App1] // shows "Hello World!"
+  val app2 = session.build[App2] // shows nothing since XY is already initialized
+  session.shutdown // shows "Good-bye World!"
 }
 
 class BindSingleton extends AirframeSpec {

--- a/src/test/scala/example/BindSingleton.scala
+++ b/src/test/scala/example/BindSingleton.scala
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example
+
+import javax.annotation.{PostConstruct, PreDestroy}
+
+import wvlet.airframe.AirframeSpec
+import wvlet.log.LogSupport
+
+/**
+  * bindSingleton[X] example
+  */
+object BindSingleton {
+  import wvlet.airframe._
+
+  trait X {
+    def hello: String = "Hello"
+    def goodbye : String = "Good-bye"
+  }
+  trait Y {
+    def world: String = "World"
+  }
+
+  trait XY extends LogSupport {
+    val x = bind[X]
+    val y = bind[Y]
+
+    @PostConstruct
+    def start() {
+      // This will be called only once since XY is used as singleton
+      info(s"${x.hello} ${y.world}!")
+    }
+
+    @PreDestroy
+    def close() {
+      // This will be called only once since XY is used as singleton
+      info(s"${x.goodbye} ${y.world}!")
+    }
+  }
+
+  trait XYService {
+    // Sharing a singleton of XY between App1 and App2
+    val service = bindSingleton[XY]
+  }
+
+  trait App1 extends XYService
+  trait App2 extends XYService
+
+  val session = newDesign.newSession
+  val app = session.build[App1]
+  val app2 = session.build[App2]
+  session.shutdown
+}
+
+class BindSingleton extends AirframeSpec {
+  "BindSingleton" should {
+    "run" in {
+      val b = BindSingleton
+    }
+  }
+}

--- a/src/test/scala/wvlet/airframe/AirframeTest.scala
+++ b/src/test/scala/wvlet/airframe/AirframeTest.scala
@@ -461,7 +461,8 @@ class AirframeTest extends AirframeSpec {
         .bind[NonAbstractModule].toInstance(SingletonOfNonAbstractModules)
 
       val m = d.newSession.build[NonAbstractModule]
-      m shouldBe SingletonOfNonAbstractModules
+      m shouldBe theSameInstanceAs (SingletonOfNonAbstractModules)
+
     }
 
     "create single with inject eagerly" in {

--- a/src/test/scala/wvlet/airframe/ProviderTest.scala
+++ b/src/test/scala/wvlet/airframe/ProviderTest.scala
@@ -74,6 +74,14 @@ trait ProviderExample {
   val pp3 = bind(provider3 _)
   val pp4 = bind(provider4 _)
   val pp5 = bind(provider5 _)
+
+  // Bind singleton
+  val ps0 = bindSingleton(App())
+  val ps1 = bindSingleton(provider1 _)
+  val ps2 = bindSingleton(provider2 _)
+  val ps3 = bindSingleton(provider3 _)
+  val ps4 = bindSingleton(provider4 _)
+  val ps5 = bindSingleton(provider5 _)
 }
 
 /**
@@ -276,6 +284,20 @@ class ProviderTest extends AirframeSpec {
 
       val app = d.newSession.build[App]
       app shouldBe App(d1, d2, d3, d4, d5)
+    }
+
+    "bind singletons" in {
+      val session = providerDesign.newSession
+
+      val p1 = session.build[ProviderExample]
+      val p2 = session.build[ProviderExample]
+
+      p1.ps0 shouldBe theSameInstanceAs (p2.ps0)
+      p1.ps1 shouldBe theSameInstanceAs (p2.ps1)
+      p1.ps2 shouldBe theSameInstanceAs (p2.ps2)
+      p1.ps3 shouldBe theSameInstanceAs (p2.ps3)
+      p1.ps4 shouldBe theSameInstanceAs (p2.ps4)
+      p1.ps5 shouldBe theSameInstanceAs (p2.ps5)
     }
   }
 }

--- a/src/test/scala/wvlet/airframe/SingletonTest.scala
+++ b/src/test/scala/wvlet/airframe/SingletonTest.scala
@@ -25,6 +25,8 @@ object SingletonTest {
 
   // This doesn't tell about Singleton
   trait X extends LogSupport {
+    info("new X is instantiated")
+
     val counter = bind[AtomicInteger @@ TraitCounter].withLifeCycle(
       init = { c =>
         val v = c.incrementAndGet()

--- a/src/test/scala/wvlet/airframe/SingletonTest.scala
+++ b/src/test/scala/wvlet/airframe/SingletonTest.scala
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import wvlet.airframe.SingletonTest._
+import wvlet.log.{LogLevel, LogSupport, Logger}
+import wvlet.obj.tag.@@
+
+object SingletonTest {
+
+  trait TraitCounter
+
+  // This doesn't tell about Singleton
+  trait X extends LogSupport {
+    val counter = bind[AtomicInteger @@ TraitCounter].withLifeCycle(
+      init = { c =>
+        val v = c.incrementAndGet()
+        info(s"Counter is initialized: ${v}")
+      }
+    )
+  }
+
+  trait A {
+    val t = bindSingleton[X]
+  }
+
+  trait B {
+    val t = bindSingleton[X]
+  }
+
+  trait SingletonService {
+    val service = bindSingleton[X]
+  }
+
+  trait U1 extends SingletonService
+  trait U2 extends SingletonService
+}
+
+/**
+  *
+  */
+class SingletonTest extends AirframeSpec {
+
+  val design =
+    newDesign
+    .bind[AtomicInteger @@ TraitCounter].toInstance(new AtomicInteger(0))
+
+  "Singleton" should {
+    "support bindSingleton[X]" in {
+      val session = design.newSession
+
+      val a = session.build[A]
+      val b = session.build[B]
+
+      a.t.counter should be theSameInstanceAs b.t.counter
+      session.build[AtomicInteger @@ TraitCounter].get() shouldBe 1
+    }
+
+    "support using bindSingleton[X] as a service" in {
+      val session = design.newSession
+
+      val u1 = session.build[U1]
+      val u2 = session.build[U2]
+
+      u1.service.counter should be theSameInstanceAs u2.service.counter
+      u1.service.counter.get() shouldBe 1
+    }
+  }
+}


### PR DESCRIPTION
When application developer already knows some object needs to be a singleton, `bindSingleton[X]` can enforce using singleton even if the design doesn't have toSingleton binding. 

