### PR TITLE
Remove finatra dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -607,7 +607,7 @@ lazy val finagle =
       // Finagle doesn't support Scala 2.13 yet
       crossScalaVersions := untilScala2_12,
       libraryDependencies ++= Seq(
-        "com.twitter" %% "finatra-http"        % FINAGLE_VERSION,
+        "com.twitter" %% "finagle-http"        % FINAGLE_VERSION,
         "com.twitter" %% "finagle-netty4-http" % FINAGLE_VERSION,
         "com.twitter" %% "finagle-netty4"      % FINAGLE_VERSION,
         "com.twitter" %% "finagle-core"        % FINAGLE_VERSION,


### PR DESCRIPTION
airframe-http doesn't need to depend on finatra-http. We can use finagle-http instead to avoid Guice 4.2.2 version conflict: 
https://github.com/twitter/finatra/pull/491