### PR TITLE
Upgrade to Scala 2.13.0-M5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,8 @@ matrix:
     - gem install fluentd -v 1.2.6
     services: postgresql
     before_script: psql -c 'create database travis_ci_test;' -U postgres
-    script: ./sbt ++$SCALA_VERSION ${PROJECT}/test
+    # Exclude design serialization tests due to bug https://github.com/scala/bug/issues/11192
+    script: ./sbt ++$SCALA_VERSION "${PROJECT}/testOnly* -- -l serde"
   - env: SCALA_VERSION=2.11.11 PROJECT=projectJVM
     jdk: openjdk8
     # Install fluentd

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ matrix:
     services: postgresql
     before_script: psql -c 'create database travis_ci_test;' -U postgres
     # Exclude design serialization tests due to bug https://github.com/scala/bug/issues/11192
-    script: ./sbt ++$SCALA_VERSION "${PROJECT}/testOnly* -- -l serde"
+    script: ./sbt ++$SCALA_VERSION "${PROJECT}/testOnly * -- -l serde"
   - env: SCALA_VERSION=2.11.11 PROJECT=projectJVM
     jdk: openjdk8
     # Install fluentd

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ matrix:
     script:
     - ./sbt ++$SCALA_VERSION "; coverage; ${PROJECT}/test; coverageReport"
     - "./sbt coverageAggregate && bash <(curl -s https://codecov.io/bash)"
-  - env: SCALA_VERSION=2.13.0-M4 PROJECT=projectJVM2_13
+  - env: SCALA_VERSION=2.13.0-M5 PROJECT=projectJVM2_13
     services: postgresql
     before_script: psql -c 'create database travis_ci_test;' -U postgres
     jdk: openjdk8

--- a/airframe-jmx/src/main/scala/wvlet/airframe/jmx/JMXMBean.scala
+++ b/airframe-jmx/src/main/scala/wvlet/airframe/jmx/JMXMBean.scala
@@ -15,13 +15,14 @@ package wvlet.airframe.jmx
 
 import java.lang.annotation.Annotation
 import java.lang.reflect.Method
-import javax.management._
 
+import javax.management._
 import wvlet.log.LogSupport
 import wvlet.airframe.surface.reflect._
 import wvlet.airframe.surface.{MethodSurface, Parameter, ParameterBase, Surface}
 
 import scala.reflect.runtime.{universe => ru}
