### PR TITLE
[WIP] Object builder

### DIFF
--- a/surface/shared/src/main/scala/wvlet/surface/SurfaceMacros.scala
+++ b/surface/shared/src/main/scala/wvlet/surface/SurfaceMacros.scala
@@ -285,7 +285,7 @@ private[surface] object SurfaceMacros {
     }
 
     def createObjectFactoryOf(targetType: c.Type): Option[c.Tree] = {
-      if (isAbstract(targetType) || hasAbstractMethods(targetType)) {
+      if (isAbstract(targetType)) {
         None
       }
       else {

--- a/surface/shared/src/main/scala/wvlet/surface/Zero.scala
+++ b/surface/shared/src/main/scala/wvlet/surface/Zero.scala
@@ -1,0 +1,101 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wvlet.surface
+
+import scala.reflect.ClassTag
+import scala.util.Try
+
+/**
+  * Create a default instance (zero) from Surface
+  */
+object Zero {
+
+  type ZeroValueFactory = PartialFunction[Surface, Any]
+  type SurfaceFilter = PartialFunction[Surface, Surface]
+
+  private def isPrimitive: SurfaceFilter = {
+    case p if p.isPrimitive => p
+  }
+  private def isGenericWithTypeArgs: SurfaceFilter = {
+    case g: GenericSurface if g.typeArgs.length > 0 => g
+  }
+
+  private def zeroOfPrimitives: ZeroValueFactory = isPrimitive andThen {
+    case Primitive.String => ""
+    case Primitive.Boolean => false
+    case Primitive.Short => 0.toShort
+    case Primitive.Int => 0
+    case Primitive.Long => 0L
+    case Primitive.Float => 0f
+    case Primitive.Double => 0.0
+    case Primitive.Byte => 0.toByte
+    case Primitive.Unit => null
+  }
+
+  private def zeroOfArray: ZeroValueFactory = {
+    case ArraySurface(cl, elementSurface) =>
+      ClassTag(elementSurface.rawType).newArray(0)
+  }
+
+  private def zeroOfSpecialType: ZeroValueFactory = {
+    case s if s.isOption => None
+    case s if s.rawType == classOf[Nothing] ||
+      s.rawType == classOf[AnyRef] ||
+      s.rawType == classOf[Any]
+    => null
+  }
+
+  private def zeroOfScalaCollections: ZeroValueFactory = isGenericWithTypeArgs andThen {
+    case g if classOf[Seq[_]].isAssignableFrom(g.rawType) =>
+      Seq.empty
+    case g if classOf[Map[_, _]].isAssignableFrom(g.rawType) =>
+      Map.empty
+    case g if classOf[Set[_]].isAssignableFrom(g.rawType) =>
+      Set.empty
+  }
+
+  private def zeroOfTuple: ZeroValueFactory = {
+    case t: TupleSurface =>
+      t.objectFactory.map {
+        val args = t.typeArgs.map(s => zeroOf(s))
+        _.newInstance(args)
+      }.getOrElse(null)
+  }
+
+  private def zeroOfInstantiatable: ZeroValueFactory = {
+    case t if t.objectFactory.isDefined =>
+      val args = t.params.map(x => zeroOf(x.surface))
+      Try(t.objectFactory.get.newInstance(args)).getOrElse(null)
+  }
+
+  private def fallBack: ZeroValueFactory = {
+    case _ => null
+  }
+
+  private val factory: ZeroValueFactory =
+    zeroOfPrimitives orElse
+      zeroOfArray orElse
+      zeroOfTuple orElse
+      zeroOfSpecialType orElse
+      zeroOfScalaCollections orElse
+      zeroOfInstantiatable orElse
+      fallBack
+
+  def zeroOf(surface: Surface): Any = {
+    // Dealias function resolves the actual types of aliased surfaces, tagged surfaces etc.
+    val zero = factory.apply(surface.dealias)
+    zero
+  }
+}

--- a/surface/shared/src/test/scala/wvlet/surface/ZeroTest.scala
+++ b/surface/shared/src/test/scala/wvlet/surface/ZeroTest.scala
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wvlet.surface
+
+import wvlet.surface.tag.@@
+
+/**
+  *
+  */
+class ZeroTest extends SurfaceSpec {
+
+  import Zero._
+  import ZeroTest._
+
+  def zeroCheck[A](surface: Surface, v: A): A = {
+    val z = zeroOf(surface).asInstanceOf[A]
+    z shouldBe v
+    z
+  }
+
+  "Zero" should {
+    "support primitives" in {
+      zeroCheck(Surface.of[Int], 0)
+      zeroCheck(Surface.of[Long], 0L)
+      zeroCheck(Surface.of[Boolean], false)
+      zeroCheck(Surface.of[Short], 0.toShort)
+      zeroCheck(Surface.of[Byte], 0.toByte)
+      zeroCheck(Surface.of[Float], 0f)
+      zeroCheck(Surface.of[Double], 0.0)
+      zeroCheck(Surface.of[String], "")
+      zeroCheck(Surface.of[Unit], null)
+    }
+
+    "support arrays" in {
+      zeroCheck(Surface.of[Array[Int]], Array.empty[Int])
+      zeroCheck(Surface.of[Array[Long]], Array.empty[Long])
+      zeroCheck(Surface.of[Array[String]], Array.empty[String])
+    }
+
+    "support Tuple" in {
+      pending
+      zeroCheck(Surface.of[(Int, String)], (0, ""))
+      zeroCheck(Surface.of[(Int, String, Seq[Int])], (0, "", Seq.empty))
+    }
+
+    "special types" in {
+      zeroCheck(Surface.of[Option[String]], None)
+      zeroCheck(Surface.of[MyA], "")
+      zeroCheck(Surface.of[Int @@ MyTag], 0)
+      zeroCheck(Surface.of[Nothing], null)
+      zeroCheck(Surface.of[AnyRef], null)
+      zeroCheck(Surface.of[Any], null)
+    }
+
+    "support case classes" in {
+      zeroCheck(Surface.of[A], A(0, "", B(0.0f, 0.0)))
+    }
+
+    "support Scala collections" in {
+      zeroCheck(Surface.of[Seq[Int]], Seq.empty[Int])
+      zeroCheck(Surface.of[IndexedSeq[Int]], IndexedSeq.empty[Int])
+      zeroCheck(Surface.of[Map[Int,String]], Map.empty[Int, String])
+      zeroCheck(Surface.of[Set[Int]], Set.empty[Int])
+      zeroCheck(Surface.of[List[Int]], List.empty[Int])
+    }
+  }
+}
+
+object ZeroTest {
+
+  trait MyTag
+  type MyA = String
+
+  case class A(i:Int, s:String, b:B)
+  case class B(f:Float, d:Double)
+}


### PR DESCRIPTION
https://github.com/wvlet/config requires building objects from Properties. Surface should support that.

- [x] Add zero value generator for populating default values
- [ ] Add ObjectBuilder with .set(param name, value) method
- [ ] Support nested object parameter set .set(path, value)