### PR TITLE
airframe-http: Allow more flexible http path routing

### DIFF
--- a/airframe-http/src/main/scala/wvlet/airframe/http/Router.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/Router.scala
@@ -31,9 +31,16 @@ class Router(val routes: Seq[Route]) {
     routes
       .find { r =>
         r.method == request.method &&
-        r.pathComponents.length == request.pathComponents.length &&
-        request.path.startsWith(r.pathPrefix)
+        checkPath(request.pathComponents, r.pathComponents)
       }
+  }
+
+  private def checkPath(requestPathComponents: Seq[String], routePathComponents: Seq[String]): Boolean = {
+    if(requestPathComponents.length == routePathComponents.length){
+      requestPathComponents.zip(routePathComponents).forall { case (requestPathComponent, routePathComponent) =>
+        routePathComponent.startsWith(":") || routePathComponent == requestPathComponent
+      }
+    } else false
   }
 
   /**
@@ -81,13 +88,6 @@ case class Route(controllerSurface: Surface, method: HttpMethod, path: String, m
       .substring(1)
       .split("/")
       .toIndexedSeq
-  }
-
-  lazy val pathPrefix: String = {
-    "/" +
-      pathComponents
-        .takeWhile(!_.startsWith(":"))
-        .mkString("/")
   }
 
   def returnTypeSurface: Surface = methodSurface.returnType

--- a/airframe-http/src/main/scala/wvlet/airframe/http/Router.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/Router.scala
@@ -36,9 +36,10 @@ class Router(val routes: Seq[Route]) {
   }
 
   private def checkPath(requestPathComponents: Seq[String], routePathComponents: Seq[String]): Boolean = {
-    if(requestPathComponents.length == routePathComponents.length){
-      requestPathComponents.zip(routePathComponents).forall { case (requestPathComponent, routePathComponent) =>
-        routePathComponent.startsWith(":") || routePathComponent == requestPathComponent
+    if (requestPathComponents.length == routePathComponents.length) {
+      requestPathComponents.zip(routePathComponents).forall {
+        case (requestPathComponent, routePathComponent) =>
+          routePathComponent.startsWith(":") || routePathComponent == requestPathComponent
       }
     } else false
   }

--- a/airframe-http/src/test/scala/wvlet/airframe/http/ControllerExample.scala
+++ b/airframe-http/src/test/scala/wvlet/airframe/http/ControllerExample.scala
@@ -20,6 +20,7 @@ import wvlet.log.LogSupport
 object ControllerExample {
   case class User(id: String, name: String)
   case class CreateUserRequest(name: String)
+  case class Group(name: String, users: Seq[User])
 }
 
 /**
@@ -54,6 +55,28 @@ trait ControllerExample extends LogSupport {
     info(s"id: ${id}, ${httpRequest.contentString}")
     httpRequest.contentString
   }
+
+  @Endpoint(path = "/:group/users", method = HttpMethod.GET)
+  def groupUsers(group: String): Group = {
+    val g = Group(group, Seq(User("10", "leo")))
+    info(s"get ${g}")
+    g
+  }
+
+  @Endpoint(path = "/:group/user/:id", method = HttpMethod.GET)
+  def groupUser(group: String, id: String): Group = {
+    val g = Group(group, Seq(User(id, "leo")))
+    info(s"get ${g}")
+    g
+  }
+
+  @Endpoint(path = "/conflict/users", method = HttpMethod.GET)
+  def conflictPath(): Group = {
+    val g = Group("xxx", Seq(User("10", "leo")))
+    info(s"get ${g}")
+    g
+  }
+
 }
 
 trait InvalidService {

--- a/airframe-http/src/test/scala/wvlet/airframe/http/RouterTest.scala
+++ b/airframe-http/src/test/scala/wvlet/airframe/http/RouterTest.scala
@@ -122,6 +122,36 @@ class RouterTest extends AirframeSpec {
 
         ret.get.asInstanceOf[ControllerExample.User].name shouldBe "aina"
       }
+
+      {
+        val req = SimpleHttpRequest(HttpMethod.GET, "/scala/users")
+        val ret =
+          router
+            .findRoute(req)
+            .flatMap(_.call(serviceProvider, req))
+
+        ret.get shouldBe ControllerExample.Group("scala", Seq(ControllerExample.User("10", "leo")))
+      }
+
+      {
+        val req = SimpleHttpRequest(HttpMethod.GET, "/scala/user/11")
+        val ret =
+          router
+            .findRoute(req)
+            .flatMap(_.call(serviceProvider, req))
+
+        ret.get shouldBe ControllerExample.Group("scala", Seq(ControllerExample.User("11", "leo")))
+      }
+
+      {
+        val req = SimpleHttpRequest(HttpMethod.GET, "/conflict/users")
+        val ret =
+          router
+            .findRoute(req)
+            .flatMap(_.call(serviceProvider, req))
+
+        ret.get shouldBe ControllerExample.Group("xxx", Seq(ControllerExample.User("10", "leo")))
+      }
     }
   }
 }


### PR DESCRIPTION
The current implementation of airframe-http's router allows to define the parameter only at the last component of the path. This pull request allows more flexible http path routing like:

- `/:param/hoge`
- `/:param1/hoge/:param2`

See also #417