+import wvlet.airframe.{jmx => aj}
 
 /**
   * Expose object information using DynamicMBean
@@ -76,7 +77,7 @@ object JMXMBean extends LogSupport {
     // Find JMX description
     val cl = obj.getClass
 
-    val description = cl.getAnnotation(classOf[JMX]) match {
+    val description = cl.getAnnotation(classOf[aj.JMX]) match {
       case a if a != null => a.description()
       case _              => ""
     }
@@ -112,8 +113,8 @@ object JMXMBean extends LogSupport {
 
   private def getDescription(h: ParameterBase): String = {
     h match {
-      case p: Parameter     => p.findAnnotationOf[JMX].map(_.description()).getOrElse("")
-      case m: MethodSurface => m.findAnnotationOf[JMX].map(_.description()).getOrElse("")
+      case p: Parameter     => p.findAnnotationOf[aj.JMX].map(_.description()).getOrElse("")
+      case m: MethodSurface => m.findAnnotationOf[aj.JMX].map(_.description()).getOrElse("")
     }
   }
 
@@ -121,8 +122,8 @@ object JMXMBean extends LogSupport {
     val surface = SurfaceFactory.ofType(tpe)
     val methods = SurfaceFactory.methodsOfType(tpe)
 
-    val jmxParams: Seq[ParameterBase] = surface.params.filter(_.findAnnotationOf[JMX].isDefined) ++ methods.find(
-      _.findAnnotationOf[JMX].isDefined)
+    val jmxParams: Seq[ParameterBase] = surface.params.filter(_.findAnnotationOf[aj.JMX].isDefined) ++ methods.find(
+      _.findAnnotationOf[aj.JMX].isDefined)
 
     jmxParams.flatMap { p =>
       val paramName = parent.map(x => s"${x.name}.${p.name}").getOrElse(p.name)
@@ -149,7 +150,7 @@ object JMXMBean extends LogSupport {
   private def isNestedMBean(p: ParameterBase): Boolean = {
     import wvlet.airframe.surface.reflect._
 
-    val jmxParams = p.surface.params.find(x => x.findAnnotationOf[JMX].isDefined)
+    val jmxParams = p.surface.params.find(x => x.findAnnotationOf[aj.JMX].isDefined)
     if (jmxParams.isDefined) {
       true
     } else {
@@ -157,7 +158,7 @@ object JMXMBean extends LogSupport {
         case None => false
         case Some(tpe) =>
           val methods    = SurfaceFactory.methodsOfType(tpe)
-          val jmxMethods = methods.find(m => m.findAnnotationOf[JMX].isDefined)
+          val jmxMethods = methods.find(m => m.findAnnotationOf[aj.JMX].isDefined)
           jmxMethods.isDefined
       }
     }

--- a/airframe-log/shared/src/main/scala/wvlet/log/Logger.scala
+++ b/airframe-log/shared/src/main/scala/wvlet/log/Logger.scala
@@ -17,8 +17,6 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.logging._
 import java.util.{Properties, logging => jl}
 
-import wvlet.log.LogFormatter.SourceCodeLogFormatter
-
 import scala.annotation.tailrec
 import scala.language.experimental.macros
 import scala.reflect.ClassTag
@@ -147,11 +145,11 @@ class Logger(private val name: String,
   }
 
   def log(level: LogLevel, source: LogSource, message: Any): Unit = {
-    log(LogRecord(level, source, formatLog(message)))
+    log(wvlet.log.LogRecord(level, source, formatLog(message)))
   }
 
   def logWithCause(level: LogLevel, source: LogSource, message: Any, cause: Throwable): Unit = {
-    log(LogRecord(level, source, formatLog(message), cause))
+    log(wvlet.log.LogRecord(level, source, formatLog(message), cause))
   }
 
   protected def isMultiLine(str: String) = str.contains("\n")

--- a/airframe/.jvm/src/test/scala/wvlet/airframe/DesignSerializationTest.scala
+++ b/airframe/.jvm/src/test/scala/wvlet/airframe/DesignSerializationTest.scala
@@ -16,6 +16,7 @@ package wvlet.airframe
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream}
 
 import DesignTest._
+import org.scalatest.Tag
 
 object DesignSerializationTest {
 
@@ -42,13 +43,13 @@ class DesignSerializationTest extends AirframeSpec {
   import DesignSerializationTest._
 
   "Design" should {
-    "be serializable" taggedAs ("ser") in {
+    "be serializable" taggedAs (Serde) in {
       val b   = serialize(d1)
       val d1s = deserialize(b)
       d1s shouldBe (d1)
     }
 
-    "serialize instance binding" taggedAs ("ser1") in {
+    "serialize instance binding" taggedAs (Serde) in {
       val d  = Design.blanc.bind[Message].toInstance(Hello("world"))
       val b  = serialize(d)
       val ds = deserialize(b)

--- a/airframe/.jvm/src/test/scala/wvlet/airframe/ProviderSerializationTest.scala
+++ b/airframe/.jvm/src/test/scala/wvlet/airframe/ProviderSerializationTest.scala
@@ -23,7 +23,7 @@ import DesignSerializationTest._
 class ProviderSerializationTest extends AirframeSpec {
 
   "Design" should {
-    "serialize design with provider" taggedAs ("ser") in {
+    "serialize design with provider" taggedAs (Serde) in {
       val testBinderDesign =
         providerDesign.bind[App].toProvider(provider5 _)
 
@@ -34,7 +34,7 @@ class ProviderSerializationTest extends AirframeSpec {
       app shouldBe App(d1, d2, d3, d4, d5)
     }
 
-    "serialize design with provider1" taggedAs ("ser-p1") in {
+    "serialize design with provider1" taggedAs (Serde) in {
       val testBinderDesign =
         providerDesign.bind[App].toProvider(provider1 _)
 

--- a/airframe/.jvm/src/test/scala/wvlet/airframe/SerializationTest.scala
+++ b/airframe/.jvm/src/test/scala/wvlet/airframe/SerializationTest.scala
@@ -13,6 +13,7 @@
  */
 package wvlet.airframe
 
