### PR TITLE
use canonical name for arguments of method surface on MethodCallBuilder

### DIFF
--- a/airframe-surface/jvm/src/main/scala/wvlet/surface/reflect/MethodCallBuilder.scala
+++ b/airframe-surface/jvm/src/main/scala/wvlet/surface/reflect/MethodCallBuilder.scala
@@ -18,6 +18,7 @@ package wvlet.surface.reflect
   */
 import wvlet.log.LogSupport
 import wvlet.surface.{MethodParameter, MethodSurface, Zero}
+import wvlet.surface.CanonicalNameFormatter._
 
 //--------------------------------------
 //
@@ -34,7 +35,10 @@ import wvlet.surface.{MethodParameter, MethodSurface, Zero}
 class MethodCallBuilder(m: MethodSurface, owner: AnyRef) extends StandardBuilder with LogSupport {
 
   // Find the default arguments of the method
-  protected def defaultValues = (for (p <- m.args; v <- findDefaultValue(p.name)) yield p.name -> v).toMap
+  protected def defaultValues = (for (p <- m.args; v <- findDefaultValue(p.name)) yield {
+    trace(s"set default parameter $p to $v")
+    p.name.canonicalName -> v
+  }).toMap
 
   protected def findParameter(name: String): Option[MethodParameter] = {
     val cname = CName(name)

--- a/airframe-surface/jvm/src/main/scala/wvlet/surface/reflect/MethodCallBuilder.scala
+++ b/airframe-surface/jvm/src/main/scala/wvlet/surface/reflect/MethodCallBuilder.scala
@@ -35,10 +35,11 @@ import wvlet.surface.CanonicalNameFormatter._
 class MethodCallBuilder(m: MethodSurface, owner: AnyRef) extends StandardBuilder with LogSupport {
 
   // Find the default arguments of the method
-  protected def defaultValues = (for (p <- m.args; v <- findDefaultValue(p.name)) yield {
-    trace(s"set default parameter $p to $v")
-    p.name.canonicalName -> v
-  }).toMap
+  protected def defaultValues =
+    (for (p <- m.args; v <- findDefaultValue(p.name)) yield {
+      trace(s"set default parameter $p to $v")
+      p.name.canonicalName -> v
+    }).toMap
 
   protected def findParameter(name: String): Option[MethodParameter] = {
     val cname = CName(name)


### PR DESCRIPTION
`MethodCallBuilder` fail to use default value if argument name includes
capital letter. Therefore, airframe-opts's sub-command don't use default value
for such argument as follows.

```
scala> class SampleCommand() {
     |   @command()
     |   def sample(@option(prefix = "-a") aB: Int = 1) = {
     |     println(aB)
     |   }
     | }
defined class SampleCommand

scala> val l = Launcher.of[SampleCommand]
l: wvlet.airframe.opts.Launcher = wvlet.airframe.opts.Launcher@544a71e6

scala> l.execute(Array("sample"))
0
```

It is because `ObjectBuilder` tries to find arguments with canonical name.
https://github.com/yajirobee/airframe/blob/305e71afb5bda93a961d75d93a035c90e8b13905/airframe-surface/jvm/src/main/scala/wvlet/surface/reflect/ObjectBuilder.scala#L201