### PR TITLE
Remove Scala 2.11 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,11 +54,6 @@ matrix:
       before_script: psql -c 'create database travis_ci_test;' -U postgres
       # Exclude design serialization tests due to bug https://github.com/scala/bug/issues/11192
       script: ./sbt ++$SCALA_VERSION "${PROJECT}/testOnly * -- -l serde"
-    - env: SCALA_VERSION=2.11.12 PROJECT=projectJVM
-      jdk: openjdk8
-      services: postgresql
-      before_script: psql -c 'create database travis_ci_test;' -U postgres
-      script: ./sbt ++$SCALA_VERSION ${PROJECT}/test
     - env: SCALA_VERSION=2.12.8 PROJECT=projectJS
       jdk: openjdk8
       script: ./sbt ++$SCALA_VERSION ${PROJECT}/test

--- a/build.sbt
+++ b/build.sbt
@@ -2,9 +2,8 @@ import sbtcrossproject.{CrossType, crossProject}
 
 val SCALA_2_12 = "2.12.8"
 val SCALA_2_13 = "2.13.0-RC1"
-val SCALA_2_11 = "2.11.12"
 
-val untilScala2_12      = SCALA_2_12 :: SCALA_2_11 :: Nil
+val untilScala2_12      = SCALA_2_12 :: Nil
 val targetScalaVersions = SCALA_2_13 :: untilScala2_12
 
 val SCALATEST_VERSION               = "3.0.8-RC2"
@@ -436,8 +435,6 @@ lazy val launcher =
     .settings(
       name := "airframe-launcher",
       description := "Command-line program launcher",
-      // https://github.com/scala/scala-parser-combinators/issues/197
-      fork in Test := scalaVersion.value.startsWith("2.11."),
       libraryDependencies ++= Seq(
         "org.scala-lang.modules" %% "scala-parser-combinators" % SCALA_PARSER_COMBINATOR_VERSION
       )
@@ -735,8 +732,6 @@ lazy val sql =
       antlr4PackageName in Antlr4 := Some("wvlet.airframe.sql.parser"),
       antlr4GenListener in Antlr4 := true,
       antlr4GenVisitor in Antlr4 := true,
-      // https://github.com/scala/scala-parser-combinators/issues/197
-      fork in Test := scalaVersion.value.startsWith("2.11."),
       libraryDependencies ++= Seq(
         // For parsing DataType strings
         "org.scala-lang.modules" %% "scala-parser-combinators" % SCALA_PARSER_COMBINATOR_VERSION,


### PR DESCRIPTION
The only reason Airframe supports Scala 2.11 was Spark. Since Spark 2.4.2, it is built against Scala 2.12 by default, so we no longer need to maintain Scala 2.11 build.