### PR TITLE
Fix usage of symbol

### DIFF
--- a/airframe-config/src/test/scala/wvlet/airframe/config/ConfigTest.scala
+++ b/airframe-config/src/test/scala/wvlet/airframe/config/ConfigTest.scala
@@ -265,7 +265,7 @@ class ConfigTest extends AirframeSpec {
           unused = Some(p)
         })
 
-      unused shouldBe 'defined
+      unused shouldBe Symbol("defined")
       unused.get.size shouldBe 1
       unused.get.keySet should contain("sample@appscope.message")
     }

--- a/airframe-config/src/test/scala/wvlet/airframe/config/ConfigTest.scala
+++ b/airframe-config/src/test/scala/wvlet/airframe/config/ConfigTest.scala
@@ -265,7 +265,7 @@ class ConfigTest extends AirframeSpec {
           unused = Some(p)
         })
 
-      unused shouldBe Symbol("defined")
+      unused shouldBe defined
       unused.get.size shouldBe 1
       unused.get.keySet should contain("sample@appscope.message")
     }

--- a/airframe-log/jvm/src/test/scala/wvlet/log/io/IOUtilTest.scala
+++ b/airframe-log/jvm/src/test/scala/wvlet/log/io/IOUtilTest.scala
@@ -30,11 +30,11 @@ class IOUtilTest extends Spec {
 
     "find a file" in {
       val buildSbt = IOUtil.findPath("build.sbt")
-      buildSbt shouldBe 'defined
+      buildSbt shouldBe Symbol("defined")
       buildSbt.get.getPath shouldBe "build.sbt"
 
       val notFound = IOUtil.findPath("non-existing-file-path.xxxxxxx")
-      notFound shouldBe 'empty
+      notFound shouldBe Symbol("empty")
     }
 
     "read file as a String" in {

--- a/airframe-log/jvm/src/test/scala/wvlet/log/io/IOUtilTest.scala
+++ b/airframe-log/jvm/src/test/scala/wvlet/log/io/IOUtilTest.scala
@@ -30,11 +30,11 @@ class IOUtilTest extends Spec {
 
     "find a file" in {
       val buildSbt = IOUtil.findPath("build.sbt")
-      buildSbt shouldBe Symbol("defined")
+      buildSbt shouldBe defined
       buildSbt.get.getPath shouldBe "build.sbt"
 
       val notFound = IOUtil.findPath("non-existing-file-path.xxxxxxx")
-      notFound shouldBe Symbol("empty")
+      notFound shouldBe empty
     }
 
     "read file as a String" in {


### PR DESCRIPTION
#517 
Fix symbol `'xxx` to `Symbol("xxx")`.