### PR TITLE
Remove Sonatype releases resolver

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -65,10 +65,6 @@ val buildSettings = Seq[Setting[_]](
   ),
   developers := List(
     Developer(id = "leo", name = "Taro L. Saito", email = "leo@xerial.org", url = url("http://xerial.org/leo"))
-  ),
-  // Use sonatype resolvers
-  resolvers ++= Seq(
-    Resolver.sonatypeRepo("releases")
   )
 )
 


### PR DESCRIPTION
Sonatype releases repo will redirect the access to Maven central, so we no longer need to use it