### PR TITLE
Support quarter (q) duration

### DIFF
--- a/airframe-metrics/jvm/src/main/scala/wvlet/airframe/metrics/TimeUnit.scala
+++ b/airframe-metrics/jvm/src/main/scala/wvlet/airframe/metrics/TimeUnit.scala
@@ -1,0 +1,124 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.metrics
+
+import java.time.temporal.ChronoUnit
+import java.time.{DayOfWeek, ZonedDateTime}
+
+/**
+  *
+  */
+sealed abstract class TimeUnit(symbol: String) {
+
+  /**
+    * Truncate the given time to this unit
+    */
+  def truncate(t: ZonedDateTime): ZonedDateTime
+  def increment(a: ZonedDateTime, v: Long): ZonedDateTime
+}
+
+object TimeUnit {
+
+  private val unitTable: Map[String, TimeUnit] = Map(
+    "s" -> TimeUnit.Second,
+    "m" -> TimeUnit.Minute,
+    "d" -> TimeUnit.Day,
+    "h" -> TimeUnit.Hour,
+    "w" -> TimeUnit.Week,
+    "M" -> TimeUnit.Month,
+    "q" -> TimeUnit.Quarter,
+    "y" -> TimeUnit.Year
+  )
+
+  def of(s: String): TimeUnit = {
+    unitTable.getOrElse(s, throw new IllegalArgumentException(s"Unknown unit type ${s}"))
+  }
+
+  case object Second extends TimeUnit("s") {
+    override def truncate(t: ZonedDateTime): ZonedDateTime = {
+      t.truncatedTo(ChronoUnit.SECONDS)
+    }
+    override def increment(a: ZonedDateTime, v: Long): ZonedDateTime = {
+      a.plus(v, ChronoUnit.SECONDS)
+    }
+  }
+  case object Minute extends TimeUnit("m") {
+    override def truncate(t: ZonedDateTime): ZonedDateTime = {
+      t.truncatedTo(ChronoUnit.MINUTES)
+    }
+    override def increment(a: ZonedDateTime, v: Long): ZonedDateTime = {
+      a.plus(v, ChronoUnit.MINUTES)
+    }
+  }
+  case object Hour extends TimeUnit("h") {
+    override def truncate(t: ZonedDateTime): ZonedDateTime = {
+      t.truncatedTo(ChronoUnit.HOURS)
+    }
+    override def increment(a: ZonedDateTime, v: Long): ZonedDateTime = {
+      a.plus(v, ChronoUnit.HOURS)
+    }
+  }
+  case object Day extends TimeUnit("d") {
+    override def truncate(t: ZonedDateTime): ZonedDateTime = {
+      t.truncatedTo(ChronoUnit.DAYS)
+    }
+    override def increment(a: ZonedDateTime, v: Long): ZonedDateTime = {
+      a.plus(v, ChronoUnit.DAYS)
+    }
+  }
+  case object Week extends TimeUnit("w") {
+    override def truncate(t: ZonedDateTime): ZonedDateTime = {
+      t.truncatedTo(ChronoUnit.DAYS) // Truncate to the beginning of the day
+        .`with`(DayOfWeek.MONDAY) // Monday-origin week is the ISO standard
+    }
+    override def increment(a: ZonedDateTime, v: Long): ZonedDateTime = {
+      a.plus(v, ChronoUnit.WEEKS)
+    }
+  }
+  case object Month extends TimeUnit("M") {
+    override def truncate(t: ZonedDateTime): ZonedDateTime = {
+      t.withDayOfMonth(1) // Jump to the beginning of the day
+        .truncatedTo(ChronoUnit.DAYS)
+    }
+    override def increment(a: ZonedDateTime, v: Long): ZonedDateTime = {
+      a.plus(v, ChronoUnit.MONTHS)
+    }
+  }
+  case object Quarter extends TimeUnit("q") {
+    override def truncate(t: ZonedDateTime): ZonedDateTime = {
+      // The first quarter of the year is January
+      val quarter = ((t.getMonthValue - 1) / 3)
+      val month   = 3 * quarter
+      t.withDayOfYear(1)
+        .plusMonths(month)
+        .truncatedTo(ChronoUnit.DAYS)
+    }
+    override def increment(a: ZonedDateTime, v: Long): ZonedDateTime = {
+      val currentMonth = a.getMonthValue
+      val quarter      = ((a.getMonthValue - 1) / 3) + v
+      val targetMonth  = (3 * quarter) + 1
+      a.plus(targetMonth - currentMonth, ChronoUnit.MONTHS)
+    }
+  }
+
+  case object Year extends TimeUnit("y") {
+    override def truncate(t: ZonedDateTime): ZonedDateTime = {
+      t.withDayOfYear(1)
+        .truncatedTo(ChronoUnit.DAYS)
+    }
+    override def increment(a: ZonedDateTime, v: Long): ZonedDateTime = {
+      a.plus(v, ChronoUnit.YEARS)
+    }
+  }
+}

