### PR TITLE
Add convenient methods to convert JSON <-> Scala object

### DIFF
--- a/airframe-codec/.jvm/src/test/scala/wvlet/airframe/codec/MessageCodecTest.scala
+++ b/airframe-codec/.jvm/src/test/scala/wvlet/airframe/codec/MessageCodecTest.scala
@@ -14,6 +14,7 @@
 package wvlet.airframe.codec
 
 import wvlet.airframe.AirframeSpec
+import wvlet.airframe.codec.MessageCodecTest.ExtractTest
 import wvlet.airframe.codec.PrimitiveCodec.LongCodec
 
 /**
@@ -50,6 +51,21 @@ class MessageCodecTest extends AirframeSpec {
       val codec = MessageCodec.of[Seq[String]]
       codec.unpackMsgPack(Array.emptyByteArray)
     }
+
+    "convert JSON to Scala object" in {
+      val obj = MessageCodec.fromJson[ExtractTest](
+        """{"id":1, "name":"leo", "flag":true, "number":0.01, "arr":[0, 1, 2], "nil":null}""")
+      assert(obj == ExtractTest(1, "leo", true, 0.01, Seq(0, 1, 2), ""))
+    }
+
+    "convert Scala object to JSON" in {
+      val json = MessageCodec.toJson(ExtractTest(1, "leo", true, 0.01, Seq(0, 1, 2), null))
+      assert(json == """{"id":1,"name":"leo","flag":true,"number":0.01,"arr":[0,1,2],"nil":null}""")
+    }
   }
 
+}
+
+object MessageCodecTest {
+  case class ExtractTest(id: Int, name: String, flag: Boolean, number: Double, arr: Seq[Int], nil: String)
 }

--- a/airframe-codec/src/main/scala/wvlet/airframe/codec/MessageCodec.scala
+++ b/airframe-codec/src/main/scala/wvlet/airframe/codec/MessageCodec.scala
@@ -20,6 +20,7 @@ import wvlet.log.LogSupport
 
 import scala.language.experimental.macros
 import scala.util.{Failure, Success, Try}
+import scala.reflect.runtime.universe._
 
 trait MessageCodec[A] extends LogSupport {
 
@@ -134,4 +135,12 @@ trait MessageValueCodec[A] extends MessageCodec[A] {
 object MessageCodec {
   def of[A]: MessageCodec[A] = macro CodecMacros.codecOf[A]
   def ofSurface(s: Surface): MessageCodec[_] = MessageCodecFactory.defaultFactory.ofSurface(s)
+
+  def fromJson[T: TypeTag](json: String): T = {
+    ofSurface(Surface.of[T]).asInstanceOf[MessageCodec[T]].unpackJson(json).get
+  }
+
+  def toJson[T: TypeTag](obj: T): String = {
+    ofSurface(Surface.of[T]).asInstanceOf[MessageCodec[T]].toJson(obj)
+  }
 }


### PR DESCRIPTION
Add convenient methods for JSON conversion to `JSONCodec`.

At first, I thought to add these methods to `aiframe-json`. However, since `airframe-codec` depends on `airframe-json`, adding these methods to `airframe-json` side causes a cyclic dependency between `airframe-json` and `airframe-codec`. So I decided to add these methods to `airframe-codec` side.

Do you have a better idea?