### PR TITLE
Use blackbox macros

### DIFF
--- a/airframe-macros/src/main/scala/wvlet/airframe/AirframeMacros.scala
+++ b/airframe-macros/src/main/scala/wvlet/airframe/AirframeMacros.scala
@@ -14,8 +14,8 @@
 package wvlet.airframe
 
 import scala.language.experimental.macros
-import scala.reflect.macros.whitebox.Context
-import scala.reflect.{macros => sm}
+import scala.reflect.macros.blackbox.Context
+import scala.reflect.macros.{blackbox => sm}
 
 private[wvlet] object AirframeMacros {
 

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ val buildSettings = Seq[Setting[_]](
   incOptions := incOptions.value.withNameHashing(true),
   logBuffered in Test := false,
   updateOptions := updateOptions.value.withCachedResolution(true),
-  scalacOptions ++= Seq("-feature"),
+  scalacOptions ++= Seq("-feature", "-deprecation"),
   sonatypeProfileName := "org.wvlet",
   pomExtra := {
   <url>https://github.com/wvlet/airframe</url>


### PR DESCRIPTION
whitebox macros will be deprecated in future Scala versions. For details, see: http://docs.scala-lang.org/overviews/macros/blackbox-whitebox.html