### PR TITLE
Fix airframe-opts doc typo Launguer to Launcher.

### DIFF
--- a/docs/src/main/tut/docs/airframe-opts.md
+++ b/docs/src/main/tut/docs/airframe-opts.md
@@ -53,7 +53,7 @@ package org.mydomain
 
 object MyApp {
   def main(args:Array[String]) {
-    val l = Launguer.of[MyApp]
+    val l = Launcher.of[MyApp]
     l.execute(args)
   }
 }


### PR DESCRIPTION
When trying example code, I found class name typo.