### PR TITLE
Add trace logs and JMX monitoring to Parallel

### DIFF
--- a/airframe-control/README.md
+++ b/airframe-control/README.md
@@ -86,3 +86,9 @@ val result = source.parallel.withParallelism(4).map { i =>
 }
 ```
 
+You can monitor metrics of parallel execution via JMX using [airframe-jmx](https://github.com/wvlet/airframe/tree/master/airframe-jmx).
+
+```
+JMXAgent.defaultAgent.register[Parallel.ParallelExecutionStats](Parallel.jmxStats)
+```
+

--- a/airframe-control/src/main/scala/wvlet/airframe/control/Parallel.scala
+++ b/airframe-control/src/main/scala/wvlet/airframe/control/Parallel.scala
@@ -37,9 +37,7 @@ object Parallel extends LogSupport {
       @JMX(description = "Accumulated total number of started tasks")
       val startedTasks: AtomicLong = new AtomicLong(0),
       @JMX(description = "Accumulated total number of finished tasks")
-      val finishedTasks: AtomicLong = new AtomicLong(0),
-      @JMX(description = "Accumulated total number of failed tasks")
-      val failedTasks: AtomicLong = new AtomicLong(0)
+      val finishedTasks: AtomicLong = new AtomicLong(0)
   )
 
   private class ResultIterator[R](queue: LinkedBlockingQueue[Option[R]]) extends Iterator[R] {
@@ -250,7 +248,6 @@ object Parallel extends LogSupport {
       } catch {
         case e: Exception =>
           warn(s"$executionId - Error worker-$workerId", e)
-          jmxStats.failedTasks.incrementAndGet()
           throw e
       } finally {
         requestQueue.put(this)
@@ -281,7 +278,6 @@ object Parallel extends LogSupport {
       } catch {
         case e: Exception =>
           warn(s"$executionId - Error worker-$workerId", e)
-          jmxStats.failedTasks.incrementAndGet()
           throw e
       } finally {
         requestQueue.put(this)

--- a/airframe-control/src/main/scala/wvlet/airframe/control/Parallel.scala
+++ b/airframe-control/src/main/scala/wvlet/airframe/control/Parallel.scala
@@ -43,7 +43,7 @@ object Parallel extends LogSupport {
     def fetchedElements: Long = counter.longValue()
     @JMX(description = "Number of remaining elements")
     def remainingElements: String = {
-      if(totalElements == "unknown"){
+      if (totalElements == "unknown") {
         "unknown"
       } else {
         (totalElements.toLong - counter.longValue()).toString
@@ -88,7 +88,7 @@ object Parallel extends LogSupport {
     }
 
     val executor = Executors.newFixedThreadPool(parallelism)
-    val counter = new AtomicLong(0)
+    val counter  = new AtomicLong(0)
 
     val stats = new ParallelExecutionStats(executionId, parallelism, source.size.toString, requestQueue, counter)
     JMXAgent.defaultAgent.register(s"wvlet.airframe.control.Parallel:name=$executionId", stats)
@@ -152,7 +152,7 @@ object Parallel extends LogSupport {
     new Thread {
       override def run(): Unit = {
         val executor = Executors.newFixedThreadPool(parallelism)
-        val counter = new AtomicLong(0)
+        val counter  = new AtomicLong(0)
 
         val stats = new ParallelExecutionStats(executionId, parallelism, "unknown", requestQueue, counter)
         JMXAgent.defaultAgent.register(s"wvlet.airframe.control.Parallel:name=$executionId", stats)
@@ -253,7 +253,8 @@ object Parallel extends LogSupport {
                                       requestQueue: BlockingQueue[Worker[T, R]],
                                       resultQueue: BlockingQueue[Option[R]],
                                       f: T => R)
-      extends Runnable with LogSupport {
+      extends Runnable
+      with LogSupport {
 
     val message: AtomicReference[T] = new AtomicReference[T]()
 
@@ -277,7 +278,8 @@ object Parallel extends LogSupport {
                                              requestQueue: BlockingQueue[IndexedWorker[T, R]],
                                              resultArray: Array[R],
                                              f: T => R)
-      extends Runnable with LogSupport {
+      extends Runnable
+      with LogSupport {
 
     val message: AtomicReference[(T, Int)] = new AtomicReference[(T, Int)]()
 

--- a/airframe-control/src/main/scala/wvlet/airframe/control/Parallel.scala
+++ b/airframe-control/src/main/scala/wvlet/airframe/control/Parallel.scala
@@ -28,19 +28,27 @@ import scala.reflect.ClassTag
 object Parallel extends LogSupport {
 
   class ParallelExecutionStats(
-      @JMX
+      @JMX(description = "Identity of the execution")
       val executionId: String,
-      @JMX
+      @JMX(description = "Number of worker threads used for the execution")
       val parallelism: Int,
-      @JMX
-      val total: String,
+      @JMX(description = "Number of total elements")
+      val totalElements: String,
       requestQueue: LinkedBlockingQueue[_],
       counter: AtomicLong
   ) {
-    @JMX
+    @JMX(description = "Number of running workers for the execution right now")
     def runningWorkers: Int = parallelism - requestQueue.size()
-    @JMX
-    def count: Long = counter.longValue()
+    @JMX(description = "Number of fetched elements")
+    def fetchedElements: Long = counter.longValue()
+    @JMX(description = "Number of remaining elements")
+    def remainingElements: String = {
+      if(totalElements == "unknown"){
+        "unknown"
+      } else {
+        (totalElements.toLong - counter.longValue()).toString
+      }
+    }
   }
 
   private class ResultIterator[R](queue: LinkedBlockingQueue[Option[R]]) extends Iterator[R] {

--- a/airframe-control/src/main/scala/wvlet/airframe/control/Parallel.scala
+++ b/airframe-control/src/main/scala/wvlet/airframe/control/Parallel.scala
@@ -65,7 +65,7 @@ object Parallel extends LogSupport {
     * @param f Function which processes each element of the source collection
     * @return Collection of the results
     */
-  def run[T, R: ClassTag](source: Seq[T], parallelism: Int = Runtime.getRuntime.availableProcessors(), jmxAgent: Option[JMXAgent] = None)(
+  def run[T, R: ClassTag](source: Seq[T], parallelism: Int = Runtime.getRuntime.availableProcessors())(
       f: T => R): Seq[R] = {
 
     val executionId = UUID.randomUUID.toString
@@ -82,10 +82,8 @@ object Parallel extends LogSupport {
     val executor = Executors.newFixedThreadPool(parallelism)
     val counter = new AtomicLong(0)
 
-    jmxAgent.foreach { jmxAgent =>
-      val stats = new ParallelExecutionStats(executionId, parallelism, source.size.toString, requestQueue, counter)
-      jmxAgent.register(s"wvlet.airframe.control.Parallel:name=$executionId", stats)
-    }
+    val stats = new ParallelExecutionStats(executionId, parallelism, source.size.toString, requestQueue, counter)
+    JMXAgent.defaultAgent.register(s"wvlet.airframe.control.Parallel:name=$executionId", stats)
 
     try {
       // Process all elements of source
@@ -115,7 +113,7 @@ object Parallel extends LogSupport {
       // Cleanup
       executor.shutdown()
       requestQueue.clear()
-      jmxAgent.foreach(_.unregister(s"wvlet.airframe.control.Parallel:name=$executionId"))
+      JMXAgent.defaultAgent.unregister(s"wvlet.airframe.control.Parallel:name=$executionId")
     }
   }
 
@@ -148,10 +146,8 @@ object Parallel extends LogSupport {
         val executor = Executors.newFixedThreadPool(parallelism)
         val counter = new AtomicLong(0)
 
-        jmxAgent.foreach { jmxAgent =>
-          val stats = new ParallelExecutionStats(executionId, parallelism, "unknown", requestQueue, counter)
-          jmxAgent.register(s"wvlet.airframe.control.Parallel:name=$executionId", stats)
-        }
+        val stats = new ParallelExecutionStats(executionId, parallelism, "unknown", requestQueue, counter)
+        JMXAgent.defaultAgent.register(s"wvlet.airframe.control.Parallel:name=$executionId", stats)
 
         try {
           // Process all elements of source
@@ -181,7 +177,7 @@ object Parallel extends LogSupport {
           // Cleanup
           executor.shutdown()
           requestQueue.clear()
-          jmxAgent.foreach(_.unregister(s"wvlet.airframe.control.Parallel:name=$executionId"))
+          JMXAgent.defaultAgent.unregister(s"wvlet.airframe.control.Parallel:name=$executionId")
         }
       }
     }.start()

--- a/build.sbt
+++ b/build.sbt
@@ -416,7 +416,7 @@ lazy val control =
         "org.scala-lang.modules" %% "scala-parser-combinators" % SCALA_PARSER_COMBINATOR_VERSION
       )
     )
-    .dependsOn(logJVM, airframeSpecJVM % "test")
+    .dependsOn(logJVM, jmx, airframeSpecJVM % "test")
 
 lazy val jmx =
   project


### PR DESCRIPTION
Even though #473 has been reported, I haven't find any problems in `Parallel` implementation yet. To find problem easily I would like to add trace log and JMX monitoring to `Parallel`.