### PR TITLE
Fix typo, misspelling words, unnecessary imports

### DIFF
--- a/airframe-codec/src/main/scala/wvlet/airframe/codec/CollectionCodec.scala
+++ b/airframe-codec/src/main/scala/wvlet/airframe/codec/CollectionCodec.scala
@@ -77,7 +77,7 @@ object CollectionCodec {
   }
 
   /*
-    Note: If we use MessageCodec[List[A]] it causes StackOverflow. Need more inverstigation
+    Note: If we use MessageCodec[List[A]] it causes StackOverflow. Need more investigation
     <code>
     [error] java.lang.StackOverflowError
     [error] 	at scala.reflect.internal.tpe.TypeMaps$SubstMap.apply(TypeMaps.scala:764)

--- a/airframe-codec/src/main/scala/wvlet/airframe/codec/MessageCodec.scala
+++ b/airframe-codec/src/main/scala/wvlet/airframe/codec/MessageCodec.scala
@@ -79,6 +79,8 @@ object MessageCodec {
   trait ErrorCode
   case object INVALID_DATA extends ErrorCode
 
-  def defautlFactory                     = new MessageCodecFactory(StandardCodec.standardCodec)
-  def of[A: ru.TypeTag]: MessageCodec[A] = defautlFactory.of[A]
+  @deprecated(message = "Use defaultFactory instead", since = "0.67")
+  def defautlFactory: MessageCodecFactory = defaultFactory
+  def defaultFactory: MessageCodecFactory = new MessageCodecFactory(StandardCodec.standardCodec)
+  def of[A: ru.TypeTag]: MessageCodec[A] = defaultFactory.of[A]
 }

--- a/airframe-codec/src/test/scala/wvlet/airframe/codec/MessageCodecTest.scala
+++ b/airframe-codec/src/test/scala/wvlet/airframe/codec/MessageCodecTest.scala
@@ -19,7 +19,7 @@ import wvlet.airframe.codec.PrimitiveCodec.LongCodec
 /**
   *
   */