+import org.scalatest.Tag
 import wvlet.log.LogSupport
 
 object SerializationTest extends LogSupport {
@@ -34,10 +35,12 @@ object SerializationTest extends LogSupport {
 
 import DesignSerializationTest._
 
+object Serde extends Tag("serde")
+
 class SerializationTest extends AirframeSpec {
 
   "Airframe" should {
-    "serialize provider" in {
+    "serialize provider" taggedAs (Serde) in {
       import wvlet.airframe.SerializationTest._
       val b  = serialize(d)
       val ds = deserialize(b)
@@ -48,7 +51,7 @@ class SerializationTest extends AirframeSpec {
       s.build[App] shouldBe App(A1(1))
     }
 
-    "serialize provider that involves toInstance of local var" in {
+    "serialize provider that involves toInstance of local var" taggedAs (Serde) in {
       import ProviderSerializationExample._
       import ProviderVal._
 

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ val SCALA_2_11 = "2.11.11"
 val untilScala2_12      = SCALA_2_12 :: SCALA_2_11 :: Nil
 val targetScalaVersions = SCALA_2_13 :: untilScala2_12
 
-val SCALATEST_VERSION               = "3.0.6-SNAP3"
+val SCALATEST_VERSION               = "3.0.6-SNAP4"
 val SCALACHECK_VERSION              = "1.14.0"
 val SCALA_PARSER_COMBINATOR_VERSION = "1.1.1"
 val SQLITE_JDBC_VERSION             = "3.21.0.1"

--- a/build.sbt
+++ b/build.sbt
@@ -52,7 +52,6 @@ val buildSettings = Seq[Setting[_]](
   crossPaths := true,
   publishMavenStyle := true,
   logBuffered in Test := false,
-  fork in Test := (scalaVersion.value == SCALA_2_13),
   scalacOptions ++= Seq("-feature", "-deprecation"), // ,"-Ytyper-debug"),
   sonatypeProfileName := "org.wvlet",
   licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html")),
@@ -135,14 +134,14 @@ lazy val jvmProjects: Seq[ProjectReference] = List(
   msgpackJVM,
   stream,
   http,
-  jsonJVM,
-  fluentd
+  jsonJVM
 )
 
 // JVM projects that cannot be build in Scala 2.13
 lazy val jvmProjects2_12: Seq[ProjectReference] = List(
   finagle,
-  jsonBenchmark
+  jsonBenchmark,
+  fluentd
 )
 
 // Scala.js builds is only for Scala 2.12
@@ -257,6 +256,7 @@ lazy val airframe =
       )
     )
     .jvmSettings(
+      fork in Test := (scalaVersion.value == SCALA_2_13),
       // include the macro classes and resources in the main jar
       mappings in (Compile, packageBin) ++= mappings.in(airframeMacrosJVM, Compile, packageBin).value,
       // include the macro sources in the main source jar

--- a/build.sbt
+++ b/build.sbt
@@ -51,6 +51,7 @@ val buildSettings = Seq[Setting[_]](
   crossPaths := true,
   publishMavenStyle := true,
   logBuffered in Test := false,
+  fork in Test := (scalaVersion.value == SCALA_2_13),
   scalacOptions ++= Seq("-feature", "-deprecation"), // ,"-Ytyper-debug"),
   sonatypeProfileName := "org.wvlet",
   licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html")),

--- a/build.sbt
+++ b/build.sbt
@@ -256,7 +256,6 @@ lazy val airframe =
       )
     )
     .jvmSettings(
-      fork in Test := (scalaVersion.value == SCALA_2_13),
       // include the macro classes and resources in the main jar
       mappings in (Compile, packageBin) ++= mappings.in(airframeMacrosJVM, Compile, packageBin).value,
       // include the macro sources in the main source jar

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ val SCALA_2_11 = "2.11.11"
 val untilScala2_12      = SCALA_2_12 :: SCALA_2_11 :: Nil
 val targetScalaVersions = SCALA_2_13 :: untilScala2_12
 
-val SCALATEST_VERSION               = "3.0.6-SNAP1"
+val SCALATEST_VERSION               = "3.0.6-SNAP3"
 val SCALACHECK_VERSION              = "1.14.0"
 val SCALA_PARSER_COMBINATOR_VERSION = "1.1.1"
 val SQLITE_JDBC_VERSION             = "3.21.0.1"

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbtcrossproject.{crossProject, CrossType}
 
-val SCALA_2_13 = "2.13.0-M4"
 val SCALA_2_12 = "2.12.7"
+val SCALA_2_13 = "2.13.0-M5"
 val SCALA_2_11 = "2.11.11"
 
 val untilScala2_12      = SCALA_2_12 :: SCALA_2_11 :: Nil

--- a/docs/src/main/tut/docs/release-notes.md
+++ b/docs/src/main/tut/docs/release-notes.md
@@ -5,6 +5,11 @@ title: Release Notes
 
 # Release Notes
 
+## 0.70
+-  airframe-control: Add a shell command launcher ([#287](https://github.com/wvlet/airframe/issues/287)) [[1339caf](https://github.com/wvlet/airframe/commit/1339caf)]
+-  Upgrade to sbt 1.2.6 ([#285](https://github.com/wvlet/airframe/issues/285)) [[614dba6](https://github.com/wvlet/airframe/commit/614dba6)]
+-  Fix typos in docs
+
 ## 0.69
 -  surface: [#270](https://github.com/wvlet/airframe/issues/270): Move wvlet.surface -> wvlet.airframe.surface ([#272](https://github.com/wvlet/airframe/issues/272)) [[5ca3143](https://github.com/wvlet/airframe/commit/5ca3143)]
 -  docs: Add note on scalafmt [[6867642](https://github.com/wvlet/airframe/commit/6867642)]


### PR DESCRIPTION
Need to wait the updates of the following libraries:
- [x] Scala.js (0.6.25)
- [x] ScalaTest https://github.com/scalatest/scalatest/issues/1409
- [x] ScalaCheck https://github.com/rickynils/scalacheck/issues/418
  - [x] ScalaCheck for Scala.js https://github.com/rickynils/scalacheck/pull/435
- [ ] Scala 2.13.0-M5 serialization regression https://github.com/scala/scala-dev/issues/562
  -  scala.collection.generic.DefaultSerializationProxy https://travis-ci.org/wvlet/airframe/jobs/439978533
 - [ ] https://github.com/scala/bug/issues/11192
- [x] Type bound check regression https://github.com/scala/bug/issues/11202
```
[error] /home/travis/build/wvlet/airframe/airframe-jmx/src/main/scala/wvlet/airframe/jmx/JMXMBean.scala:79:26: inferred type arguments [javax.management.JMX] do not conform to method getAnnotation's type parameter bounds [A <: java.lang.annotation.Annotation]
[error]     val description = cl.getAnnotation(classOf[JMX]) match {
```