--- a/airframe-metrics/jvm/src/main/scala/wvlet/airframe/metrics/TimeVector.scala
+++ b/airframe-metrics/jvm/src/main/scala/wvlet/airframe/metrics/TimeVector.scala
@@ -15,7 +15,7 @@ package wvlet.airframe.metrics
 
 import java.time.ZonedDateTime
 
-case class TimeVector(x: Long, offset: Long, unit: TimeUnit) {
+case class TimeVector(x: Long, offset: Long, unit: TimeWindowUnit) {
 
   def timeWindowFrom(context: ZonedDateTime): TimeWindow = {
     val grid = unit.truncate(context)
@@ -45,23 +45,23 @@ object TimeVector {
       //   |----------x----------|
       //   <---------------------| x = -1, 1 unit distance from the offset
       //  grid (offset=0)  offset = 1
-      case "thisHour"  => TimeVector(-1, 1, TimeUnit.Hour)
-      case "today"     => TimeVector(-1, 1, TimeUnit.Day)
-      case "thisWeek"  => TimeVector(-1, 1, TimeUnit.Week)
-      case "thisMonth" => TimeVector(-1, 1, TimeUnit.Month)
-      case "thisYear"  => TimeVector(-1, 1, TimeUnit.Year)
+      case "thisHour"  => TimeVector(-1, 1, TimeWindowUnit.Hour)
+      case "today"     => TimeVector(-1, 1, TimeWindowUnit.Day)
+      case "thisWeek"  => TimeVector(-1, 1, TimeWindowUnit.Week)
+      case "thisMonth" => TimeVector(-1, 1, TimeWindowUnit.Month)
+      case "thisYear"  => TimeVector(-1, 1, TimeWindowUnit.Year)
       // past
-      case "lastHour"  => TimeVector(-1, 0, TimeUnit.Hour)
-      case "yesterday" => TimeVector(-1, 0, TimeUnit.Day)
-      case "lastWeek"  => TimeVector(-1, 0, TimeUnit.Week)
-      case "lastMonth" => TimeVector(-1, 0, TimeUnit.Month)
-      case "lastYear"  => TimeVector(-1, 0, TimeUnit.Year)
+      case "lastHour"  => TimeVector(-1, 0, TimeWindowUnit.Hour)
+      case "yesterday" => TimeVector(-1, 0, TimeWindowUnit.Day)
+      case "lastWeek"  => TimeVector(-1, 0, TimeWindowUnit.Week)
+      case "lastMonth" => TimeVector(-1, 0, TimeWindowUnit.Month)
+      case "lastYear"  => TimeVector(-1, 0, TimeWindowUnit.Year)
       // future
-      case "nextHour"  => TimeVector(1, 1, TimeUnit.Hour)
-      case "tomorrow"  => TimeVector(1, 1, TimeUnit.Day)
-      case "nextWeek"  => TimeVector(1, 1, TimeUnit.Week)
-      case "nextMonth" => TimeVector(1, 1, TimeUnit.Month)
-      case "nextYear"  => TimeVector(1, 1, TimeUnit.Year)
+      case "nextHour"  => TimeVector(1, 1, TimeWindowUnit.Hour)
+      case "tomorrow"  => TimeVector(1, 1, TimeWindowUnit.Day)
+      case "nextWeek"  => TimeVector(1, 1, TimeWindowUnit.Week)
+      case "nextMonth" => TimeVector(1, 1, TimeWindowUnit.Month)
+      case "nextYear"  => TimeVector(1, 1, TimeWindowUnit.Year)
 
       case other =>
         durationPattern.findFirstMatchIn(s) match {
@@ -69,7 +69,7 @@ object TimeVector {
             throw new IllegalArgumentException(s"Invalid duration: ${s}")
           case Some(m) =>
             val length = m.group("num").toInt
-            val unit   = TimeUnit.of(m.group("unit"))
+            val unit   = TimeWindowUnit.of(m.group("unit"))
             m.group("prefix") match {
               case "-" | "last" =>
                 TimeVector(-length, 0, unit)

--- a/airframe-metrics/jvm/src/main/scala/wvlet/airframe/metrics/TimeWindow.scala
+++ b/airframe-metrics/jvm/src/main/scala/wvlet/airframe/metrics/TimeWindow.scala
@@ -118,22 +118,6 @@ object TimeWindow {
   def withTimeZone(zoneId: ZoneOffset): TimeWindowBuilder = new TimeWindowBuilder(zoneId)
   def withUTC: TimeWindowBuilder                          = withTimeZone(UTC)
   def withSystemTimeZone: TimeWindowBuilder               = withTimeZone(systemTimeZone)
-
-  def truncateTo(t: ZonedDateTime, unit: ChronoUnit): ZonedDateTime = {
-    unit match {
-      case ChronoUnit.SECONDS | ChronoUnit.MINUTES | ChronoUnit.HOURS | ChronoUnit.DAYS =>
-        t.truncatedTo(unit)
-      case ChronoUnit.WEEKS =>
-        t.truncatedTo(ChronoUnit.DAYS).`with`(DayOfWeek.MONDAY)
-      case ChronoUnit.MONTHS =>
-        t.withDayOfMonth(1).truncatedTo(ChronoUnit.DAYS)
-      case ChronoUnit.YEARS =>
-        t.withDayOfYear(1).truncatedTo(ChronoUnit.DAYS)
-      case other =>
-        throw new UnsupportedOperationException(s"${other} is not supported")
-    }
-  }
-
 }
 
 class TimeWindowBuilder(val zone: ZoneOffset, currentTime: Option[ZonedDateTime] = None) extends LogSupport {
@@ -195,7 +179,7 @@ class TimeWindowBuilder(val zone: ZoneOffset, currentTime: Option[ZonedDateTime]
         m.group("offset") match {
           case null =>
             // When offset is not given, use the truncated time
-            val context = TimeWindow.truncateTo(now, duration.unit)
+            val context = duration.unit.truncate(now)
             duration.timeWindowFrom(context)
           case offsetStr =>
             val offset = parseOffset(offsetStr)

--- a/airframe-metrics/jvm/src/main/scala/wvlet/airframe/metrics/TimeWindowUnit.scala
+++ b/airframe-metrics/jvm/src/main/scala/wvlet/airframe/metrics/TimeWindowUnit.scala
@@ -19,7 +19,7 @@ import java.time.{DayOfWeek, ZonedDateTime}
 /**
   *
   */
-sealed abstract class TimeUnit(symbol: String) {
+sealed abstract class TimeWindowUnit(symbol: String) {
 
   /**
     * Truncate the given time to this unit
@@ -28,24 +28,24 @@ sealed abstract class TimeUnit(symbol: String) {
   def increment(a: ZonedDateTime, v: Long): ZonedDateTime
 }
 
-object TimeUnit {
+object TimeWindowUnit {
 
-  private val unitTable: Map[String, TimeUnit] = Map(
-    "s" -> TimeUnit.Second,
-    "m" -> TimeUnit.Minute,
-    "d" -> TimeUnit.Day,
-    "h" -> TimeUnit.Hour,
-    "w" -> TimeUnit.Week,
-    "M" -> TimeUnit.Month,
-    "q" -> TimeUnit.Quarter,
-    "y" -> TimeUnit.Year
+  private val unitTable: Map[String, TimeWindowUnit] = Map(
+    "s" -> TimeWindowUnit.Second,
+    "m" -> TimeWindowUnit.Minute,
+    "d" -> TimeWindowUnit.Day,
+    "h" -> TimeWindowUnit.Hour,
+    "w" -> TimeWindowUnit.Week,
+    "M" -> TimeWindowUnit.Month,
+    "q" -> TimeWindowUnit.Quarter,
+    "y" -> TimeWindowUnit.Year
   )
 
-  def of(s: String): TimeUnit = {
+  def of(s: String): TimeWindowUnit = {
     unitTable.getOrElse(s, throw new IllegalArgumentException(s"Unknown unit type ${s}"))
   }
 
-  case object Second extends TimeUnit("s") {
+  case object Second extends TimeWindowUnit("s") {
     override def truncate(t: ZonedDateTime): ZonedDateTime = {
       t.truncatedTo(ChronoUnit.SECONDS)
     }
@@ -53,7 +53,7 @@ object TimeUnit {
       a.plus(v, ChronoUnit.SECONDS)
     }
   }
-  case object Minute extends TimeUnit("m") {
+  case object Minute extends TimeWindowUnit("m") {
     override def truncate(t: ZonedDateTime): ZonedDateTime = {
       t.truncatedTo(ChronoUnit.MINUTES)
     }
@@ -61,7 +61,7 @@ object TimeUnit {
       a.plus(v, ChronoUnit.MINUTES)
     }
   }
-  case object Hour extends TimeUnit("h") {
+  case object Hour extends TimeWindowUnit("h") {
     override def truncate(t: ZonedDateTime): ZonedDateTime = {
       t.truncatedTo(ChronoUnit.HOURS)
     }
@@ -69,7 +69,7 @@ object TimeUnit {
       a.plus(v, ChronoUnit.HOURS)
     }
   }
-  case object Day extends TimeUnit("d") {
+  case object Day extends TimeWindowUnit("d") {
     override def truncate(t: ZonedDateTime): ZonedDateTime = {
       t.truncatedTo(ChronoUnit.DAYS)
     }
@@ -77,7 +77,7 @@ object TimeUnit {
       a.plus(v, ChronoUnit.DAYS)
     }
   }
-  case object Week extends TimeUnit("w") {
+  case object Week extends TimeWindowUnit("w") {
     override def truncate(t: ZonedDateTime): ZonedDateTime = {
       t.truncatedTo(ChronoUnit.DAYS) // Truncate to the beginning of the day
         .`with`(DayOfWeek.MONDAY) // Monday-origin week is the ISO standard
@@ -86,7 +86,7 @@ object TimeUnit {
       a.plus(v, ChronoUnit.WEEKS)
     }
   }
-  case object Month extends TimeUnit("M") {
+  case object Month extends TimeWindowUnit("M") {
     override def truncate(t: ZonedDateTime): ZonedDateTime = {
       t.withDayOfMonth(1) // Jump to the beginning of the day
         .truncatedTo(ChronoUnit.DAYS)
@@ -95,7 +95,7 @@ object TimeUnit {
       a.plus(v, ChronoUnit.MONTHS)
     }
   }
-  case object Quarter extends TimeUnit("q") {
+  case object Quarter extends TimeWindowUnit("q") {
     override def truncate(t: ZonedDateTime): ZonedDateTime = {
       // The first quarter of the year is January
       val quarter = ((t.getMonthValue - 1) / 3)
@@ -112,7 +112,7 @@ object TimeUnit {
     }
   }
 
-  case object Year extends TimeUnit("y") {
+  case object Year extends TimeWindowUnit("y") {
     override def truncate(t: ZonedDateTime): ZonedDateTime = {
       t.withDayOfYear(1)
         .truncatedTo(ChronoUnit.DAYS)

--- a/airframe-metrics/jvm/src/test/scala/wvlet/airframe/metrics/TimeWindowTest.scala
+++ b/airframe-metrics/jvm/src/test/scala/wvlet/airframe/metrics/TimeWindowTest.scala
@@ -128,6 +128,12 @@ class TimeWindowTest extends AirframeSpec {
       parse("-1h/2017-01-23 01:00:00", "[2017-01-23 00:00:00-0700,2017-01-23 01:00:00-0700)")
       parse("-1h/2017-01-23 01:23:45", "[2017-01-23 00:00:00-0700,2017-01-23 01:23:45-0700)")
       parse("-60m/2017-01-23 01:23:45", "[2017-01-23 00:23:00-0700,2017-01-23 01:23:45-0700)")
+
+      // quarter
+      parse("-1q", "[2016-01-01 00:00:00-0700,2016-04-01 00:00:00-0700)")
+      parse("1q", "[2016-04-01 00:00:00-0700,2016-07-01 00:00:00-0700)")
+      parse("-2q", "[2015-10-01 00:00:00-0700,2016-04-01 00:00:00-0700)")
+      parse("-1q/0y", "[2015-10-01 00:00:00-0700,2016-01-01 00:00:00-0700)")
     }
 
     "support human-friendly range" in {
@@ -187,10 +193,10 @@ class TimeWindowTest extends AirframeSpec {
       try {
         TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
         val t = TimeParser.parse("2017-04-04", ZoneOffset.of("-07:00"))
-        info(t)
+        debug(t)
         val w = TimeWindow.withTimeZone("PDT")
         val d = w.parse("-3d/2017-04-07")
-        info(d)
+        debug(d)
       } finally {
         TimeZone.setDefault(default)
       }

--- a/docs/src/main/tut/docs/airframe-metrics.md
+++ b/docs/src/main/tut/docs/airframe-metrics.md
@@ -81,8 +81,8 @@ Values with (or without)`-` sign means the *last* time range, and values with `+
 
 ```
 DURATION := (+ | -)?(INTEGER)(UNIT)
-// seconds, minutes, hours, days, weeks, (M)onths, years
-UNIT     := s | m | h | d | w | M | y
+// seconds, minutes, hours, days, weeks, (M)onths, quarters, years
+UNIT     := s | m | h | d | w | M | q | y
 
 OFFSET   := DURATION | DATE_TIME
 RANGE    := (DURATION) (/ (OFFSET))?
@@ -109,6 +109,7 @@ Here are several examples of relative time window strings when the current time 
 |`+7d/now`| next 7 days from now | `2016-06-26 01:23:45-0700` | `2016-07-03 00:00:00-0700`|
 |  `-1w`    | last week  |`2016-06-13 00:00:00-0700` | `2016-06-20 00:00:00-0700`|
 |  `-1M`    | last month |`2016-05-01 00:00:00-0700` | `2016-06-01 00:00:00-0700`|
+|  `-1q`    | last quarter |`2016-01-01 00:00:00-0700` | `2016-04-01 00:00:00-0700`|
 |  `-1y`    | last year  |`2015-01-01 00:00:00-0700` | `2016-01-01 00:00:00-0700`|
 |`-1h/2017-01-23 01:00:00`| last hour to a given offset | `2017-01-23 00:00:00-0700` | `2017-01-23 01:00:00-0700`|
 |`-1h/2017-01-23 01:23:45`| last hour to a given offset | `2017-01-23 00:00:00-0700` | `2017-01-23 01:23:45-0700`|


### PR DESCRIPTION
- There is no ChronoUnit.Quarter in JDK, so created ~TimeUnit~ TimeWindowUnit classes to use Quarter unit.
- The beginning of the quarter is January. But note that the definition of a quarter can be different depending on company culture.