### PR TITLE
 Use RuntimeSurface to convert Map type element

### DIFF
--- a/airframe-config/src/main/scala/wvlet/config/Config.scala
+++ b/airframe-config/src/main/scala/wvlet/config/Config.scala
@@ -203,11 +203,11 @@ case class Config private[config](env: ConfigEnv, holder: Map[Surface, ConfigHol
         p.setProperty(k, x.toString)
       }
     }
-    PropertiesConfig.overrideWithProperties(this, p, onUnusedProperties)
+    if (p.isEmpty) this else PropertiesConfig.overrideWithProperties(this, p, onUnusedProperties)
   }
 
   def overrideWithProperties(props: Properties, onUnusedProperties: Properties => Unit = REPORT_UNUSED_PROPERTIES): Config = {
-    PropertiesConfig.overrideWithProperties(this, props, onUnusedProperties)
+    if (props.isEmpty) this else PropertiesConfig.overrideWithProperties(this, props, onUnusedProperties)
   }
 
   def overrideWithPropertiesFile(propertiesFile: String, onUnusedProperties: Properties => Unit = REPORT_UNUSED_PROPERTIES): Config = {

--- a/airframe-config/src/main/scala/wvlet/config/YamlReader.scala
+++ b/airframe-config/src/main/scala/wvlet/config/YamlReader.scala
@@ -18,9 +18,9 @@ import java.{util => ju}
 import org.yaml.snakeyaml.Yaml
 import wvlet.log.LogSupport
 import wvlet.log.io.IOUtil._
-import wvlet.surface.reflect.ObjectBuilder
 import wvlet.surface
 import wvlet.surface.Surface
+import wvlet.surface.reflect.ObjectBuilder
 
 import scala.collection.JavaConverters._
 import scala.collection.immutable.ListMap
@@ -76,6 +76,10 @@ object YamlReader extends LogSupport {
           case al: java.util.ArrayList[_] =>
             for (a <- al.asScala) {
               builder.set(k.toString, a)
+            }
+          case map: java.util.Map[_, _] =>
+            for ((mk, mv) <- map.asScala) {
+              builder.set(k.toString, mk -> mv)
             }
           case _ =>
             builder.set(k.toString, v)

--- a/airframe-config/src/main/scala/wvlet/config/YamlReader.scala
+++ b/airframe-config/src/main/scala/wvlet/config/YamlReader.scala
@@ -72,18 +72,19 @@ object YamlReader extends LogSupport {
     val builder = ObjectBuilder(surface)
     if (prop != null) {
       for ((k, v) <- prop.asScala) {
-        v match {
-          case al: java.util.ArrayList[_] =>
-            for (a <- al.asScala) {
-              builder.set(k.toString, a)
-            }
-          case map: java.util.Map[_, _] =>
-            for ((mk, mv) <- map.asScala) {
-              builder.set(k.toString, mk -> mv)
-            }
-          case _ =>
-            builder.set(k.toString, v)
-        }
+        builder.set(k.toString, v)
+//        v match {
+//          case al: java.util.ArrayList[_] =>
+//            for (a <- al.asScala) {
+//              builder.set(k.toString, a)
+//            }
+//          case map: java.util.Map[_, _] =>
+//            for ((mk, mv) <- map.asScala) {
+//              builder.set(k.toString, mk -> mv)
+//            }
+//          case _ =>
+//            builder.set(k.toString, v)
+//        }
       }
     }
     builder.build.asInstanceOf[A]

--- a/airframe-config/src/main/scala/wvlet/config/YamlReader.scala
+++ b/airframe-config/src/main/scala/wvlet/config/YamlReader.scala
@@ -73,18 +73,6 @@ object YamlReader extends LogSupport {
     if (prop != null) {
       for ((k, v) <- prop.asScala) {
         builder.set(k.toString, v)
-//        v match {
-//          case al: java.util.ArrayList[_] =>
-//            for (a <- al.asScala) {
-//              builder.set(k.toString, a)
-//            }
-//          case map: java.util.Map[_, _] =>
-//            for ((mk, mv) <- map.asScala) {
-//              builder.set(k.toString, mk -> mv)
-//            }
-//          case _ =>
-//            builder.set(k.toString, v)
-//        }
       }
     }
     builder.build.asInstanceOf[A]

--- a/airframe-config/src/test/resources/classes.yml
+++ b/airframe-config/src/test/resources/classes.yml
@@ -1,0 +1,12 @@
+default: &default
+  classes:
+    - class1
+    - class2
+    - class3
+
+development:
+  <<: *default
+  class_assignments:
+    nobita: class1
+    takeshi: class2
+    suneo: class3

--- a/airframe-config/src/test/scala/wvlet/config/ConfigTest.scala
+++ b/airframe-config/src/test/scala/wvlet/config/ConfigTest.scala
@@ -26,6 +26,7 @@ trait SessionScope
 
 case class SampleConfig(id: Int, fullName: String)
 case class DefaultConfig(id: Int = 1, a:String = "hello")
+case class ClassConfig(classes: Seq[String], classAssignments: Map[String, String])
 
 /**
   *
@@ -37,6 +38,23 @@ class ConfigTest extends WvletSpec {
   def loadConfig(env: String) =
     Config(env = env, configPaths = configPaths)
     .registerFromYaml[SampleConfig]("myconfig.yml")
+    .registerFromYaml[ClassConfig]("classes.yml")
+
+  "MapConfig" should {
+    "read map type configuration items" in {
+      val config = loadConfig("development")
+      val classConfig = config.of[ClassConfig]
+      classConfig.classes.size shouldBe 3
+      classConfig.classes(0) shouldBe "class1"
+      classConfig.classes(1) shouldBe "class2"
+      classConfig.classes(2) shouldBe "class3"
+
+      classConfig.classAssignments.size shouldBe 3
+      classConfig.classAssignments("nobita") shouldBe "class1"
+      classConfig.classAssignments("takeshi") shouldBe "class2"
+      classConfig.classAssignments("suneo") shouldBe "class3"
+    }
+  }
 
   "ConfigEnv" should {
     "set config paths" in {

--- a/airframe-config/src/test/scala/wvlet/config/YamlReaderTest.scala
+++ b/airframe-config/src/test/scala/wvlet/config/YamlReaderTest.scala
@@ -76,7 +76,7 @@ class YamlReaderTest extends WvletSpec {
       s(1) shouldBe DB(10, "mydb2", Seq("T1", "T2"))
     }
 
-    "parse map in yaml" in {
+    "parse map in yaml" taggedAs("map") in {
       val m = YamlReader.loadMapOf[ClassConfig](classesYml)
       m should have size(2)
       m("development").classes shouldBe Seq("class1", "class2", "class3")

--- a/airframe-config/src/test/scala/wvlet/config/YamlReaderTest.scala
+++ b/airframe-config/src/test/scala/wvlet/config/YamlReaderTest.scala
@@ -18,6 +18,7 @@ import wvlet.test.WvletSpec
 
 case class MyConfig(id: Int, fullName: String)
 case class DB(accountId:Int, database:String, table:Seq[String])
+
 /**
   *
   */
@@ -28,6 +29,10 @@ class YamlReaderTest extends WvletSpec {
   }
   val listYml = Resource.find("list.yml").map(_.getPath).getOrElse {
     fail("list.yml is not found")
+  }
+
+  val classesYml = Resource.find("classes.yml").map(_.getPath).getOrElse {
+    fail("classes.yml is not found")
   }
 
   "YamlReader" should {
@@ -69,6 +74,17 @@ class YamlReaderTest extends WvletSpec {
       val s = m.map(p => YamlReader.bind[DB](p))
       s(0) shouldBe DB(1, "mydb", Seq("A"))
       s(1) shouldBe DB(10, "mydb2", Seq("T1", "T2"))
+    }
+
+    "parse map in yaml" in {
+      val m = YamlReader.loadMapOf[ClassConfig](classesYml)
+      m should have size(2)
+      m("development").classes shouldBe Seq("class1", "class2", "class3")
+      m("development").classAssignments shouldBe Map(
+        "nobita" -> "class1",
+        "takeshi" -> "class2",
+        "suneo" -> "class3"
+      )
     }
   }
 }

--- a/surface/jvm/src/main/scala/wvlet/surface/reflect/ObjectBuilder.scala
+++ b/surface/jvm/src/main/scala/wvlet/surface/reflect/ObjectBuilder.scala
@@ -16,12 +16,15 @@ package wvlet.surface.reflect
 import java.util.Locale
 
 import wvlet.log.LogSupport
-import wvlet.surface.reflect.ReflectTypeUtil.{canBuildFromBuffer, canBuildFromString, isArray}
-import wvlet.surface.{OptionSurface, Parameter, Surface, Zero}
+import wvlet.surface.reflect.ReflectTypeUtil._
+import wvlet.surface._
 
+import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import wvlet.surface.CanonicalNameFormatter._
+
+
 //--------------------------------------
 //
 // ObjectBuilder.scala
@@ -110,53 +113,84 @@ trait StandardBuilder extends GenericBuilder with LogSupport {
     }
   }
 
+  private def getArrayHolder(name:String): ArrayHolder = {
+    // Clear the default value holder if exists
+    holder.get(name) match {
+      case Some(Value(v)) =>
+        // remove the default value
+        holder.remove(name)
+      case _ => // do nothing
+    }
+    holder.getOrElseUpdate(name, ArrayHolder(new ArrayBuffer[Any])).asInstanceOf[ArrayHolder]
+  }
+
+
   def set(path: Path, value: Any) {
-    if (!path.isEmpty) {
+    if (path.isEmpty) {
+      // do nothing
+    }
+    else {
       val name = path.head.canonicalName
       val p = findParameter(name)
       if (p.isEmpty) {
         error(s"no parameter is found for path $path")
-        return
       }
-
-      trace(s"set path $path : $value")
-
-      if (path.isLeaf) {
-        val valueType = p.get.surface
-        trace(s"update value holder name:$name, valueType:$valueType (isArray:${isArray(valueType)}) with value:$value")
-        if (canBuildFromBuffer(valueType)) {
-          val gt = if (ReflectTypeUtil.isMap(valueType.rawType)) {
-            RuntimeSurface.of[Tuple2[Any, Any]]
-          } else {
-            valueType.typeArgs(0)
+      else {
+        trace(s"set path $path : $value")
+        if (path.isLeaf) {
+          val targetType = p.get.surface
+          trace(s"update value holder name:$name, valueType:$targetType (isArray:${isArray(targetType)}) with value:$value (${value.getClass})")
+          if (canBuildFromBuffer(targetType)) {
+            val arr = getArrayHolder(name)
+            targetType.typeArgs.length match {
+              case 1 =>
+                // Append array elements to the buffer
+                val elementType = targetType.typeArgs(0)
+                val lst = value match {
+                  case a if isArray(value.getClass) => a.asInstanceOf[Array[_]].toIndexedSeq
+                  case a if isJavaColleciton(value.getClass) =>
+                    a.asInstanceOf[java.util.Collection[_]].asScala.toIndexedSeq
+                  case s if isSeq(value.getClass) => s.asInstanceOf[Seq[_]]
+                  case other=>
+                    Seq(other)
+                }
+                lst
+                .flatMap{x =>  TypeConverter.convert(x, elementType) }
+                .map{ x => arr.holder += x }
+              case 2 =>
+                // Append map elements to the buffer
+                val lst = value match {
+                  case m if isJavaMap(value.getClass) => m.asInstanceOf[java.util.Map[_, _]].asScala.toMap
+                  case m if isMap(m.getClass) => m.asInstanceOf[Map[_, _]]
+                  case other => Seq(other)
+                }
+                val keyType = targetType.typeArgs(0)
+                val valueType = targetType.typeArgs(1)
+                val tupleSurface = TupleSurface(classOf[Tuple2[_,_]], Seq(keyType, valueType))
+                lst.map{x => TypeConverter.convert(x, tupleSurface) map {arr.holder += _}}
+              case other =>
+                error(s"Cannot convert ${value} to ${targetType}")
+            }
           }
-          holder.get(name) match {
-            case Some(Value(v)) =>
-              // remove the default value
-              holder.remove(name)
-            case _ => // do nothing
+          else if (canBuildFromStringValue(targetType)) {
+            TypeConverter.convert(value, targetType).map {v =>
+              holder += name -> Value(v)
+            }
           }
-          val arr = holder.getOrElseUpdate(name, ArrayHolder(new ArrayBuffer[Any])).asInstanceOf[ArrayHolder]
-          TypeConverter.convert(value, gt) map {arr.holder += _}
-        }
-        else if (canBuildFromStringValue(valueType)) {
-          TypeConverter.convert(value, valueType).map {v =>
-            holder += name -> Value(v)
+          else {
+            error(s"failed to set $value to path $path")
           }
         }
         else {
-          error(s"failed to set $value to path $path")
-        }
-      }
-      else {
-        // nested object
-        val paramName = path.head.canonicalName
-        val h = holder.getOrElseUpdate(paramName, Holder(ObjectBuilder(p.get.surface)))
-        h match {
-          case Holder(b) => b.set(path.tailPath, value)
-          case other =>
-            // overwrite the existing holder
-            throw new IllegalStateException("invalid path:%s, value:%s, holder:%s".format(path, value, other))
+          // nested object
+          val paramName = path.head.canonicalName
+          val h = holder.getOrElseUpdate(paramName, Holder(ObjectBuilder(p.get.surface)))
+          h match {
+            case Holder(b) => b.set(path.tailPath, value)
+            case other =>
+              // overwrite the existing holder
+              throw new IllegalStateException("invalid path:%s, value:%s, holder:%s".format(path, value, other))
+          }
         }
       }
     }

--- a/surface/jvm/src/main/scala/wvlet/surface/reflect/ObjectBuilder.scala
+++ b/surface/jvm/src/main/scala/wvlet/surface/reflect/ObjectBuilder.scala
@@ -125,8 +125,11 @@ trait StandardBuilder extends GenericBuilder with LogSupport {
         val valueType = p.get.surface
         trace(s"update value holder name:$name, valueType:$valueType (isArray:${isArray(valueType)}) with value:$value")
         if (canBuildFromBuffer(valueType)) {
-          val gt = valueType.typeArgs(0)
-
+          val gt = if (ReflectTypeUtil.isMap(valueType.rawType)) {
+            RuntimeSurface.of[Tuple2[Any, Any]]
+          } else {
+            valueType.typeArgs(0)
+          }
           holder.get(name) match {
             case Some(Value(v)) =>
               // remove the default value

--- a/surface/jvm/src/main/scala/wvlet/surface/reflect/ObjectBuilder.scala
+++ b/surface/jvm/src/main/scala/wvlet/surface/reflect/ObjectBuilder.scala
@@ -24,7 +24,6 @@ import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import wvlet.surface.CanonicalNameFormatter._
 
-
 //--------------------------------------
 //
 // ObjectBuilder.scala
@@ -42,7 +41,7 @@ object ObjectBuilder extends LogSupport {
     new SimpleObjectBuilder(s)
   }
 
-  def fromObject[A](surface: Surface, obj:A): ObjectBuilder = {
+  def fromObject[A](surface: Surface, obj: A): ObjectBuilder = {
     val b = new SimpleObjectBuilder(surface)
     for (p <- surface.params) {
       b.set(p.name, p.get(obj))
@@ -113,7 +112,7 @@ trait StandardBuilder extends GenericBuilder with LogSupport {
     }
   }
 
-  private def getArrayHolder(name:String): ArrayHolder = {
+  private def getArrayHolder(name: String): ArrayHolder = {
     // Clear the default value holder if exists
     holder.get(name) match {
       case Some(Value(v)) =>
@@ -123,7 +122,6 @@ trait StandardBuilder extends GenericBuilder with LogSupport {
     }
     holder.getOrElseUpdate(name, ArrayHolder(new ArrayBuffer[Any])).asInstanceOf[ArrayHolder]
   }
-
 
   def set(path: Path, value: Any) {
     if (path.isEmpty) {
@@ -151,12 +149,12 @@ trait StandardBuilder extends GenericBuilder with LogSupport {
                   case a if isJavaColleciton(value.getClass) =>
                     a.asInstanceOf[java.util.Collection[_]].asScala.toIndexedSeq
                   case s if isSeq(value.getClass) => s.asInstanceOf[Seq[_]]
-                  case other=>
+                  case other =>
                     Seq(other)
                 }
                 lst
-                .flatMap{x =>  TypeConverter.convert(x, elementType) }
-                .map{ x => arr.holder += x }
+                .flatMap {x => TypeConverter.convert(x, elementType)}
+                .foreach {arr.holder += _}
               case 2 =>
                 // Append map elements to the buffer
                 val lst = value match {
@@ -166,8 +164,10 @@ trait StandardBuilder extends GenericBuilder with LogSupport {
                 }
                 val keyType = targetType.typeArgs(0)
                 val valueType = targetType.typeArgs(1)
-                val tupleSurface = TupleSurface(classOf[Tuple2[_,_]], Seq(keyType, valueType))
-                lst.map{x => TypeConverter.convert(x, tupleSurface) map {arr.holder += _}}
+                val tupleSurface = TupleSurface(classOf[Tuple2[_, _]], Seq(keyType, valueType))
+                lst
+                .flatMap {x => TypeConverter.convert(x, tupleSurface)}
+                .foreach {arr.holder += _}
               case other =>
                 error(s"Cannot convert ${value} to ${targetType}")
             }

--- a/surface/jvm/src/main/scala/wvlet/surface/reflect/ObjectBuilder.scala
+++ b/surface/jvm/src/main/scala/wvlet/surface/reflect/ObjectBuilder.scala
@@ -23,6 +23,7 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import wvlet.surface.CanonicalNameFormatter._
+import scala.language.existentials
 
 //--------------------------------------
 //

--- a/surface/jvm/src/main/scala/wvlet/surface/reflect/ReflectTypeUtil.scala
+++ b/surface/jvm/src/main/scala/wvlet/surface/reflect/ReflectTypeUtil.scala
@@ -20,6 +20,7 @@ import wvlet.surface.{ArraySurface, Surface}
 
 import scala.collection.mutable
 import scala.collection.parallel.ParSeq
+import scala.language.existentials
 
 /**
   *
@@ -83,6 +84,10 @@ object ReflectTypeUtil extends LogSupport {
     cl.isArray || cl.getSimpleName == "Array"
   }
 
+  def isJavaColleciton[T](cl: Class[T]): Boolean = {
+    classOf[java.util.Collection[_]].isAssignableFrom(cl)
+  }
+
   /**
     * If the class has unapply(s:String) : T method in the companion object for instantiating class T, returns true.
     *
@@ -135,6 +140,10 @@ object ReflectTypeUtil extends LogSupport {
 
   def isMap[T](cl: Class[T]): Boolean = {
     classOf[Map[_, _]].isAssignableFrom(cl)
+  }
+
+  def isJavaMap[T](cl: Class[T]): Boolean = {
+    classOf[java.util.Map[_, _]].isAssignableFrom(cl)
   }
 
   def isSet[T](cl: Class[T]): Boolean = {

--- a/surface/jvm/src/main/scala/wvlet/surface/reflect/TypeConverter.scala
+++ b/surface/jvm/src/main/scala/wvlet/surface/reflect/TypeConverter.scala
@@ -34,7 +34,7 @@ object TypeConverter extends LogSupport {
   import ReflectTypeUtil._
 
   def convert[T](value: T, targetType: Surface): Option[Any] = {
-    debug(s"convert ${value} (${value.getClass}) to ${targetType}")
+    trace(s"convert ${value} (${value.getClass}) to ${targetType}")
     if (targetType.isOption) {
       if (isOption(cls(value))) {
         Option(value)
@@ -53,7 +53,7 @@ object TypeConverter extends LogSupport {
         Some(value)
       }
       else if (isBuffer(s)) {
-        debug(s"convert buffer $value into $targetType")
+        trace(s"convert buffer $value into $targetType")
         val buf = value.asInstanceOf[mutable.Buffer[_]]
         val gt: Seq[Surface] = targetType.typeArgs
         val e = gt(0).rawType

--- a/surface/jvm/src/main/scala/wvlet/surface/reflect/TypeConverter.scala
+++ b/surface/jvm/src/main/scala/wvlet/surface/reflect/TypeConverter.scala
@@ -22,7 +22,7 @@ import wvlet.surface.{Primitive, Surface}
 
 import scala.collection.mutable
 import scala.reflect.ClassTag
-
+import scala.collection.JavaConverters._
 /**
   *
   */
@@ -34,6 +34,7 @@ object TypeConverter extends LogSupport {
   import ReflectTypeUtil._
 
   def convert[T](value: T, targetType: Surface): Option[Any] = {
+    debug(s"convert ${value} (${value.getClass}) to ${targetType}")
     if (targetType.isOption) {
       if (isOption(cls(value))) {
         Option(value)


### PR DESCRIPTION
Objects which can be build from Buffer is constructed with one element type like Array type. It is necessary to convert each element to Tuple2 type in case of Map type.