### PR TITLE
airframe-json: Parsing large array of objects throws StackOverflowError

### DIFF
--- a/airframe-json/src/main/scala/wvlet/airframe/json/JSONScanner.scala
+++ b/airframe-json/src/main/scala/wvlet/airframe/json/JSONScanner.scala
@@ -232,9 +232,11 @@ class JSONScanner[J](private[this] val s: JSONSource, private[this] val handler:
       rscan(state, stack)
     } else if (state == DATA) {
       if (ch == LSquare) {
-        scanArray(stack)
+        cursor += 1
+        rscan(ARRAY_START, stack.head.arrayContext(s, cursor - 1) :: stack)
       } else if (ch == LBracket) {
-        scanObject(stack)
+        cursor += 1
+        rscan(OBJECT_START, stack.head.objectContext(s, cursor - 1) :: stack)
       } else {
         val ctx = stack.head
         if ((ch >= '0' && ch <= '9') || ch == '-') {

--- a/airframe-json/src/test/scala/wvlet/airframe/json/JSONParserTest.scala
+++ b/airframe-json/src/test/scala/wvlet/airframe/json/JSONParserTest.scala
@@ -32,5 +32,9 @@ class JSONParserTest extends AirframeSpec {
       parse("{}")
       parse("""{"id":1, "name":"leo", "value":0.1, "num":10000000000000000000000000}""")
     }
+    "parse large array of objects" in {
+      val json = (for (_ <- 0 to 10000) yield "{}").mkString("[", ",", "]")
+      parse(json)
+    }
   }
 }


### PR DESCRIPTION
Parsing objects in array looks recursive and stack consuming.
```
[error]         at wvlet.airframe.json.JSONScanner.rscan(JSONScanner.scala:237)
[error]         at wvlet.airframe.json.JSONScanner.scanArray(JSONScanner.scala:190)
[error]         at wvlet.airframe.json.JSONScanner.rscan(JSONScanner.scala:235)
[error]         at wvlet.airframe.json.JSONScanner.scanObject(JSONScanner.scala:186)
[error]         at wvlet.airframe.json.JSONScanner.rscan(JSONScanner.scala:237)
```