### PR TITLE
Show the chain of missing dependencies upon MISSING_DEPENDENCY error

### DIFF
--- a/airframe/shared/src/main/scala/wvlet/airframe/AirframeException.scala
+++ b/airframe/shared/src/main/scala/wvlet/airframe/AirframeException.scala
@@ -23,12 +23,12 @@ trait AirframeException extends Exception { self =>
 
 object AirframeException {
   case class MISSING_SESSION(cl: Class[_]) extends AirframeException {
-    override def getMessage: String = s"[$getCode] ${cl}"
+    override def getMessage: String = s"[$getCode] Session is not found inside ${cl}. You may need to define ${cl} as a trait or to use constructor injection."
   }
   case class CYCLIC_DEPENDENCY(deps: Set[Surface]) extends AirframeException {
-    override def getMessage: String = s"[$getCode] ${deps.mkString(", ")}"
+    override def getMessage: String = s"[$getCode] ${deps.mkString(" <- ")}"
   }
   case class MISSING_DEPENDENCY(stack: List[Surface]) extends AirframeException {
-    override def getMessage: String = s"[$getCode] ${stack.mkString(" <- ")}"
+    override def getMessage: String = s"[$getCode] Binding for ${stack.head} is not found: ${stack.mkString(" <- ")}"
   }
 }

--- a/airframe/shared/src/test/scala/wvlet/airframe/DependencyTest.scala
+++ b/airframe/shared/src/test/scala/wvlet/airframe/DependencyTest.scala
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe
+
+import wvlet.airframe.AirframeException.MISSING_DEPENDENCY
+
+object DependencyTest1 {
+  trait A {
+    val b = bind[B]
+  }
+  trait B {
+    val c = bind[C]
+  }
+  case class C(d: D)
+  trait D
+  trait DImpl extends D
+}
+
+class DependencyTest extends AirframeSpec {
+  "Airframe" should {
+    "show missing dependencies" in {
+      val d = newDesign
+      d.withSession { session =>
+        val m = intercept[MISSING_DEPENDENCY] {
+          val a = session.build[DependencyTest1.A]
+        }
+        val msg = m.getMessage
+        msg should include("D <- C")
+      }
+    }
+
+    "resolve concrete dependencies" in {
+      val d = newDesign
+        .bind[DependencyTest1.D].to[DependencyTest1.DImpl] // abstract class to a concreate trait
+      d.withSession { session =>
+        val a = session.build[DependencyTest1.A]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add a warning when some dependency cannot be instantiated. This often happens when the missing dependency (e.g., say `D`) is a pure trait (= no default constructor).

If you use `bind[D].toSingleton`, Airframe can generate code for instantiating `D`:
```scala
// Good
trait C {
   val d = bind[D]   //  Macro generates session.getOrElse(surface.of[D], new D {})
}
trait D
```

But constructor injection has nowhere to use Scala macros to generate `new D{}`, so MISSING_DEPENDENCY error will be thrown:
```scala
// NG
// There is no chance to use Scala macros for generating new D {} 
case class C(d:D) {
}

newDesign.newSession.build[C] // <-- MISSING_DEPENDENCY for D <- C
```

So in this case `design.bind[D].toXXX` should be used to generate code `new D{}` 
