### PR TITLE
Add name conversion functionallity to CName

### DIFF
--- a/airframe-surface/js/src/main/scala/wvlet/airframe/surface/package.scala
+++ b/airframe-surface/js/src/main/scala/wvlet/airframe/surface/package.scala
@@ -16,6 +16,7 @@ package wvlet.airframe
 import java.util.concurrent.ConcurrentHashMap
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable
 
 /**
   *
@@ -26,4 +27,6 @@ package object surface {
 
   def getCached(fullName: String): Surface =
     surfaceCache.getOrElse(fullName, throw new IllegalArgumentException(s"Surface ${fullName} is not found in cache"))
+
+  def newCacheMap[A, B]: mutable.Map[A, B] = new mutable.HashMap[A, B]()
 }

--- a/airframe-surface/jvm/src/main/scala/wvlet/airframe/surface/package.scala
+++ b/airframe-surface/jvm/src/main/scala/wvlet/airframe/surface/package.scala
@@ -15,9 +15,12 @@ package wvlet.airframe
 
 import wvlet.airframe.surface.reflect.ReflectSurfaceFactory
 
+import scala.collection.mutable
+
 /**
   *
   */
 package object surface {
   def getCached(fullName: String): Surface = ReflectSurfaceFactory.get(fullName)
+  def newCacheMap[A, B]: mutable.Map[A, B] = new mutable.WeakHashMap[A, B]()
 }

--- a/airframe-surface/shared/src/main/scala/wvlet/airframe/surface/CName.scala
+++ b/airframe-surface/shared/src/main/scala/wvlet/airframe/surface/CName.scala
@@ -66,8 +66,6 @@ object CName {
       varName
     } else {
       def translate(varName: String) = {
-        //var components = Array[String]()
-
         def wikiNameComponents: List[String] = {
           findWikiNameComponent(0)
         }
@@ -140,6 +138,40 @@ class CName(val canonicalName: String, val naturalName: String) extends Comparab
       case o: CName if canonicalName.equals(o.canonicalName) => true
       case _                                                 => false
     }
+  }
+
+  lazy val snakeCase: String = naturalName.toLowerCase.replace(' ', '_')
+  lazy val dashCase: String  = naturalName.toLowerCase.replace(' ', '-')
+  lazy val upperCamelCase: String = {
+    val sb               = new StringBuilder()
+    var prevIsWhitespace = false
+    naturalName.toLowerCase.map { c =>
+      if (c != ' ') {
+        if (sb.length == 0 || prevIsWhitespace) {
+          sb.append(c.toUpper)
+        } else {
+          sb.append(c)
+        }
+      }
+      prevIsWhitespace = (c == ' ')
+    }
+    sb.toString
+  }
+
+  lazy val lowerCamelCase: String = {
+    val sb               = new StringBuilder()
+    var prevIsWhitespace = false
+    naturalName.toLowerCase.map { c =>
+      if (c != ' ') {
+        if (prevIsWhitespace) {
+          sb.append(c.toUpper)
+        } else {
+          sb.append(c)
+        }
+      }
+      prevIsWhitespace = (c == ' ')
+    }
+    sb.toString
   }
 
 }

