### PR TITLE
Set the code coverage test threshold to 80% overall, 5% diff coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,8 @@
 codecov:
   notify:
     require_ci_to_pass: no
+
+coverage:
   status:
     project:
       default:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,10 +1,12 @@
 codecov:
   notify:
     require_ci_to_pass: no
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 5%
 
 ignore:
   - "**/*Macros.scala"        # Scala Macros coverage cannot be evaluated
   - "**/[\.]?js/src/**.scala" # Scala.js code 
-
-
-


### PR DESCRIPTION
Having strict coverage check is good in general, but time-consuming at the same time. 

This PR will use 80% code coverage as a guideline of maintaining the code health. 
