### PR TITLE
Add ArrayJSONCodec to parse JSON array string

### DIFF
--- a/airframe-tablet/src/main/scala/wvlet/airframe/tablet/text/ArrayJSONCodec.scala
+++ b/airframe-tablet/src/main/scala/wvlet/airframe/tablet/text/ArrayJSONCodec.scala
@@ -32,9 +32,7 @@ import scala.reflect.runtime.{universe => ru}
 sealed trait ArrayJSONCodec[T] {
   protected val codec: MessageCodec[Array[T]]
   def toJSON(v: Array[T]): String = {
-    val packer = MessagePack.newBufferPacker
-    codec.pack(packer, v)
-    val bytes = packer.toByteArray
+    val bytes = codec.toMsgPack(v)
     JSONObjectPrinter.write(MessagePackRecord(bytes))
   }
 
@@ -72,7 +70,7 @@ object ArrayJSONCodec {
   implicit object StringArrayJSONCodec extends ArrayJSONCodec[String] {
     override protected val codec: MessageCodec[Array[String]] = StringArrayCodec
   }
-  def of[A](implicit tt: ru.TypeTag[Array[A]], codec: ArrayJSONCodec[A]): ArrayJSONCodec[A] = {
+  def of[A: ru.TypeTag](implicit codec: ArrayJSONCodec[A]): ArrayJSONCodec[A] = {
     MessageCodec.of[Array[A]] match {
       case _: MessageCodec[Array[A]] => codec
       case _ =>

--- a/airframe-tablet/src/main/scala/wvlet/airframe/tablet/text/ArrayJSONCodec.scala
+++ b/airframe-tablet/src/main/scala/wvlet/airframe/tablet/text/ArrayJSONCodec.scala
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.tablet.text
+import wvlet.airframe.codec.PrimitiveCodec.{
+  BooleanArrayCodec,
+  CharArrayCodec,
+  DoubleArrayCodec,
+  FloatArrayCodec,
+  IntArrayCodec,
+  LongArrayCodec,
+  ShortArrayCodec,
+  StringArrayCodec
+}
+import wvlet.airframe.codec.{JSONCodec, MessageCodec, MessageHolder}
+import wvlet.airframe.msgpack.spi.MessagePack
+import wvlet.airframe.surface.Surface
+import wvlet.airframe.tablet.MessagePackRecord
+
+import scala.reflect.runtime.{universe => ru}
+
+sealed trait ArrayJSONCodec[T] {
+  protected val codec: MessageCodec[Array[T]]
+  def toJSON(v: Array[T]): String = {
+    val packer = MessagePack.newBufferPacker
+    codec.pack(packer, v)
+    val bytes = packer.toByteArray
+    JSONObjectPrinter.write(MessagePackRecord(bytes))
+  }
+
+  def fromJSON(json: String, v: MessageHolder): Unit = {
+    val jsonMessage = MessagePackRecord(JSONCodec.toMsgPack(json))
+    codec.unpack(jsonMessage.unpacker, v)
+  }
+}
+
+/**
+  * JSON array codec for the primitive type elements.
+  */
+object ArrayJSONCodec {
+  implicit object ShortArrayJSONCodec extends ArrayJSONCodec[Short] {
+    override protected val codec: MessageCodec[Array[Short]] = ShortArrayCodec
+  }
+  implicit object IntArrayJSONCodec extends ArrayJSONCodec[Int] {
+    override protected val codec: MessageCodec[Array[Int]] = IntArrayCodec
+  }
+  implicit object LongArrayJSONCodec extends ArrayJSONCodec[Long] {
+    override protected val codec: MessageCodec[Array[Long]] = LongArrayCodec
+  }
+  implicit object CharArrayJSONCodec extends ArrayJSONCodec[Char] {
+    override protected val codec: MessageCodec[Array[Char]] = CharArrayCodec
+  }
+  implicit object FloatArrayJSONCodec extends ArrayJSONCodec[Float] {
+    override protected val codec: MessageCodec[Array[Float]] = FloatArrayCodec
+  }
+  implicit object DoubleArrayJSONCodec extends ArrayJSONCodec[Double] {
+    override protected val codec: MessageCodec[Array[Double]] = DoubleArrayCodec
+  }
+  implicit object BooleanArrayJSONCodec extends ArrayJSONCodec[Boolean] {
+    override protected val codec: MessageCodec[Array[Boolean]] = BooleanArrayCodec
+  }
+  implicit object StringArrayJSONCodec extends ArrayJSONCodec[String] {
+    override protected val codec: MessageCodec[Array[String]] = StringArrayCodec
+  }
+  def of[A](implicit tt: ru.TypeTag[Array[A]], codec: ArrayJSONCodec[A]): ArrayJSONCodec[A] = {
+    MessageCodec.of[Array[A]] match {
+      case _: MessageCodec[Array[A]] => codec
+      case _ =>
+        throw new IllegalArgumentException(s"${Surface.of[A]} has no PrimitiveCodec for array")
+    }
+  }
+}

--- a/airframe-tablet/src/test/scala/wvlet/airframe/tablet/text/ArrayJSONCodecTest.scala
+++ b/airframe-tablet/src/test/scala/wvlet/airframe/tablet/text/ArrayJSONCodecTest.scala
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.tablet.text
+
+import wvlet.airframe.AirframeSpec
+import wvlet.airframe.codec.MessageHolder
+
+class ArrayJSONCodecTest extends AirframeSpec {
+  private def assertEncode[T](codec: ArrayJSONCodec[T], input: Array[T]) = {
+    val json = codec.toJSON(input)
+    info(s"encoded: $json")
+    val v = new MessageHolder
+    codec.fromJSON(json, v)
+
+    v.isNull shouldBe false
+    v.getLastValue shouldBe input
+  }
+
+  "ArrayJSONCodec" should {
+    "encode short array" in {
+      val codec = ArrayJSONCodec.of[Short]
+      val a     = Array[Short](1, 2)
+      assertEncode(codec, a)
+    }
+
+    "encode int array" in {
+      val codec = ArrayJSONCodec.of[Int]
+      val a     = Array(1, 2)
+      assertEncode(codec, a)
+    }
+
+    "encode long array" in {
+      val codec = ArrayJSONCodec.of[Long]
+      val a     = Array(1L, 2L)
+      assertEncode(codec, a)
+    }
+
+    "encode char array" in {
+      val codec = ArrayJSONCodec.of[Char]
+      val a     = Array('a', 'b')
+      assertEncode(codec, a)
+    }
+
+    "encode float array" in {
+      val codec = ArrayJSONCodec.of[Float]
+      val a     = Array(1.5f, 2.5f)
+      assertEncode(codec, a)
+    }
+
+    "encode double array" in {
+      val codec = ArrayJSONCodec.of[Double]
+      val a     = Array(1.5d, 2.5d)
+      assertEncode(codec, a)
+    }
+
+    "encode boolean array" in {
+      val codec = ArrayJSONCodec.of[Boolean]
+      val a     = Array(true, false)
+      assertEncode(codec, a)
+    }
+
+    "encode string array" in {
+      val codec = ArrayJSONCodec.of[String]
+      val a     = Array("a", "b")
+      assertEncode(codec, a)
+    }
+  }
+}


### PR DESCRIPTION
JSON string can have array string [in the root level](https://www.json.org/). I added `ArrayJSONCodec` in order to provide the similar usability as `ObjectJSONCodec` for array JSON string.

```scala
val codec = ArrayJSONCodec.of[String]
val a = Array("a", "b")

// Encode
val json = codec.toJSON(a) // -> '["a", "b"]'

// Decode
val v = new MessageHolder
codec.fromJSON(json, v)
```

Supported primitive types
- `Short`
- `Int`
- `Long`
- `Char`
- `Float`
- `Double`
- `Boolean`
- `String`