### PR TITLE
Build for Scala 2.11 only at mater branch commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,13 @@ matrix:
       services: postgresql
       before_script: psql -c 'create database travis_ci_test;' -U postgres
       script: ./sbt ++$SCALA_VERSION ${PROJECT}/test
+    - env: SCALA_VERSION=2.11.12 PROJECT=projectJVM
+      # Build Scala 2.11 support only for master and releases	
+      if: (branch = master OR tag IS present) AND type != pull_request
+      jdk: openjdk8
+      services: postgresql
+      before_script: psql -c 'create database travis_ci_test;' -U postgres
+      script: ./sbt ++$SCALA_VERSION ${PROJECT}/test
 
 env:
   global:

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,10 @@
 import sbtcrossproject.{CrossType, crossProject}
 
+val SCALA_2_11 = "2.11.12"
 val SCALA_2_12 = "2.12.8"
 val SCALA_2_13 = "2.13.0-RC1"
 
-val untilScala2_12      = SCALA_2_12 :: Nil
+val untilScala2_12      = SCALA_2_12 :: SCALA_2_11 :: Nil
 val targetScalaVersions = SCALA_2_13 :: untilScala2_12
 
 val SCALATEST_VERSION               = "3.0.8-RC2"


### PR DESCRIPTION
Spark 2.4.x is rolled back to Scala 2.11 because there are many Spark users who still need time to migrate to Scala 2.12. 

This PR will recover Scala 2.11 build only for master branch commits.