### PR TITLE
Use Scala 2.13.x + JDK11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ matrix:
     - ./sbt ++$SCALA_VERSION "; coverage; ${PROJECT}/test; coverageReport"
     - "./sbt coverageAggregate && bash <(curl -s https://codecov.io/bash)"
   - env: SCALA_VERSION=2.13.0-M5 PROJECT=projectJVM2_13
-    jdk: openjdk8
+    jdk: openjdk11
     # Install fluentd
     install:
     - rvm use 2.2.5 --install --fuzzy

--- a/airframe-codec/.jvm/src/test/scala/wvlet/airframe/codec/JDBCCodecTest.scala
+++ b/airframe-codec/.jvm/src/test/scala/wvlet/airframe/codec/JDBCCodecTest.scala
@@ -181,7 +181,7 @@ class JDBCCodecTest extends AirframeSpec {
   "ResultSet to JSON maps" taggedAs working in {
     withQuery("""with a(id, name) as
                 |(select * from (values (1, 'leo'), (2, 'yui')))
-                |select * from a
+                |select * from a order by id asc
                 |""".stripMargin) { rs =>
       val jsonSeq = JDBCCodec(rs).toJsonSeq.toIndexedSeq
       jsonSeq(0) shouldBe """{"id":1,"name":"leo"}"""

--- a/sbt
+++ b/sbt
@@ -6,11 +6,11 @@
 
 set -o pipefail
 
-declare -r sbt_release_version="0.13.17"
-declare -r sbt_unreleased_version="0.13.17"
+declare -r sbt_release_version="1.2.8"
+declare -r sbt_unreleased_version="1.2.8"
 
-declare -r latest_213="2.13.0-M4"
-declare -r latest_212="2.12.6"
+declare -r latest_213="2.13.0-M5"
+declare -r latest_212="2.12.8"
 declare -r latest_211="2.11.12"
 declare -r latest_210="2.10.7"
 declare -r latest_29="2.9.3"


### PR DESCRIPTION
It seems the community build is failing because of Serialization bug of Scala 2.13 collection library. 
 - Vector is not serializable

This PR is for reproducing that bug, and finding a workaround.