-class aMessageCodecTest extends AirframeSpec {
+class MessageCodecTest extends AirframeSpec {
   "MessageCodec" should {
 
     "have surface" in {

--- a/airframe-codec/src/test/scala/wvlet/airframe/codec/ObjectCodecTest.scala
+++ b/airframe-codec/src/test/scala/wvlet/airframe/codec/ObjectCodecTest.scala
@@ -28,7 +28,7 @@ class ObjectCodecTest extends CodecSpec {
     roundtrip(codec, v, DataType.ANY)
 
     forAll { (i: Int, l: Long, f: Float, d: Double, c: Char, st: Short) =>
-      // scalacheck supports only upto 6 elements
+      // scalacheck supports only up to 6 elements
       forAll { (b: Boolean, s: String) =>
         val v = A1(i, l, f, d, c, st, b, s)
         roundtrip[A1](codec, v, DataType.ANY)
@@ -69,7 +69,7 @@ class ObjectCodecTest extends CodecSpec {
   }
 
   "populate case class with Option" in {
-    val codecFactory = MessageCodec.defautlFactory.withObjectMapCodec
+    val codecFactory = MessageCodec.defaultFactory.withObjectMapCodec
     val codec        = codecFactory.of[A3]
 
     {

--- a/airframe-config/src/main/scala/wvlet/airframe/config/package.scala
+++ b/airframe-config/src/main/scala/wvlet/airframe/config/package.scala
@@ -15,7 +15,7 @@ package wvlet.airframe
 import java.util.Properties
 
 import wvlet.airframe.config.Config.REPORT_UNUSED_PROPERTIES
-import wvlet.log.{LogSupport, Logger}
+import wvlet.log.Logger
 import wvlet.surface
 
 import scala.reflect.ClassTag
@@ -26,7 +26,6 @@ import scala.reflect.ClassTag
 package object config {
   private val logger = Logger("wvlet.airframe.config")
 
-  import wvlet.airframe._
   import scala.reflect.runtime.{universe => ru}
 
   def printConfig(c: Config): Unit = {
@@ -95,7 +94,7 @@ package object config {
     }
 
     /**
-      * Overide a subset of the configuration parameters, registered to the design.
+      * Override a subset of the configuration parameters, registered to the design.
       */
     def overrideConfigParams(props: Map[String, Any],
                              onUnusedProperties: Properties => Unit = REPORT_UNUSED_PROPERTIES): Design = {
@@ -111,7 +110,7 @@ package object config {
     }
 
     /**
-      * Overide a subset of the configuration parameters, registered to the design.
+      * Override a subset of the configuration parameters, registered to the design.
       */
     def overrideConfigParamsWithProperties(
         props: Properties,

--- a/airframe-http-finagle/src/main/scala/wvlet/airframe/http/finagle/FinagleRouter.scala
+++ b/airframe-http-finagle/src/main/scala/wvlet/airframe/http/finagle/FinagleRouter.scala
@@ -77,7 +77,7 @@ trait FinagleResponseHandler extends ResponseHandler[Request, Response] {
 
   // Use Map codecs to create natural JSON responses
   private[this] val mapCodecFactory =
-    MessageCodec.defautlFactory.withObjectMapCodec
+    MessageCodec.defaultFactory.withObjectMapCodec
 
   def toHttpResponse[A](request: Request, responseSurface: Surface, a: A): Response = {
     a match {

--- a/airframe-http/src/main/scala/wvlet/airframe/http/Router.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/Router.scala
@@ -121,7 +121,7 @@ case class Route(controllerSurface: Surface, method: HttpMethod, path: String, m
             request
           case _ =>
             // Build from the string value in the request params
-            val argCodec = MessageCodec.defautlFactory.of(arg.surface)
+            val argCodec = MessageCodec.defaultFactory.of(arg.surface)
             val v: Option[Any] = requestParams.get(arg.name) match {
               case Some(paramValue) =>
                 // String parameter to the method argument

--- a/airframe-jmx/src/main/scala/wvlet/airframe/jmx/JMXAgent.scala
+++ b/airframe-jmx/src/main/scala/wvlet/airframe/jmx/JMXAgent.scala
@@ -55,20 +55,23 @@ class JMXAgent(config: JMXConfig) extends JMXRegistry with JMXMBeanServerService
     new JMXServiceURL(url)
   }
 
-  def withConnetor[U](f: JMXConnector => U): U = {
+  @deprecated("Use #withConnector instead",  since = "0.67")
+  def withConnetor[U](f: JMXConnector => U): U = withConnector(f)
+
+  def withConnector[U](f: JMXConnector => U): U = {
     withResource(JMXConnectorFactory.connect(serviceUrl)) { connector =>
       f(connector)
     }
   }
 
   def getMBeanInfo(mbeanName: String): MBeanInfo = {
-    withConnetor { connector =>
+    withConnector { connector =>
       connector.getMBeanServerConnection.getMBeanInfo(new ObjectName(mbeanName))
     }
   }
 
   def getMBeanAttribute(mbeanName: String, attrName: String): Any = {
-    withConnetor { connector =>
+    withConnector { connector =>
       connector.getMBeanServerConnection.getAttribute(new ObjectName(mbeanName), attrName)
     }
   }

--- a/airframe-jmx/src/test/scala/wvlet/airframe/jmx/JMXAgentTest.scala
+++ b/airframe-jmx/src/test/scala/wvlet/airframe/jmx/JMXAgentTest.scala
@@ -26,7 +26,7 @@ class JMXAgentTest extends AirframeSpec {
     "find jmx registry" in {
       if (!JMXUtil.isAtLeastJava9) {
         val agent = new JMXAgent(new JMXConfig())
-        agent.withConnetor { connector =>
+        agent.withConnector { connector =>
           val connection = connector.getMBeanServerConnection()
           connection.getMBeanCount.toInt shouldBe >(0)
           val m = connection.getMBeanInfo(new ObjectName("java.lang:type=OperatingSystem"))

--- a/airframe-json/src/main/scala/wvlet/airframe/json/JSONParseException.scala
+++ b/airframe-json/src/main/scala/wvlet/airframe/json/JSONParseException.scala
@@ -23,4 +23,5 @@ class UnexpectedToken(line: Int, column: Int, pos: Int, message: String)
 class UnexpectedEOF(line: Int, column: Int, pos: Int, message: String)
     extends JSONParseException(s"line:${line}, column:${column}: ${message}")
 
-class InvalidJSONObject(messsage: String) extends JSONParseException(messsage)
+// TODO: unused as of 0.66
+class InvalidJSONObject(message: String) extends JSONParseException(message)

--- a/airframe-msgpack/src/main/scala/wvlet/airframe/msgpack/spi/ReadCursor.scala
+++ b/airframe-msgpack/src/main/scala/wvlet/airframe/msgpack/spi/ReadCursor.scala
@@ -21,7 +21,9 @@ package wvlet.airframe.msgpack.spi
 case class ReadCursor(var buf: ReadBuffer, var position: Int) {
   private var offset: Int = 0
 
-  def lastReaadByteLength: Int = offset
+  @deprecated("Use #lastReadByteLength instead", since = "0.67")
+  def lastReaadByteLength: Int = lastReadByteLength
+  def lastReadByteLength: Int = offset
 
   def resetCursor: Unit = {
     offset = 0

--- a/airframe-msgpack/src/main/scala/wvlet/airframe/msgpack/spi/Unpacker.scala
+++ b/airframe-msgpack/src/main/scala/wvlet/airframe/msgpack/spi/Unpacker.scala
@@ -23,7 +23,7 @@ import wvlet.airframe.msgpack.spi.Value._
 import MessageException._
 
 /**
-  * Read a message pack data from a given offset in the buffer. The last read byte length can be checked by calling [[ReadCursor.lastReaadByteLength]] method.
+  * Read a message pack data from a given offset in the buffer. The last read byte length can be checked by calling [[ReadCursor.lastReadByteLength]] method.
   */
 object Unpacker {
   def unpackValue(cursor: ReadCursor): Value = {
@@ -430,7 +430,7 @@ object Unpacker {
 
   def unpackString(cursor: ReadCursor): String = {
     val len       = unpackRawStringHeader(cursor)
-    val headerLen = cursor.lastReaadByteLength
+    val headerLen = cursor.lastReadByteLength
     if (len == 0) {
       EMPTY_STRING
     } else if (len >= Integer.MAX_VALUE) {

--- a/airframe-msgpack/src/main/scala/wvlet/airframe/msgpack/spi/WriteCursor.scala
+++ b/airframe-msgpack/src/main/scala/wvlet/airframe/msgpack/spi/WriteCursor.scala
@@ -13,8 +13,6 @@
  */
 package wvlet.airframe.msgpack.spi
 
-import java.math.BigInteger
-
 /**
   *
   */

--- a/airframe-opts/src/main/scala/wvlet/airframe/opts/CommandModule.scala
+++ b/airframe-opts/src/main/scala/wvlet/airframe/opts/CommandModule.scala
@@ -21,7 +21,6 @@
 
 package wvlet.airframe.opts
 
-import wvlet.surface.Surface
 import wvlet.surface.reflect.SurfaceFactory
 
 import scala.reflect.runtime.{universe => ru}

--- a/airframe-stream/src/main/scala/wvlet/airframe/stream/spi/SQLModel.scala
+++ b/airframe-stream/src/main/scala/wvlet/airframe/stream/spi/SQLModel.scala
@@ -83,7 +83,7 @@ object SQLModel {
   case object LeftOuterJoin extends JoinType
   // Joins for preserving right table entries
   case object RightOuterJoin extends JoinType
-  // Joins for preserbing both table entries
+  // Joins for preserving both table entries
   case object FullOuterJoin extends JoinType
   // Cartesian product of two tables
   case object CrossJoin extends JoinType

--- a/airframe-tablet/src/main/scala/wvlet/airframe/tablet/Schema.scala
+++ b/airframe-tablet/src/main/scala/wvlet/airframe/tablet/Schema.scala
@@ -13,8 +13,6 @@
  */
 package wvlet.airframe.tablet
 
-import java.util.Locale
-
 object Schema {
   sealed trait DataType {
     def signature: String

--- a/airframe-tablet/src/main/scala/wvlet/airframe/tablet/obj/ObjectTabletReader.scala
+++ b/airframe-tablet/src/main/scala/wvlet/airframe/tablet/obj/ObjectTabletReader.scala
@@ -33,12 +33,12 @@ class ObjectTabletReader[A](elementCodec: MessageCodec[A], input: Seq[A]) extend
 
 object ObjectTabletReader {
   def newTabletReader[A](seq: Seq[A], surface: Surface, codec: Map[Surface, MessageCodec[_]] = Map.empty) = {
-    val elementCodec = MessageCodec.defautlFactory.withCodecs(codec).of(surface)
+    val elementCodec = MessageCodec.defaultFactory.withCodecs(codec).of(surface)
     new ObjectTabletReader[A](elementCodec.asInstanceOf[MessageCodec[A]], seq)
   }
 
   def newTabletReaderOf[A: ru.TypeTag](seq: Seq[A], codec: Map[Surface, MessageCodec[_]] = Map.empty) = {
-    val elementCodec = MessageCodec.defautlFactory.withCodecs(codec).of[A]
+    val elementCodec = MessageCodec.defaultFactory.withCodecs(codec).of[A]
     new ObjectTabletReader[A](elementCodec, seq)
   }
 }

--- a/airframe-tablet/src/main/scala/wvlet/airframe/tablet/obj/ObjectTabletWriter.scala
+++ b/airframe-tablet/src/main/scala/wvlet/airframe/tablet/obj/ObjectTabletWriter.scala
@@ -28,7 +28,7 @@ class ObjectTabletWriter[A: ru.TypeTag](codec: Map[Surface, MessageCodec[_]] = M
     extends TabletWriter[A]
     with LogSupport {
 
-  private val elementCodec = MessageCodec.defautlFactory.withCodecs(codec).of[A]
+  private val elementCodec = MessageCodec.defaultFactory.withCodecs(codec).of[A]
 
   private val h         = new MessageHolder
   private val s         = surface.of[A]

--- a/airframe/src/main/scala/wvlet/airframe/Airframe.scala
+++ b/airframe/src/main/scala/wvlet/airframe/Airframe.scala
@@ -14,7 +14,7 @@
 package wvlet.airframe
 
 /**
-  * If importing wvlet.airframe._ is not preferrable, Airframe.newDesign can be used.
+  * If importing wvlet.airframe._ is not preferable, Airframe.newDesign can be used.
   */
 object Airframe {
   def newDesign: Design = Design.blanc

--- a/airframe/src/main/scala/wvlet/airframe/LifeCycleManager.scala
+++ b/airframe/src/main/scala/wvlet/airframe/LifeCycleManager.scala
@@ -196,7 +196,7 @@ object FILOLifeCycleHookExecutor extends LifeCycleEventHandler with LogSupport {
   override def beforeShutdown(lifeCycleManager: LifeCycleManager): Unit = {
     // beforeShutdown
     for (h <- lifeCycleManager.preShutdownHooks.reverse) {
-      trace(s"Calling pre-shutdown hoook: $h")
+      trace(s"Calling pre-shutdown hook: $h")
       h.execute
     }
 

--- a/airframe/src/test/scala/wvlet/airframe/AirframeMacrosTest.scala
+++ b/airframe/src/test/scala/wvlet/airframe/AirframeMacrosTest.scala
@@ -13,10 +13,7 @@
  */
 package wvlet.airframe
 
-import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream}
-
-import wvlet.log.{LogLevel, LogSupport, Logger}
-import wvlet.surface.Surface
+import wvlet.log.LogSupport
 
 trait NonAbstractTrait extends LogSupport {
   info("hello trait")

--- a/airframe/src/test/scala/wvlet/airframe/AirframeTest.scala
+++ b/airframe/src/test/scala/wvlet/airframe/AirframeTest.scala
@@ -67,7 +67,7 @@ object ServiceMixinExample {
     *   - Need to define XXXService boilerplate, which just has a val or def of the service object
     *   - Cannot change the variable name without defining additional XXXService trait
     *     - Need to care about variable naming conflict
-    *   - We don't know the missing dependenncy at compile time
+    *   - We don't know the missing dependency at compile time
     */
   trait FortunePrinterMixin extends PrinterService with FortuneService {
     printer.print(fortune.generate)
@@ -164,7 +164,7 @@ object ServiceMixinExample {
   }
 
   trait Nest1 extends LogSupport {
-    info("instanciated Nest1")
+    info("instantiated Nest1")
     val nest2 = bind[Nest2]
   }
 

--- a/airframe/src/test/scala/wvlet/airframe/AssistedInjectionTest.scala
+++ b/airframe/src/test/scala/wvlet/airframe/AssistedInjectionTest.scala
@@ -24,7 +24,7 @@ class AssistedInjectionTest extends AirframeSpec {
 
   "Airframe" should {
 
-    "support assistd injection" in {
+    "support assisted injection" in {
       newSilentDesign
         .bind[MyService].toInstance("hello")
         .withSession { session =>

--- a/airframe/src/test/scala/wvlet/airframe/DependencyTest.scala
+++ b/airframe/src/test/scala/wvlet/airframe/DependencyTest.scala
@@ -42,7 +42,7 @@ class DependencyTest extends AirframeSpec {
 
     "resolve concrete dependencies" in {
       val d = newSilentDesign
-        .bind[DependencyTest1.D].to[DependencyTest1.DImpl] // abstract class to a concreate trait
+        .bind[DependencyTest1.D].to[DependencyTest1.DImpl] // abstract class to a concrete trait
       d.withSession { session =>
         val a = session.build[DependencyTest1.A]
       }

--- a/airframe/src/test/scala/wvlet/airframe/LifeCycleManagerTest.scala
+++ b/airframe/src/test/scala/wvlet/airframe/LifeCycleManagerTest.scala
@@ -15,7 +15,6 @@ package wvlet.airframe
 
 import java.util.concurrent.atomic.AtomicInteger
 
-import javax.annotation.{PostConstruct, PreDestroy}
 import wvlet.log.{LogLevel, LogSupport, Logger}
 
 class Counter extends LogSupport {
@@ -142,7 +141,7 @@ class LifeCycleManagerTest extends AirframeSpec {
       u2.shutdownCount shouldBe 1
     }
 
-    "run start hook when the seesion is already strarted" in {
+    "run start hook when the session is already started" in {
       val session = newSilentDesign.newSession
 
       var cs: CounterService = null


### PR DESCRIPTION
This pull request improves:

* Fixing typo, misspelled words
  * Regarding method names, I kept the existing names as deprecated ones, too
* Removing unused imports