### PR TITLE
control: Add Retry.retryable/nonRetryableFailure method

### DIFF
--- a/airframe-control/README.md
+++ b/airframe-control/README.md
@@ -36,19 +36,20 @@ Control.withResources(
 
 ```scala
 import wvlet.airframe.control.Retry
+import java.util.concurrent.TimeoutException
 
 // Backoff retry
 val r: String =
   Retry
     .withBackOff(maxRetry = 3)
-    .retryOn { s: RetryContext[_] =>
-      warn(s"[${s.retryCount}/${s.maxRetry}] ${s.lastError.getMessage}. Retrying in ${s.nextWaitMillis} millis")
+    .retryOn { 
+       case e: TimeoutException => Retry.retryableFailure(e)
     }
     .run {
       logger.info("hello retry")
       if (count < 2) {
         count += 1
-        throw new IllegalStateException("retry test")
+        throw new TimeoutException("retry test")
       } else {
         "success"
       }

--- a/airframe-control/src/main/scala/wvlet/airframe/control/ResultClass.scala
+++ b/airframe-control/src/main/scala/wvlet/airframe/control/ResultClass.scala
@@ -30,8 +30,8 @@ object ResultClass {
     */
   case class Failed(isRetryable: Boolean, cause: Throwable) extends ResultClass
 
-  def retryableFailure(e: Throwable)    = Failed(isRetryable = true, e)
-  def nonRetryableFailure(e: Throwable) = Failed(isRetryable = false, e)
+  def retryableFailure(e: Throwable)    = Retry.retryableFailure(e)
+  def nonRetryableFailure(e: Throwable) = Retry.nonRetryableFailure(e)
 
   val ALWAYS_SUCCEED: Any => ResultClass = { x: Any =>
     Succeeded

--- a/airframe-control/src/main/scala/wvlet/airframe/control/Retry.scala
+++ b/airframe-control/src/main/scala/wvlet/airframe/control/Retry.scala
@@ -24,6 +24,9 @@ import scala.util.{Failure, Random, Success, Try}
   */
 object Retry extends LogSupport {
 
+  def retryableFailure(e: Throwable)    = Failed(isRetryable = true, e)
+  def nonRetryableFailure(e: Throwable) = Failed(isRetryable = false, e)
+
   def withBackOff(maxRetry: Int = 3,
                   initialIntervalMillis: Int = 100,
                   maxIntervalMillis: Int = 15000,

--- a/examples/src/main/scala/wvlet/airframe/examples/control/Control_02_Jitter.scala
+++ b/examples/src/main/scala/wvlet/airframe/examples/control/Control_02_Jitter.scala
@@ -19,7 +19,7 @@ import scala.concurrent.TimeoutException
   * Adding randomness to the retry interval of exponential backoff is good to spread out
   * retry interval timings. See also https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
   */
-class Control_02_Jitter {
+object Control_02_Jitter {
 
   import wvlet.airframe.control.Retry
 

--- a/examples/src/main/scala/wvlet/airframe/examples/control/Control_02_Jitter.scala
+++ b/examples/src/main/scala/wvlet/airframe/examples/control/Control_02_Jitter.scala
@@ -16,14 +16,15 @@ package wvlet.airframe.examples.control
 import scala.concurrent.TimeoutException
 
 /**
-  *
+  * Adding randomness to the retry interval of exponential backoff is good to spread out
+  * retry interval timings. See also https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
   */
-object Control_01_Retry extends App {
+class Control_02_Jitter {
 
   import wvlet.airframe.control.Retry
 
   Retry
-    .withBackOff(maxRetry = 3)
+    .withJitter(maxRetry = 3) // It will wait nextWaitMillis * rand() upon retry
     .retryOn {
       case e: TimeoutException =>
         Retry.retryableFailure(e)

--- a/examples/src/main/scala/wvlet/airframe/examples/control/Control_03_CustomRetry.scala
+++ b/examples/src/main/scala/wvlet/airframe/examples/control/Control_03_CustomRetry.scala
@@ -13,23 +13,32 @@
  */
 package wvlet.airframe.examples.control
 
-import scala.concurrent.TimeoutException
+import java.util.concurrent.TimeoutException
+
+import wvlet.airframe.control.Retry
+import wvlet.log.LogSupport
 
 /**
   *
   */
-object Control_01_Retry extends App {
+class Control_03_CustomRetry extends LogSupport {
 
-  import wvlet.airframe.control.Retry
+  val withRetry =
+    Retry
+      .withJitter()
+      .retryOn {
+        case e: IllegalArgumentException =>
+          Retry.nonRetryableFailure(e)
+        case e: TimeoutException =>
+          Retry.retryableFailure(e)
+      }
 
-  Retry
-    .withBackOff(maxRetry = 3)
-    .retryOn {
-      case e: TimeoutException =>
-        Retry.retryableFailure(e)
-    }
-    .run {
-      // body
-    }
+  withRetry.run {
+    debug("Hello Retry!")
+  }
+
+  withRetry.run {
+    debug("Retryer can be reused for other runs")
+  }
 
 }

--- a/examples/src/main/scala/wvlet/airframe/examples/control/Control_03_CustomRetry.scala
+++ b/examples/src/main/scala/wvlet/airframe/examples/control/Control_03_CustomRetry.scala
@@ -21,7 +21,7 @@ import wvlet.log.LogSupport
 /**
   *
   */
-class Control_03_CustomRetry extends LogSupport {
+object Control_03_CustomRetry extends LogSupport {
 
   val withRetry =
     Retry


### PR DESCRIPTION
Add convenient methods to Retry, instead of moving to ResultClass.retryableFailure method
#522 
