### PR TITLE
Add JSON.parseAny(json)

### DIFF
--- a/airframe-codec/.jvm/src/test/scala/wvlet/airframe/codec/JSONCodecTest.scala
+++ b/airframe-codec/.jvm/src/test/scala/wvlet/airframe/codec/JSONCodecTest.scala
@@ -24,7 +24,7 @@ class JSONCodecTest extends AirframeSpec {
     val b = JSONCodec.toMsgPack(json)
     JSONCodec.unpackMsgPack(b) match {
       case Some(parsedJson) =>
-        JSON.parse(parsedJson) shouldBe JSON.parse(json)
+        JSON.parseAny(parsedJson) shouldBe JSON.parseAny(json)
       case None =>
         fail(s"Failed to ser/de ${json}")
     }
@@ -43,5 +43,14 @@ class JSONCodecTest extends AirframeSpec {
     check("""[1, 2, 3.0, "apple", true, false]""")
     check("{}")
     check("[]")
+  }
+
+  "serialize non-array/object json values" in {
+    check("true")
+    check("null")
+    check("false")
+    check("1")
+    check("1.0e1")
+    check("1.234")
   }
 }

--- a/airframe-codec/src/main/scala/wvlet/airframe/codec/JSONCodec.scala
+++ b/airframe-codec/src/main/scala/wvlet/airframe/codec/JSONCodec.scala
@@ -23,12 +23,12 @@ import wvlet.airframe.msgpack.spi.{MessagePack, Packer, Unpacker}
 object JSONCodec extends MessageCodec[String] {
 
   override def pack(p: Packer, json: String): Unit = {
-    val j = JSON.parse(json)
+    val j = JSON.parseAny(json)
     packJsonValue(p, j)
   }
 
   def toMsgPack(jsonBytes: Array[Byte]): Array[Byte] = {
-    toMsgPack(JSON.parse(jsonBytes))
+    toMsgPack(JSON.parseAny(jsonBytes))
   }
 
   def toMsgPack(jsonValue: JSONValue): Array[Byte] = {

--- a/airframe-json/src/main/scala/wvlet/airframe/json/JSON.scala
+++ b/airframe-json/src/main/scala/wvlet/airframe/json/JSON.scala
@@ -13,6 +13,7 @@
  */
 package wvlet.airframe.json
 
+import wvlet.airframe.json.JSON.JSONValue
 import wvlet.log.LogSupport
 
 /**
@@ -20,20 +21,64 @@ import wvlet.log.LogSupport
   */
 object JSON extends LogSupport {
 
+  /**
+    * Parse JSON object or array
+    */
   def parse(s: String): JSONValue = {
     parse(JSONSource.fromString(s))
   }
+
+  /**
+    * Parse JSON object or array
+    */
   def parse(s: Array[Byte]): JSONValue = {
     parse(JSONSource.fromBytes(s))
   }
+
+  /**
+    * Parse JSON object or array
+    */
   def parse(s: Array[Byte], offset: Int, length: Int): JSONValue = {
     parse(JSONSource.fromBytes(s, offset, length))
   }
+
+  /**
+    * Parse JSON object or array
+    */
   def parse(s: JSONSource): JSONValue = {
     val b = new JSONValueBuilder().singleContext(s, 0)
     JSONScanner.scan(s, b)
     val j = b.result
     j
+  }
+
+  /**
+    * Parse any json values including null
+    */
+  def parseAny(s: Array[Byte]): JSONValue = {
+    parseAny(JSONSource.fromBytes(s))
+  }
+
+  /**
+    * Parse any json values including null
+    */
+  def parseAny(s: String): JSONValue = {
+    parseAny(JSONSource.fromString(s))
+  }
+
+  /**
+    * Parse any json values including null
+    */
+  def parseAny(s: Array[Byte], offset: Int, length: Int): JSONValue = {
+    parseAny(JSONSource.fromBytes(s, offset, length))
+  }
+
+  /**
+    * Parse any json values including null
+    */
+  def parseAny(s: JSONSource): JSONValue = {
+    val b = new JSONValueBuilder().singleContext(s, 0)
+    JSONScanner.scanAny(s, b)
   }
 
   sealed trait JSONValue {

--- a/airframe-json/src/main/scala/wvlet/airframe/json/JSON.scala
+++ b/airframe-json/src/main/scala/wvlet/airframe/json/JSON.scala
@@ -38,25 +38,11 @@ object JSON extends LogSupport {
   /**
     * Parse JSON object or array
     */
-  def parse(s: Array[Byte], offset: Int, length: Int): JSONValue = {
-    parse(JSONSource.fromBytes(s, offset, length))
-  }
-
-  /**
-    * Parse JSON object or array
-    */
   def parse(s: JSONSource): JSONValue = {
     val b = new JSONValueBuilder().singleContext(s, 0)
     JSONScanner.scan(s, b)
     val j = b.result
     j
-  }
-
-  /**
-    * Parse any json values including null
-    */
-  def parseAny(s: Array[Byte]): JSONValue = {
-    parseAny(JSONSource.fromBytes(s))
   }
 
   /**
@@ -69,8 +55,8 @@ object JSON extends LogSupport {
   /**
     * Parse any json values including null
     */
-  def parseAny(s: Array[Byte], offset: Int, length: Int): JSONValue = {
-    parseAny(JSONSource.fromBytes(s, offset, length))
+  def parseAny(s: Array[Byte]): JSONValue = {
+    parseAny(JSONSource.fromBytes(s))
   }
 
   /**

--- a/airframe-json/src/main/scala/wvlet/airframe/json/JSONEventHandler.scala
+++ b/airframe-json/src/main/scala/wvlet/airframe/json/JSONEventHandler.scala
@@ -21,14 +21,18 @@ trait JSONHandler[Expr] {
 
 /**
   * A facade to build json ASTs while scanning json with JSONScanner
+  *
   * @tparam Expr
   */
 trait JSONContext[Expr] extends JSONHandler[Expr] {
   def result: Expr
   def isObjectContext: Boolean
   private[json] final def endScannerState: Int = {
-    if (isObjectContext) JSONScanner.OBJECT_END
-    else JSONScanner.ARRAY_END
+    if (isObjectContext) {
+      JSONScanner.OBJECT_END
+    } else {
+      JSONScanner.ARRAY_END
+    }
   }
 
   def add(v: Expr): Unit

--- a/airframe-json/src/test/scala/wvlet/airframe/json/JSONParserTest.scala
+++ b/airframe-json/src/test/scala/wvlet/airframe/json/JSONParserTest.scala
@@ -14,7 +14,7 @@
 package wvlet.airframe.json
 
 import wvlet.airframe.AirframeSpec
-import wvlet.airframe.json.JSON.JSONValue
+import wvlet.airframe.json.JSON._
 
 /**
   *
@@ -35,6 +35,16 @@ class JSONParserTest extends AirframeSpec {
     "parse large array of objects" in {
       val json = (for (_ <- 0 to 10000) yield "{}").mkString("[", ",", "]")
       parse(json)
+    }
+
+    "parse any json values" in {
+      val v = JSON.parseAny("null")
+      v shouldBe JSONNull
+      JSON.parseAny("1") shouldBe JSONLong(1L)
+      JSON.parseAny("1.23") shouldBe JSONDouble(1.23)
+      JSON.parseAny("[]") shouldBe JSONArray(IndexedSeq.empty)
+      JSON.parseAny("[1, 2]") shouldBe JSONArray(IndexedSeq(JSONLong(1L), JSONLong(2L)))
+      JSON.parseAny("""{"id":1}""") shouldBe JSONObject(Seq("id" -> JSONLong(1L)))
     }
   }
 }

--- a/airframe-json/src/test/scala/wvlet/airframe/json/JSONScannerTest.scala
+++ b/airframe-json/src/test/scala/wvlet/airframe/json/JSONScannerTest.scala
@@ -81,13 +81,13 @@ class JSONScannerTest extends AirframeSpec {
         scan("{")
       }
       intercept[UnexpectedEOF] {
-        scan("""[tru]""") // too small boolean
+        scan("""[tru""") // too small boolean
       }
       intercept[UnexpectedEOF] {
-        scan("""[fa]""") // too small boolean
+        scan("""[fa""") // too small boolean
       }
       intercept[UnexpectedEOF] {
-        scan("""[nul]""") // insufficient null token
+        scan("""[nul""") // insufficient null token
       }
     }
 


### PR DESCRIPTION
Problem:
- Option[X] can be MessagePack Nil value. 
- Nil value can be represented as `null` in JSON
- Trying to parse this value causes a JSON parsing exception, because `null` is not JSON object nor JSON array.
- airframe-http should support returning Option[X] value
- Option[X] is difficult to represent in JSONObject because it's not clear whether the empty JSON object `{}` can be `Some(X(no parameter))` or `None`. 
- So returning JSON `null` should be acceptable for Option[X] type
- MessageCodec should be able to parse null JSON string as Option[X]

Solution:
- Add JSON.parseAny(json value string): JSONValue