### PR TITLE
#373: design.build[X] { ... } closure scope

### DIFF
--- a/airframe-macros/src/main/scala/wvlet/airframe/AirframeMacros.scala
+++ b/airframe-macros/src/main/scala/wvlet/airframe/AirframeMacros.scala
@@ -242,9 +242,11 @@ private[wvlet] object AirframeMacros {
     val t = implicitly[c.WeakTypeTag[A]].tpe
     val h = new BindHelper[c.type](c)
     h.withFactoryRegistration(t,
-                              q"""${c.prefix}
-         .bind(${h.surfaceOf(t)})
-         .asInstanceOf[wvlet.airframe.Binder[$t]]""")
+                              q"""{
+         val d = ${c.prefix}
+         d.bind(${h.surfaceOf(t)}).asInstanceOf[wvlet.airframe.Binder[$t]]
+        }
+        """)
   }
 
   def designRemoveImpl[A: c.WeakTypeTag](c: sm.Context): c.Tree = {

--- a/airframe-macros/src/main/scala/wvlet/airframe/AirframeMacros.scala
+++ b/airframe-macros/src/main/scala/wvlet/airframe/AirframeMacros.scala
@@ -407,20 +407,27 @@ private[wvlet] object AirframeMacros {
     new BindHelper[c.type](c).bind(c.prefix.tree, t)
   }
 
-  def buildWithSession[A: c.WeakTypeTag](c: sm.Context)(body: c.Tree): c.Tree = {
+  def buildWithSession[A: c.WeakTypeTag](c: sm.Context)(body: c.Expr[A => Any]): c.Tree = {
     import c.universe._
+    import internal._
     val t = implicitly[c.WeakTypeTag[A]].tpe
-    q"""{
-           ${c.prefix}.withSession { session =>
-              val a = session.build[${t}]
-              ${body}(a)
-           }
-        }
+    val e = q"""
+         ${c.prefix}.withSession { x =>
+            val a = x.build[${t}]
+            ${body}(a)
+         }
      """
+    val m = showRaw(e)
+    if (m.contains("helloDesign")) {
+      println(showRaw(body))
+      println(showCode(e))
+    }
+    e
   }
 
   def addLifeCycle[A: c.WeakTypeTag](c: sm.Context): c.Tree = {
     import c.universe._
+
     val t = implicitly[c.WeakTypeTag[A]].tpe
     val h = new BindHelper[c.type](c)
     q"""{

--- a/airframe-macros/src/main/scala/wvlet/airframe/AirframeMacros.scala
+++ b/airframe-macros/src/main/scala/wvlet/airframe/AirframeMacros.scala
@@ -232,7 +232,6 @@ private[wvlet] object AirframeMacros {
   }
 
   def registerTraitFactoryImpl[A: c.WeakTypeTag](c: sm.Context): c.Tree = {
-    import c.universe._
     val t = implicitly[c.WeakTypeTag[A]].tpe
     val h = new BindHelper[c.type](c)
     h.registerTraitFactory(t)
@@ -402,26 +401,23 @@ private[wvlet] object AirframeMacros {
     * @return
     */
   def buildImpl[A: c.WeakTypeTag](c: sm.Context): c.Tree = {
-    import c.universe._
     val t = implicitly[c.WeakTypeTag[A]].tpe
     new BindHelper[c.type](c).bind(c.prefix.tree, t)
   }
 
   def buildWithSession[A: c.WeakTypeTag](c: sm.Context)(body: c.Expr[A => Any]): c.Tree = {
     import c.universe._
-    import internal._
     val t = implicitly[c.WeakTypeTag[A]].tpe
+    // Bind the code block to a local var to resolve #373
     val e = q"""
-         ${c.prefix}.withSession { x =>
-            val a = x.build[${t}]
-            ${body}(a)
+         {
+           val codeBlock = ${body}
+           (${c.prefix}).withSession { session =>
+              val a = session.build[${t}]
+              codeBlock(a)
+           }
          }
      """
-    val m = showRaw(e)
-    if (m.contains("helloDesign")) {
-      println(showRaw(body))
-      println(showCode(e))
-    }
     e
   }
 
@@ -631,8 +627,9 @@ private[wvlet] object AirframeMacros {
   }
 
   def bindFactoryImpl[F: c.WeakTypeTag](c: sm.Context): c.Tree = {
-    import scala.language.higherKinds
     import c.universe._
+
+    import scala.language.higherKinds
     val t  = implicitly[c.WeakTypeTag[F]].tpe // F = Function[I1, A]
     val i1 = t.typeArgs(0) // I1
     val a  = t.typeArgs(1) // A
@@ -645,8 +642,9 @@ private[wvlet] object AirframeMacros {
   }
 
   def bindFactory2Impl[F: c.WeakTypeTag](c: sm.Context): c.Tree = {
-    import scala.language.higherKinds
     import c.universe._
+
+    import scala.language.higherKinds
     val t  = implicitly[c.WeakTypeTag[F]].tpe // F = Function[(I1, I2), A]
     val i1 = t.typeArgs(0) // I1
     val i2 = t.typeArgs(1) // I2
@@ -664,8 +662,9 @@ private[wvlet] object AirframeMacros {
   }
 
   def bindFactory3Impl[F: c.WeakTypeTag](c: sm.Context): c.Tree = {
-    import scala.language.higherKinds
     import c.universe._
+
+    import scala.language.higherKinds
     val t  = implicitly[c.WeakTypeTag[F]].tpe // F = Function[(I1, I2, I3), A]
     val i1 = t.typeArgs(0) // I1
     val i2 = t.typeArgs(1) // I2
@@ -685,8 +684,9 @@ private[wvlet] object AirframeMacros {
   }
 
   def bindFactory4Impl[F: c.WeakTypeTag](c: sm.Context): c.Tree = {
-    import scala.language.higherKinds
     import c.universe._
+
+    import scala.language.higherKinds
     val t  = implicitly[c.WeakTypeTag[F]].tpe // F = Function[(I1, I2, I3, I4), A]
     val i1 = t.typeArgs(0) // I1
     val i2 = t.typeArgs(1) // I2
@@ -708,8 +708,9 @@ private[wvlet] object AirframeMacros {
   }
 
   def bindFactory5Impl[F: c.WeakTypeTag](c: sm.Context): c.Tree = {
-    import scala.language.higherKinds
     import c.universe._
+
+    import scala.language.higherKinds
     val t  = implicitly[c.WeakTypeTag[F]].tpe // F = Function[(I1, I2, I3, I4, I4), A]
     val i1 = t.typeArgs(0) // I1
     val i2 = t.typeArgs(1) // I2

--- a/airframe/src/test/scala/wvlet/airframe/DesignBuildTest.scala
+++ b/airframe/src/test/scala/wvlet/airframe/DesignBuildTest.scala
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe
+
+/**
+  *
+  */
+class DesignBuildTest extends AirframeSpec {
+
+  "visible outer variables in code block" in {
+    val helloDesign = "hello"
+    val d = newDesign
+      .bind[String].toInstance(helloDesign)
+
+    d.build[String] { x =>
+      helloDesign
+    }
+  }
+}


### PR DESCRIPTION
It seems closure handling has changed after Scala 2.12 and local variables cannot be found inside the passed closure. #373

 In Scala 2.11 there is no problem.