### PR TITLE
Fix the several typos detected by github.com/client9/misspell

### DIFF
--- a/airframe-jmx/README.md
+++ b/airframe-jmx/README.md
@@ -52,7 +52,7 @@ class NestedMBean {
 
 case class Stat(@JMX count: Int, @JMX state: String)
 ```
-In this example, `stat.count` adn `stat.state` will be reported.
+In this example, `stat.count` and `stat.state` will be reported.
 
 
 ## Launching JMX Registry

--- a/airframe-log/RELEASE_NOTES.md
+++ b/airframe-log/RELEASE_NOTES.md
@@ -21,7 +21,7 @@ Release Notes
 - Support Scala.js
   - The usage is same. Just add `wvlet.log.LogSupport` in your traits.
   - limitations 
-     - LogLevelScanner, LogRotateHandler, AsyncHandler are avilable only for ScalaJVM
+     - LogLevelScanner, LogRotateHandler, AsyncHandler are available only for ScalaJVM
      - Because reflection is missing in Scala.js, the logger name of complex traits may not be resolved properly. In this case, call `val logger = wvlet.log.Logger.of(name)` to use a proper logger name.
 
 ## 1.1

--- a/airframe-log/jvm/src/test/scala/wvlet/log/AsyncHandlerTest.scala
+++ b/airframe-log/jvm/src/test/scala/wvlet/log/AsyncHandlerTest.scala
@@ -52,7 +52,7 @@ class AsyncHandlerTest extends Spec with Timer {
             // sync
             sl.resetHandler(handler)
 
-            // Temporarly removed to handle missing parallel collection issue of Scala 2.13.0-M4
+            // Temporarily removed to handle missing parallel collection issue of Scala 2.13.0-M4
             //import CompatParColls.Converters._
 //            block("async") {
 //              for (i <- (0 until N).par) {

--- a/airframe-msgpack/src/main/scala/wvlet/airframe/msgpack/spi/Buffer.scala
+++ b/airframe-msgpack/src/main/scala/wvlet/airframe/msgpack/spi/Buffer.scala
@@ -67,7 +67,7 @@ trait WriteBuffer extends Buffer {
 
   def writeBytes(position: Int, src: Array[Byte]): Int = writeBytes(position, src, 0, src.length)
   def writeBytes(position: Int, src: Array[Byte], srcOffset: Int, length: Int): Int
-  def writeBytes(position: Int, src: ReadBuffer, srcPosition: Int, lenght: Int): Int
+  def writeBytes(position: Int, src: ReadBuffer, srcPosition: Int, length: Int): Int
 
   def writeByteAndByte(position: Int, b: Byte, v: Byte): Int = {
     ensureCapacity(position, 2)

--- a/airframe-msgpack/src/main/scala/wvlet/airframe/msgpack/spi/Code.scala
+++ b/airframe-msgpack/src/main/scala/wvlet/airframe/msgpack/spi/Code.scala
@@ -55,7 +55,7 @@ object Code {
   val MAP32: Byte            = 0xdf.toByte
   val NEGFIXINT_PREFIX: Byte = 0xe0.toByte
 
-  // Pre-defined extention type code
+  // Pre-defined extension type code
   val EXT_TIMESTAMP: Byte = -1
 
   def isFixInt(b: Byte): Boolean = {

--- a/airframe-opts/src/test/scala/wvlet/airframe/opts/LauncherTest.scala
+++ b/airframe-opts/src/test/scala/wvlet/airframe/opts/LauncherTest.scala
@@ -123,7 +123,7 @@ class LauncherTest extends AirframeSpec {
       help should (include("--loglevel"))
     }
 
-    "populate nested options even when no paramter is given" taggedAs ("nested2") in {
+    "populate nested options even when no parameter is given" taggedAs ("nested2") in {
       val l = Launcher.execute[NestedOption]("")
       l.g should not be (null)
       l.g.help should be(false)

--- a/airframe-surface/jvm/src/main/scala/wvlet/surface/reflect/CName.scala
+++ b/airframe-surface/jvm/src/main/scala/wvlet/surface/reflect/CName.scala
@@ -124,7 +124,7 @@ object CName {
 }
 
 /**
-  * Cannonical name. This name is used as a common name of wording variants (e.g., difference of capital letter usage, hyphenation, etc.)
+  * Canonical name. This name is used as a common name of wording variants (e.g., difference of capital letter usage, hyphenation, etc.)
   *
   * @param canonicalName
   * @param naturalName

--- a/build.sbt
+++ b/build.sbt
@@ -106,7 +106,7 @@ lazy val scaladoc =
     .settings(buildSettings)
     .settings(
       name := "airframe-scaladoc",
-      // Need to exclude JS project explicitely to avoid '<type> is already defined' errors
+      // Need to exclude JS project explicitly to avoid '<type> is already defined' errors
       unidocProjectFilter in (ScalaUnidoc, unidoc) := inAnyProject -- inProjects(airframeMacrosJS) -- inProjects(
         jsProjects: _*),
       Defaults.packageTaskSettings(packageDoc in Compile, (unidoc in Compile).map(_.flatMap(Path.allSubpaths)))

--- a/docs/src/main/tut/docs/airframe-config.md
+++ b/docs/src/main/tut/docs/airframe-config.md
@@ -124,7 +124,7 @@ import wvlet.config.Config
 
 ...
 
-val env = "prodcution"
+val env = "production"
 
 // For overriding properties, or you can load the environmental variables here
 val properties = Map(

--- a/docs/src/main/tut/docs/airframe-jmx.md
+++ b/docs/src/main/tut/docs/airframe-jmx.md
@@ -56,7 +56,7 @@ class NestedMBean {
 
 case class Stat(@JMX count: Int, @JMX state: String)
 ```
-In this example, `stat.count` adn `stat.state` will be reported.
+In this example, `stat.count` and `stat.state` will be reported.
 
 
 ## Launching JMX Registry

--- a/docs/src/main/tut/docs/comparison.md
+++ b/docs/src/main/tut/docs/comparison.md
@@ -12,7 +12,7 @@ There are two types of dependency injection approaches; **runtime** and **compil
 - [Google Guice](https://github.com/google/guice) is a popular run-time dependency injection libraries in Java, which is also used in [Presto](https://github.com/prestodb/presto) to construct a distributed SQL engine consisting of hundreds of classes. Guice itself does not manage the lifecycle of objects and binding configurations, so Presto team at Facebook has developed [airlift-bootstrap](https://github.com/airlift/airlift/tree/master/bootstrap/src/main/java/io/airlift/bootstrap) and [airlift- configuration](https://github.com/airlift/airlift/tree/master/configuration/src/main/java/io/airlift/configuration) libraries to extend Guice's functionality.
    - One of the disadvantages of Guice is it requires constructor annotation like `@Inject`. This is less convenient if you are using third-party libraries, which cannot add such annotations. So you often need to write many provider binding modules to use third-party classes.
    - Airframe has provider bindings in `bind { d1: D1 => new X(d1) }` syntax so that you can directly call the constructor of third-party classes. No need to implement object binding modules.
-    - [Guice Bootstrap](https://github.com/embulk/guice-bootstrap) is an extention of Guice to support life-cycle management using `@PostConstruct` and `@PreDestroy` annotations.
+    - [Guice Bootstrap](https://github.com/embulk/guice-bootstrap) is an extension of Guice to support life-cycle management using `@PostConstruct` and `@PreDestroy` annotations.
 
 - [Scaldi](https://github.com/scaldi/scaldi) is an early adaptor of Guice like DI for Scala and has implemented all of the major functionalities of Guice. However it requires extending your class with Scaldi `Module`. Airframe is simplifying it so that you only need to use `bind[X]` without extending any trait.
 
@@ -87,7 +87,7 @@ The chart below shows major features supported in selected DI frameworks. For co
   - **cons**: Missed binding founds as a runtime error.
 
 - Pure-Scala approach
-  - **pros**: It's just Scala! No special extention is required.
+  - **pros**: It's just Scala! No special extension is required.
   - **pros**: Since all objects are manually wired, missing dependencies will be reported as compile errors.
   - **cons**: Requires manual binding and overrides of classes.
   - **cons**: Need to think about how to pass explicit/implicit parameters to classes and traits.

--- a/docs/src/main/tut/docs/internals.md
+++ b/docs/src/main/tut/docs/internals.md
@@ -105,7 +105,7 @@ new A extends SessionHolder {
 }
 ```
 
-### Comparsion with a naive approach
+### Comparison with a naive approach
 
 At first look, the above macro expantion looks quite scarly, however, when calling constructor of `App` you are actually doing similar things:
 ```
@@ -193,7 +193,7 @@ Seq[_] => Seq[AnyRef]
 
 Similarly the above type alias `MyInt` and `Int` will be the same types.
 
-To provide detailed type information only avaiable at compile-time, Surface uses runtime-reflecation, which can pass compile-type type information such as 
+To provide detailed type information only available at compile-time, Surface uses runtime-reflecation, which can pass compile-type type information such as 
  function argument names, generic types, etc., to the runtime environment. Surface extensively uses `scala.reflect.runtime.universe.Type` 
 information so that bindings using type names can be convenient for the users.  
 

--- a/docs/src/main/tut/docs/release-notes.md
+++ b/docs/src/main/tut/docs/release-notes.md
@@ -68,7 +68,7 @@ title: Release Notes
  - Fixes Logger.scanLoglevels to use given log level files appropriately [#141](https://github.com/wvlet/airframe/pull/141)
 
 ## 0.35
- - Minor fixes to project strucutres and build scripts.
+ - Minor fixes to project strucutures and build scripts.
 
 ## 0.34
  - No major change in terms of features, API.


### PR DESCRIPTION
This pull request fixes the typos in this repository. Although I am not a native English speaker, [misspell](https://github.com/client9/misspell) detected obvious mistakes for us. I've fixed them except for false positives.

```
$ misspell .
airframe-jmx/README.md:55:30: "adn" is a misspelling of "and"
airframe-log/RELEASE_NOTES.md:24:59: "avilable" is a misspelling of "available"
airframe-log/jvm/src/test/scala/wvlet/log/AsyncHandlerTest.scala:55:15: "Temporarly" is a misspelling of "Temporary"
airframe-msgpack/src/main/scala/wvlet/airframe/msgpack/spi/Code.scala:58:17: "extention" is a misspelling of "extension"
airframe-msgpack/src/main/scala/wvlet/airframe/msgpack/spi/Buffer.scala:70:67: "lenght" is a misspelling of "length"
airframe-opts/src/test/scala/wvlet/airframe/opts/LauncherTest.scala:126:42: "paramter" is a misspelling of "parameter"
airframe-surface/jvm/src/main/scala/wvlet/surface/reflect/CName.scala:127:4: "Cannonical" is a misspelling of "Canonical"
docs/src/main/tut/docs/airframe-jmx.md:59:30: "adn" is a misspelling of "and"
docs/src/main/tut/docs/airframe-config.md:127:11: "prodcution" is a misspelling of "production"
build.sbt:109:36: "explicitely" is a misspelling of "explicitly"
docs/src/main/tut/docs/internals.md:108:4: "Comparsion" is a misspelling of "Comparison"
docs/src/main/tut/docs/internals.md:196:42: "avaiable" is a misspelling of "available"
docs/src/main/tut/docs/release-notes.md:71:26: "strucutres" is a misspelling of "structures"
docs/src/main/tut/docs/comparison.md:15:73: "extention" is a misspelling of "extension"
docs/src/main/tut/docs/comparison.md:90:42: "extention" is a misspelling of "extension"
sn0138:airframe kazuhiro.sera$ vi airframe-jmx/README.md
```