--- a/airframe-surface/shared/src/main/scala/wvlet/airframe/surface/CName.scala
+++ b/airframe-surface/shared/src/main/scala/wvlet/airframe/surface/CName.scala
@@ -39,15 +39,15 @@ import scala.collection.mutable.WeakHashMap
   */
 object CName {
 
-  private val cnameTable = new WeakHashMap[String, CName]
+  private val cnameTable = newCacheMap[String, CName]
 
   def apply(name: String): CName = {
     cnameTable.getOrElseUpdate(name, new CName(toCanonicalName(name), toNaturalName(name)))
   }
 
   private val paramNameReplacePattern = Pattern.compile("[\\s-_]");
-  private val canonicalNameTable      = new WeakHashMap[String, String]
-  private val naturalNameTable        = new WeakHashMap[String, String]
+  private val canonicalNameTable      = newCacheMap[String, String]
+  private val naturalNameTable        = newCacheMap[String, String]
 
   private def isSplitChar(c: Char)    = c.isUpper || c == '_' || c == '-' || c == ' '
   private def isUpcasePrefix(c: Char) = c.isUpper || c.isDigit

--- a/airframe-surface/shared/src/main/scala/wvlet/airframe/surface/CName.scala
+++ b/airframe-surface/shared/src/main/scala/wvlet/airframe/surface/CName.scala
@@ -49,76 +49,77 @@ object CName {
   private val canonicalNameTable      = new WeakHashMap[String, String]
   private val naturalNameTable        = new WeakHashMap[String, String]
 
+  private def isSplitChar(c: Char)    = c.isUpper || c == '_' || c == '-' || c == ' '
+  private def isUpcasePrefix(c: Char) = c.isUpper || c.isDigit
+
   def toCanonicalName(paramName: String): String = {
     if (paramName == null) {
-      return paramName
-    };
-
-    canonicalNameTable.getOrElseUpdate(paramName, paramNameReplacePattern.matcher(paramName).replaceAll("").toLowerCase)
+      paramName
+    } else {
+      canonicalNameTable.getOrElseUpdate(paramName,
+                                         paramNameReplacePattern.matcher(paramName).replaceAll("").toLowerCase)
+    }
   }
 
   def toNaturalName(varName: String): String = {
     if (varName == null) {
-      return null
-    };
+      varName
+    } else {
+      def translate(varName: String) = {
+        //var components = Array[String]()
 
-    def isSplitChar(c: Char)    = c.isUpper || c == '_' || c == '-' || c == ' '
-    def isUpcasePrefix(c: Char) = c.isUpper || c.isDigit
-
-    def translate(varName: String) = {
-      //var components = Array[String]()
-
-      def wikiNameComponents: List[String] = {
-        findWikiNameComponent(0)
-      }
-
-      def findWikiNameComponent(index: Int): List[String] = {
-        val len = varName.length
-
-        def skipUpcasePrefix(i: Int): Int = {
-          if (i < len && isUpcasePrefix(varName(i))) {
-            skipUpcasePrefix(i + 1)
-          } else {
-            i
-          }
+        def wikiNameComponents: List[String] = {
+          findWikiNameComponent(0)
         }
 
-        def parseWikiComponent(i: Int): Int =
-          if (i < len && !isSplitChar(varName(i))) {
-            parseWikiComponent(i + 1)
-          } else {
-            i
-          }
+        def findWikiNameComponent(index: Int): List[String] = {
+          val len = varName.length
 
-        val start  = index
-        var cursor = index
-        if (cursor >= len) {
-          Nil
-        } else {
-          cursor = skipUpcasePrefix(cursor)
-          // Upcase prefix length is longer than or equals to 2
-          if (cursor - start >= 2) {
-            if (start == 0 && varName(cursor).isLower) {
-              cursor -= 1
-            }
-            varName.substring(start, cursor) :: findWikiNameComponent(cursor)
-          } else {
-            cursor = parseWikiComponent(cursor)
-            if (start < cursor) {
-              varName.substring(start, cursor).toLowerCase() :: findWikiNameComponent(cursor)
+          def skipUpcasePrefix(i: Int): Int = {
+            if (i < len && isUpcasePrefix(varName(i))) {
+              skipUpcasePrefix(i + 1)
             } else {
-              findWikiNameComponent(cursor + 1)
+              i
+            }
+          }
+
+          def parseWikiComponent(i: Int): Int =
+            if (i < len && !isSplitChar(varName(i))) {
+              parseWikiComponent(i + 1)
+            } else {
+              i
+            }
+
+          val start  = index
+          var cursor = index
+          if (cursor >= len) {
+            Nil
+          } else {
+            cursor = skipUpcasePrefix(cursor)
+            // Upcase prefix length is longer than or equals to 2
+            if (cursor - start >= 2) {
+              if (start == 0 && varName(cursor).isLower) {
+                cursor -= 1
+              }
+              varName.substring(start, cursor) :: findWikiNameComponent(cursor)
+            } else {
+              cursor = parseWikiComponent(cursor)
+              if (start < cursor) {
+                varName.substring(start, cursor).toLowerCase() :: findWikiNameComponent(cursor)
+              } else {
+                findWikiNameComponent(cursor + 1)
+              }
             }
           }
         }
+
+        val components = wikiNameComponents
+        val nName      = components.mkString(" ")
+        nName
       }
 
-      val components = wikiNameComponents
-      val nName      = components.mkString(" ")
-      nName
+      naturalNameTable.getOrElseUpdate(varName, translate(varName))
     }
-
-    naturalNameTable.getOrElseUpdate(varName, translate(varName))
   }
 
 }
@@ -135,10 +136,9 @@ class CName(val canonicalName: String, val naturalName: String) extends Comparab
 
   override def hashCode = canonicalName.hashCode()
   override def equals(other: Any) = {
-    if (other.isInstanceOf[CName]) {
-      canonicalName.equals(other.asInstanceOf[CName].canonicalName)
-    } else {
-      false
+    other match {
+      case o: CName if canonicalName.equals(o.canonicalName) => true
+      case _                                                 => false
     }
   }
 

--- a/airframe-surface/shared/src/test/scala/wvlet/airframe/surface/CNameTest.scala
+++ b/airframe-surface/shared/src/test/scala/wvlet/airframe/surface/CNameTest.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.surface
+
+import wvlet.airframe.AirframeSpec
+
+class CNameTest extends AirframeSpec {
+
+  "CName" should {
+    "convert to snakeCase" in {
+      assert(CName("AirframeSurface").snakeCase == "airframe_surface")
+      assert(CName("airframe_surface").snakeCase == "airframe_surface")
+      assert(CName("airframe-surface").snakeCase == "airframe_surface")
+      assert(CName("airframeSurface").snakeCase == "airframe_surface")
+      assert(CName("Airframe Surface").snakeCase == "airframe_surface")
+    }
+
+    "convert to dashCase" in {
+      assert(CName("AirframeSurface").dashCase == "airframe-surface")
+      assert(CName("airframe_surface").dashCase == "airframe-surface")
+      assert(CName("airframe-surface").dashCase == "airframe-surface")
+      assert(CName("airframeSurface").dashCase == "airframe-surface")
+      assert(CName("Airframe Surface").dashCase == "airframe-surface")
+    }
+
+    "convert to .upperCamelCase" in {
+      assert(CName("AirframeSurface").upperCamelCase == "AirframeSurface")
+      assert(CName("airframe_surface").upperCamelCase == "AirframeSurface")
+      assert(CName("airframe-surface").upperCamelCase == "AirframeSurface")
+      assert(CName("airframeSurface").upperCamelCase == "AirframeSurface")
+      assert(CName("Airframe Surface").upperCamelCase == "AirframeSurface")
+    }
+
+    "convert to lowerCamelCase" in {
+      assert(CName("AirframeSurface").lowerCamelCase == "airframeSurface")
+      assert(CName("airframe_surface").lowerCamelCase == "airframeSurface")
+      assert(CName("airframe-surface").lowerCamelCase == "airframeSurface")
+      assert(CName("airframeSurface").lowerCamelCase == "airframeSurface")
+      assert(CName("Airframe Surface").lowerCamelCase == "airframeSurface")
+    }
+  }
+}


### PR DESCRIPTION
- Refactored existing code
  - Not use `return`
  - Avoid cast in `CName#equals()`
  - Use `HashMap` instead of `WeakHashMap` in Scala.js
- Added name conversions from natural name
  - `snakeCase`
  - `dashCase`
  - `upperCamelCase`
  - `lowerCamelCase`