### PR TITLE
airframe-json optimization

### DIFF
--- a/airframe-json/.jvm/src/test/scala/wvlet/airframe/json/JSONScannerBenchmark.scala
+++ b/airframe-json/.jvm/src/test/scala/wvlet/airframe/json/JSONScannerBenchmark.scala
@@ -35,32 +35,32 @@ class JSONScannerBenchmark extends AirframeSpec with Timer {
     "parse twitter.json" taggedAs ("comparison") in {
       val jsonByteBuffer = ByteBuffer.wrap(jsonBytes)
       val jawnParser     = new JawnParser()
-      time("twitter.json", repeat = 10, blockRepeat = 10) {
+      time("twitter.json", repeat = 10, blockRepeat = 3) {
 //        block("airframe (string)    ") {
 //          JSONScanner.scan(JSONSource.fromString(json), SimpleJSONEventHandler)
 //        }
 //        block("airframe (byte buffer)") {
 //          JSONScanner.scan(JSONSource.fromByteBuffer(ByteBuffer.wrap(jsonBytes)), SimpleJSONEventHandler)
 //        }
-        // Excluded for supporting muiltiple Scala versions
-        block("jawn                  ") {
-          jawnParser.parse(json)
-        }
-        block("circe                 ") {
-          io.circe.parser.parse(json)
+        block("airframe json parser ") {
+          JSON.parse(jsonBytes)
         }
         block("airframe (push parser) ") {
           JSONScanner.scan(JSONSource.fromBytes(jsonBytes), SimpleJSONEventHandler)
         }
-        block("json4s 3.5.4 (native)") {
-          org.json4s.native.JsonMethods.parse(json)
-        }
-        block("json4s 3.5.4 (jackson)") {
-          org.json4s.jackson.JsonMethods.parse(json)
-        }
-        block("airframe json parser ") {
-          JSON.parse(jsonBytes)
-        }
+        // Excluded for supporting muiltiple Scala versions
+//        block("jawn                  ") {
+//          jawnParser.parse(json)
+//        }
+//        block("circe                 ") {
+//          io.circe.parser.parse(json)
+//        }
+//        block("json4s 3.5.4 (native)") {
+//          org.json4s.native.JsonMethods.parse(json)
+//        }
+//        block("json4s 3.5.4 (jackson)") {
+//          org.json4s.jackson.JsonMethods.parse(json)
+//        }
 //        block("uJson (string)        ") {
 //          ujson.read(json)
 //        }

--- a/airframe-json/.jvm/src/test/scala/wvlet/airframe/json/JSONScannerBenchmark.scala
+++ b/airframe-json/.jvm/src/test/scala/wvlet/airframe/json/JSONScannerBenchmark.scala
@@ -30,7 +30,7 @@ class JSONScannerBenchmark extends AirframeSpec with Timer {
       val jsonBytes      = json.getBytes(StandardCharsets.UTF_8)
       val jsonByteBuffer = ByteBuffer.wrap(jsonBytes)
 
-      time("twitter.json", repeat = 10, blockRepeat = 10) {
+      time("twitter.json", repeat = 3, blockRepeat = 10) {
         block("airframe (string)    ") {
           JSONScanner.scan(JSONSource.fromString(json), SimpleJSONEventHandler)
         }

--- a/airframe-json/.jvm/src/test/scala/wvlet/airframe/json/JSONScannerBenchmark.scala
+++ b/airframe-json/.jvm/src/test/scala/wvlet/airframe/json/JSONScannerBenchmark.scala
@@ -30,7 +30,7 @@ class JSONScannerBenchmark extends AirframeSpec with Timer {
       val jsonBytes      = json.getBytes(StandardCharsets.UTF_8)
       val jsonByteBuffer = ByteBuffer.wrap(jsonBytes)
 
-      time("twitter.json", repeat = 10, blockRepeat = 1) {
+      time("twitter.json", repeat = 10, blockRepeat = 10) {
         block("airframe (string)    ") {
           JSONScanner.scan(JSONSource.fromString(json), SimpleJSONEventHandler)
         }

--- a/airframe-json/.jvm/src/test/scala/wvlet/airframe/json/JSONScannerBenchmark.scala
+++ b/airframe-json/.jvm/src/test/scala/wvlet/airframe/json/JSONScannerBenchmark.scala
@@ -34,8 +34,8 @@ class JSONScannerBenchmark extends AirframeSpec with Timer {
   "JSONScannerBenchmarhk" should {
     "parse twitter.json" taggedAs ("comparison") in {
       val jsonByteBuffer = ByteBuffer.wrap(jsonBytes)
-
-      time("twitter.json", repeat = 3, blockRepeat = 10) {
+      val jawnParser     = new JawnParser()
+      time("twitter.json", repeat = 10, blockRepeat = 10) {
 //        block("airframe (string)    ") {
 //          JSONScanner.scan(JSONSource.fromString(json), SimpleJSONEventHandler)
 //        }
@@ -43,14 +43,14 @@ class JSONScannerBenchmark extends AirframeSpec with Timer {
 //          JSONScanner.scan(JSONSource.fromByteBuffer(ByteBuffer.wrap(jsonBytes)), SimpleJSONEventHandler)
 //        }
         // Excluded for supporting muiltiple Scala versions
-        block("airframe (push parser) ") {
-          JSONScanner.scan(JSONSource.fromBytes(jsonBytes), SimpleJSONEventHandler)
-        }
         block("jawn                  ") {
-          new JawnParser().parse(json)
+          jawnParser.parse(json)
         }
         block("circe                 ") {
           io.circe.parser.parse(json)
+        }
+        block("airframe (push parser) ") {
+          JSONScanner.scan(JSONSource.fromBytes(jsonBytes), SimpleJSONEventHandler)
         }
         block("json4s 3.5.4 (native)") {
           org.json4s.native.JsonMethods.parse(json)

--- a/airframe-json/.jvm/src/test/scala/wvlet/airframe/json/JSONScannerBenchmark.scala
+++ b/airframe-json/.jvm/src/test/scala/wvlet/airframe/json/JSONScannerBenchmark.scala
@@ -27,11 +27,11 @@ import scala.util.Random
   */
 class JSONScannerBenchmark extends AirframeSpec with Timer {
 
-  val json = IOUtil.readAsString("airframe-json/src/test/resources/twitter.json")
+  val json      = IOUtil.readAsString("airframe-json/src/test/resources/twitter.json")
+  val jsonBytes = json.getBytes(StandardCharsets.UTF_8)
 
   "JSONScannerBenchmarhk" should {
     "parse twitter.json" in {
-      val jsonBytes      = json.getBytes(StandardCharsets.UTF_8)
       val jsonByteBuffer = ByteBuffer.wrap(jsonBytes)
 
       time("twitter.json", repeat = 3, blockRepeat = 10) {
@@ -66,6 +66,14 @@ class JSONScannerBenchmark extends AirframeSpec with Timer {
       }
     }
 
+    "parse twitter.json bytes" taggedAs ("airframe-push") in {
+      time("airframe-push", repeat = 10, blockRepeat = 1) {
+        block("airframe (byte array)") {
+          JSONScanner.scan(JSONSource.fromBytes(jsonBytes), SimpleJSONEventHandler)
+        }
+      }
+    }
+
     "parse boolen arrays" taggedAs ("boolean-array") in {
       val jsonArray = s"[${(0 until 10000).map(_ => Random.nextBoolean()).mkString(",")}]"
       val s         = JSONSource.fromString(jsonArray)
@@ -76,7 +84,6 @@ class JSONScannerBenchmark extends AirframeSpec with Timer {
     }
 
     "parse string arrays" taggedAs ("string-array") in {
-
       // Extract JSON strings from twitter.json
       val j = JSON.parse(json)
       val b = Seq.newBuilder[JSONString]
@@ -91,7 +98,7 @@ class JSONScannerBenchmark extends AirframeSpec with Timer {
       val jsonArray = JSONArray(b.result()).toJSON
       val s         = JSONSource.fromString(jsonArray)
 
-      time("string array", repeat = 1000) {
+      time("string array", repeat = 10) {
         JSONScanner.scan(s, SimpleJSONEventHandler)
       }
     }

--- a/airframe-json/.jvm/src/test/scala/wvlet/airframe/json/JSONScannerBenchmark.scala
+++ b/airframe-json/.jvm/src/test/scala/wvlet/airframe/json/JSONScannerBenchmark.scala
@@ -16,6 +16,7 @@ package wvlet.airframe.json
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 
+import io.circe.jawn.JawnParser
 import wvlet.airframe.AirframeSpec
 import wvlet.airframe.json.JSON.{JSONArray, JSONString}
 import wvlet.log.io.{IOUtil, Timer}
@@ -31,32 +32,35 @@ class JSONScannerBenchmark extends AirframeSpec with Timer {
   val jsonBytes = json.getBytes(StandardCharsets.UTF_8)
 
   "JSONScannerBenchmarhk" should {
-    "parse twitter.json" in {
+    "parse twitter.json" taggedAs ("comparison") in {
       val jsonByteBuffer = ByteBuffer.wrap(jsonBytes)
 
       time("twitter.json", repeat = 3, blockRepeat = 10) {
-        block("airframe (string)    ") {
-          JSONScanner.scan(JSONSource.fromString(json), SimpleJSONEventHandler)
-        }
-        block("airframe (byte buffer)") {
-          JSONScanner.scan(JSONSource.fromByteBuffer(jsonByteBuffer), SimpleJSONEventHandler)
-        }
-        block("airframe (byte array)") {
+//        block("airframe (string)    ") {
+//          JSONScanner.scan(JSONSource.fromString(json), SimpleJSONEventHandler)
+//        }
+//        block("airframe (byte buffer)") {
+//          JSONScanner.scan(JSONSource.fromByteBuffer(ByteBuffer.wrap(jsonBytes)), SimpleJSONEventHandler)
+//        }
+        // Excluded for supporting muiltiple Scala versions
+        block("airframe (push parser) ") {
           JSONScanner.scan(JSONSource.fromBytes(jsonBytes), SimpleJSONEventHandler)
+        }
+        block("jawn                  ") {
+          new JawnParser().parse(json)
+        }
+        block("circe                 ") {
+          io.circe.parser.parse(json)
+        }
+        block("json4s 3.5.4 (native)") {
+          org.json4s.native.JsonMethods.parse(json)
+        }
+        block("json4s 3.5.4 (jackson)") {
+          org.json4s.jackson.JsonMethods.parse(json)
         }
         block("airframe json parser ") {
           JSON.parse(jsonBytes)
         }
-//        // Excluded for supporting muiltiple Scala versions
-//        block("circe                 ") {
-//          io.circe.parser.parse(json)
-//        }
-//        block("json4s 3.5.4 (native)") {
-//          org.json4s.native.JsonMethods.parse(json)
-//        }
-//        block("json4s 3.5.4 (jackson)") {
-//          org.json4s.jackson.JsonMethods.parse(json)
-//        }
 //        block("uJson (string)        ") {
 //          ujson.read(json)
 //        }

--- a/airframe-json/.jvm/src/test/scala/wvlet/airframe/json/JSONScannerBenchmark.scala
+++ b/airframe-json/.jvm/src/test/scala/wvlet/airframe/json/JSONScannerBenchmark.scala
@@ -15,8 +15,11 @@ package wvlet.airframe.json
 
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
+
 import wvlet.airframe.AirframeSpec
 import wvlet.log.io.{IOUtil, Timer}
+
+import scala.util.Random
 
 /**
   *
@@ -59,6 +62,15 @@ class JSONScannerBenchmark extends AirframeSpec with Timer {
 //        block("uJson (byte array)    ") {
 //          ujson.read(jsonBytes)
 //        }
+      }
+    }
+
+    "parser boolen arrays" taggedAs ("boolean-array") in {
+      val jsonArray = s"[${(0 until 10000).map(_ => Random.nextBoolean()).mkString(",")}]"
+      val s         = JSONSource.fromString(jsonArray)
+
+      time("boolean array", repeat = 10) {
+        JSONScanner.scan(s, SimpleJSONEventHandler)
       }
     }
 

--- a/airframe-json/.jvm/src/test/scala/wvlet/airframe/json/JSONScannerBenchmark.scala
+++ b/airframe-json/.jvm/src/test/scala/wvlet/airframe/json/JSONScannerBenchmark.scala
@@ -16,7 +16,6 @@ package wvlet.airframe.json
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 
-import io.circe.jawn.JawnParser
 import wvlet.airframe.AirframeSpec
 import wvlet.airframe.json.JSON.{JSONArray, JSONString}
 import wvlet.log.io.{IOUtil, Timer}
@@ -34,7 +33,6 @@ class JSONScannerBenchmark extends AirframeSpec with Timer {
   "JSONScannerBenchmarhk" should {
     "parse twitter.json" taggedAs ("comparison") in {
       val jsonByteBuffer = ByteBuffer.wrap(jsonBytes)
-      val jawnParser     = new JawnParser()
       time("twitter.json", repeat = 10, blockRepeat = 3) {
 //        block("airframe (string)    ") {
 //          JSONScanner.scan(JSONSource.fromString(json), SimpleJSONEventHandler)
@@ -50,7 +48,7 @@ class JSONScannerBenchmark extends AirframeSpec with Timer {
         }
         // Excluded for supporting muiltiple Scala versions
 //        block("jawn                  ") {
-//          jawnParser.parse(json)
+//          io.circe.jawn.JawnParser.parse(json)
 //        }
 //        block("circe                 ") {
 //          io.circe.parser.parse(json)

--- a/airframe-json/src/main/scala/wvlet/airframe/json/JSON.scala
+++ b/airframe-json/src/main/scala/wvlet/airframe/json/JSON.scala
@@ -82,7 +82,6 @@ object JSON {
       s.append("}")
       s.result()
     }
-
   }
   case class JSONArray(v: Seq[JSONValue]) extends JSONValue {
     override def toJSON: String = {

--- a/airframe-json/src/main/scala/wvlet/airframe/json/JSONParser.scala
+++ b/airframe-json/src/main/scala/wvlet/airframe/json/JSONParser.scala
@@ -28,8 +28,6 @@ object JSONParser {
     JSONScanner.scan(s, parser)
     parser.result
   }
-
-  private[json] val fracDelimiters = Pattern.compile("[\\.eE]")
 }
 
 private class JSONParser(s: JSONSource) extends JSONEventHandler {
@@ -88,7 +86,7 @@ private class JSONParser(s: JSONSource) extends JSONEventHandler {
 
   override def numberValue(s: JSONSource, start: Int, end: Int, dotIndex: Int, expIndex: Int): Unit = {
     val v = s.substring(start, end)
-    if (dotIndex < end || expIndex < end) {
+    if (dotIndex >= 0 && expIndex >= 0) {
       stack.head += JSONDouble(v.toDouble)
     } else {
       Try(JSONLong(v.toLong))

--- a/airframe-json/src/main/scala/wvlet/airframe/json/JSONScanner.scala
+++ b/airframe-json/src/main/scala/wvlet/airframe/json/JSONScanner.scala
@@ -42,25 +42,6 @@ object JSONToken {
 
   final val Slash     = '/'
   final val BackSlash = '\\'
-
-  final val TRUE: Int =
-    (('t'.toByte & 0xFF) << 24) |
-      (('r'.toByte & 0xFF) << 16) |
-      (('u'.toByte & 0xFF) << 8) |
-      ('e'.toByte & 0xFF)
-
-  final val NULL: Int =
-    (('n'.toByte & 0xFF) << 24) |
-      (('u'.toByte & 0xFF) << 16) |
-      (('l'.toByte & 0xFF) << 8) |
-      ('l'.toByte & 0xFF)
-
-  final val FALSE: Long =
-    (('f'.toByte & 0xFFL) << 32) |
-      (('a'.toByte & 0xFFL) << 24) |
-      (('l'.toByte & 0xFFL) << 16) |
-      (('s'.toByte & 0xFFL) << 8) |
-      ('e'.toByte & 0xFFL)
 }
 
 object JSONScanner {
@@ -285,7 +266,8 @@ class JSONScanner(s: JSONSource, eventHandler: JSONEventHandler) extends LogSupp
   }
 
   private def scanTrue: Unit = {
-    if (get4bytesAsInt == TRUE) {
+    ensure(4)
+    if (s(cursor) == 't' && s(cursor + 1) == 'r' && s(cursor + 2) == 'u' && s(cursor + 3) == 'e') {
       cursor += 4
       eventHandler.booleanValue(s, true, cursor - 4, cursor)
     } else {
@@ -294,7 +276,8 @@ class JSONScanner(s: JSONSource, eventHandler: JSONEventHandler) extends LogSupp
   }
 
   private def scanFalse: Unit = {
-    if (get5bytesAsLong == FALSE) {
+    ensure(5)
+    if (s(cursor) == 'f' && s(cursor + 1) == 'a' && s(cursor + 2) == 'l' && s(cursor + 3) == 's' && s(cursor + 4) == 'e') {
       cursor += 5
       eventHandler.booleanValue(s, false, cursor - 5, cursor)
     } else {
@@ -304,7 +287,7 @@ class JSONScanner(s: JSONSource, eventHandler: JSONEventHandler) extends LogSupp
 
   private def scanNull: Unit = {
     ensure(4)
-    if (get4bytesAsInt == NULL) {
+    if (s(cursor) == 'n' && s(cursor + 1) == 'u' && s(cursor + 2) == 'l' && s(cursor + 3) == 'l') {
       cursor += 4
       eventHandler.nullValue(s, cursor - 4, cursor)
     } else {

--- a/airframe-json/src/main/scala/wvlet/airframe/json/JSONScanner.scala
+++ b/airframe-json/src/main/scala/wvlet/airframe/json/JSONScanner.scala
@@ -19,29 +19,29 @@ import scala.annotation.{switch, tailrec}
 
 object JSONToken {
 
-  final val LBracket = '{'
-  final val RBracket = '}'
-  final val Comma    = ','
+  @inline final val LBracket = '{'
+  @inline final val RBracket = '}'
+  @inline final val Comma    = ','
 
-  final val DoubleQuote = '"'
-  final val Colon       = ':'
+  @inline final val DoubleQuote = '"'
+  @inline final val Colon       = ':'
 
-  final val Minus = '-'
-  final val Plus  = '+'
-  final val Dot   = '.'
-  final val Exp   = 'e'
-  final val ExpL  = 'E'
+  @inline final val Minus = '-'
+  @inline final val Plus  = '+'
+  @inline final val Dot   = '.'
+  @inline final val Exp   = 'e'
+  @inline final val ExpL  = 'E'
 
-  final val LSquare = '['
-  final val RSquare = ']'
+  @inline final val LSquare = '['
+  @inline final val RSquare = ']'
 
-  final val WS   = ' '
-  final val WS_T = '\t'
-  final val WS_N = '\n'
-  final val WS_R = '\r'
+  @inline final val WS   = ' '
+  @inline final val WS_T = '\t'
+  @inline final val WS_N = '\n'
+  @inline final val WS_R = '\r'
 
-  final val Slash     = '/'
-  final val BackSlash = '\\'
+  @inline final val Slash     = '/'
+  @inline final val BackSlash = '\\'
 }
 
 object JSONScanner {

--- a/airframe-json/src/main/scala/wvlet/airframe/json/JSONScanner.scala
+++ b/airframe-json/src/main/scala/wvlet/airframe/json/JSONScanner.scala
@@ -119,7 +119,7 @@ class JSONScanner(s: JSONSource, eventHandler: JSONEventHandler) extends LogSupp
 
   private def skipWhiteSpaces: Unit = {
     var toContinue = true
-    while (toContinue && cursor < s.length) {
+    while (toContinue) {
       val ch = s(cursor)
       (ch: @switch) match {
         case WS | WS_T | WS_R =>

--- a/airframe-json/src/main/scala/wvlet/airframe/json/JSONTraverser.scala
+++ b/airframe-json/src/main/scala/wvlet/airframe/json/JSONTraverser.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.json
+
+import wvlet.airframe.json.JSON._
+
+trait JSONVisitor {
+  def visitObject(o: JSONObject): Unit             = {}
+  def visitKeyValue(k: String, v: JSONValue): Unit = {}
+  def visitArray(a: JSONArray): Unit               = {}
+  def visitString(v: JSONString): Unit             = {}
+  def visitNumber(n: JSONNumber): Unit             = {}
+  def visitBoolean(n: JSONBoolean): Unit           = {}
+  def visitNull: Unit                              = {}
+}
+
+/**
+  *
+  */
+object JSONTraverser {
+  def traverse(json: JSONValue, visitor: JSONVisitor): Unit = {
+    json match {
+      case o: JSONObject =>
+        visitor.visitObject(o)
+        for ((jk, jv) <- o.v) {
+          visitor.visitKeyValue(jk, jv)
+          traverse(jv, visitor)
+        }
+      case a: JSONArray =>
+        visitor.visitArray(a)
+        a.v.foreach(traverse(_, visitor))
+      case v: JSONString =>
+        visitor.visitString(v)
+      case v: JSONNumber =>
+        visitor.visitNumber(v)
+      case v: JSONBoolean =>
+        visitor.visitBoolean(v)
+      case JSONNull =>
+        visitor.visitNull
+    }
+  }
+}

--- a/airframe-json/src/test/scala/wvlet/airframe/json/SimpleJSONEventHandler.scala
+++ b/airframe-json/src/test/scala/wvlet/airframe/json/SimpleJSONEventHandler.scala
@@ -22,27 +22,27 @@ object SimpleJSONEventHandler extends JSONEventHandler with LogSupport {
   def startJson(s: JSONSource, start: Int) {}
   def endJson(s: JSONSource, start: Int) {}
   def startObject(s: JSONSource, start: Int): Unit = {
-    debug(s"start obj: ${start}")
+    //debug(s"start obj: ${start}")
   }
   def endObject(s: JSONSource, start: Int, end: Int, numElem: Int): Unit = {
-    debug(s"end obj: [${start},${end}),  num elems:${numElem}")
+    //debug(s"end obj: [${start},${end}),  num elems:${numElem}")
   }
   def startArray(s: JSONSource, start: Int): Unit = {
-    debug(s"start array: ${start}")
+    //debug(s"start array: ${start}")
   }
   def endArray(s: JSONSource, start: Int, end: Int, numElem: Int): Unit = {
-    debug(s"end array: [${start},${end}), num elems:${numElem}")
+    //debug(s"end array: [${start},${end}), num elems:${numElem}")
   }
   def stringValue(s: JSONSource, start: Int, end: Int): Unit = {
-    debug(s"string value: [${start},${end}) ${s.substring(start, end)}")
+    //debug(s"string value: [${start},${end}) ${s.substring(start, end)}")
   }
   def numberValue(s: JSONSource, start: Int, end: Int, dotIndex: Int, expIndex: Int): Unit = {
-    debug(s"number value: [${start}, ${end}) dot:${dotIndex}, exp:${expIndex} ${s.substring(start, end)}")
+    //debug(s"number value: [${start}, ${end}) dot:${dotIndex}, exp:${expIndex} ${s.substring(start, end)}")
   }
   def booleanValue(s: JSONSource, v: Boolean, start: Int, end: Int): Unit = {
-    debug(s"boolean value: [${start}, ${end}) ${s.substring(start, end)}")
+    //debug(s"boolean value: [${start}, ${end}) ${s.substring(start, end)}")
   }
   def nullValue(s: JSONSource, start: Int, end: Int): Unit = {
-    debug(s"null value: [${start}, ${end}) ${s.substring(start, end)}")
+    //debug(s"null value: [${start}, ${end}) ${s.substring(start, end)}")
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -564,10 +564,11 @@ lazy val json =
       description := "JSON pull parser",
       libraryDependencies ++= Seq(
         // Used only for benchmark purpose
-//        "org.json4s" %% "json4s-native" % "3.5.4",
-//        "org.json4s" %% "json4s-jackson" % "3.5.4",
-//        "io.circe" %% "circe-parser" % "0.9.3",
-//        "com.lihaoyi" %% "ujson" % "0.6.6"
+        "org.json4s"     %% "json4s-native"  % "3.5.4",
+        "org.json4s"     %% "json4s-jackson" % "3.5.4",
+        //"org.spire-math" %% "jawn-ast"       % "0.13.0",
+        "io.circe"       %% "circe-parser"   % "0.9.3",
+        "com.lihaoyi"    %% "ujson"          % "0.6.6"
       )
     )
     .jsSettings(jsBuildSettings)

--- a/build.sbt
+++ b/build.sbt
@@ -564,11 +564,11 @@ lazy val json =
       description := "JSON pull parser",
       libraryDependencies ++= Seq(
         // Used only for benchmark purpose
-        "org.json4s"     %% "json4s-native"  % "3.5.4",
-        "org.json4s"     %% "json4s-jackson" % "3.5.4",
-        //"org.spire-math" %% "jawn-ast"       % "0.13.0",
-        "io.circe"       %% "circe-parser"   % "0.9.3",
-        "com.lihaoyi"    %% "ujson"          % "0.6.6"
+//        "org.json4s"     %% "json4s-native"  % "3.5.4",
+//        "org.json4s"     %% "json4s-jackson" % "3.5.4",
+//        //"org.spire-math" %% "jawn-ast"       % "0.13.0",
+//        "io.circe"       %% "circe-parser"   % "0.9.3",
+//        "com.lihaoyi"    %% "ujson"          % "0.6.6"
       )
     )
     .jsSettings(jsBuildSettings)


### PR DESCRIPTION
- Use tableswitch: https://www.scala-lang.org/api/2.12.1/scala/annotation/switch.html
- Suppress TypeProfile generation in JSONSource by supporting only Array buffer
- Use recursive parser (with tailrec optimization) 
- Faster parsing for simple strings which has no escape characters.
