### PR TITLE
Minimum testcase to reproduce compilation error in toInstance binding

### DIFF
--- a/airframe/src/test/scala/wvlet/airframe/AirframeTest.scala
+++ b/airframe/src/test/scala/wvlet/airframe/AirframeTest.scala
@@ -547,5 +547,15 @@ class AirframeTest extends AirframeSpec {
       }
       warn(caught.getMessage)
     }
+
+    case class ConfigA(param1: Int = 0, param2: Int = 0)
+    case class ConfigB()
+
+    "not cause compilation error" in {
+      val d = newDesign
+        .bind[ConfigA].toInstance(ConfigA(param2 = 1))
+        .bind[ConfigB].toInstance(ConfigB())
+    }
+
   }
 }


### PR DESCRIPTION
This pull request is for showing a minimum testcase to reproduce compilation error in toInstance binding which was reported in #420.