### PR TITLE
remove unused string interpolations

### DIFF
--- a/airframe-codec/src/main/scala/wvlet/airframe/codec/JSONCodec.scala
+++ b/airframe-codec/src/main/scala/wvlet/airframe/codec/JSONCodec.scala
@@ -72,7 +72,7 @@ object JSONCodec extends MessageCodec[String] {
 
   def toJson(msgpack: Array[Byte]): String = {
     unpackBytes(msgpack).getOrElse {
-      throw new IllegalArgumentException(s"Failed to read as json")
+      throw new IllegalArgumentException("Failed to read as json")
     }
   }
 }

--- a/airframe-fluentd/src/main/scala/wvlet/airframe/fluentd/FluentdLogger.scala
+++ b/airframe-fluentd/src/main/scala/wvlet/airframe/fluentd/FluentdLogger.scala
@@ -22,7 +22,7 @@ class FluentdLogger(val tagPrefix: Option[String] = None, useExtendedEventTime: 
     extends MetricLogger
     with LogSupport {
 
-  debug(s"Starting Fluency")
+  debug("Starting Fluency")
 
   override def withTagPrefix(newTagPrefix: String): FluentdLogger = {
     new FluentdLogger(Some(newTagPrefix), useExtendedEventTime, fluency)
@@ -30,7 +30,7 @@ class FluentdLogger(val tagPrefix: Option[String] = None, useExtendedEventTime: 
 
   @PreDestroy
   def close(): Unit = {
-    debug(s"Stopping Fluency")
+    debug("Stopping Fluency")
     fluency.flush()
     fluency.close()
   }

--- a/airframe-fluentd/src/main/scala/wvlet/airframe/fluentd/MetricLogger.scala
+++ b/airframe-fluentd/src/main/scala/wvlet/airframe/fluentd/MetricLogger.scala
@@ -80,7 +80,7 @@ class MetricLoggerFactory(fluentdClient: MetricLogger) extends LogSupport {
 
   @PreDestroy
   def shutdown: Unit = {
-    debug(s"Closing MetricLoggerFactory")
+    debug("Closing MetricLoggerFactory")
     fluentdClient.close()
   }
 }

--- a/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/FinagleClientTest.scala
+++ b/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/FinagleClientTest.scala
@@ -107,7 +107,7 @@ class FinagleClientTest extends AirframeSpec {
           server.localAddress,
           config = FinagleClientConfig(
             retry = FinagleClient.defaultRetry.withMaxRetry(3).withBackOff(initialIntervalMillis = 1)))) { client =>
-        warn(s"Starting http client failure tests")
+        warn("Starting http client failure tests")
 
         {
           // Test max retry failure

--- a/airframe-http-recorder/src/main/scala/wvlet/airframe/http/recorder/HttpRecorder.scala
+++ b/airframe-http-recorder/src/main/scala/wvlet/airframe/http/recorder/HttpRecorder.scala
@@ -73,7 +73,7 @@ object HttpRecorder extends LogSupport {
     val destClient =
       ClientBuilder()
         .stack(Http.client)
-        .name(s"airframe-http-recorder-proxy")
+        .name("airframe-http-recorder-proxy")
         .dest(recorderConfig.destAddress.hostAndPort)
         .tls(SSLContext.getDefault)
         .noFailureAccrual

--- a/airframe-http/src/test/scala/wvlet/airframe/http/RouterTest.scala
+++ b/airframe-http/src/test/scala/wvlet/airframe/http/RouterTest.scala
@@ -117,7 +117,7 @@ class RouterTest extends AirframeSpec {
 
   "find ambiguous path patterns" in {
     val r = Router.add[AmbiguousPathExample]
-    warn(s"Ambiguous HTTP path pattern test")
+    warn("Ambiguous HTTP path pattern test")
     val ex = intercept[Throwable] {
       r.findRoute(SimpleHttpRequest(HttpMethod.GET, "/v1"))
     }

--- a/airframe-jmx/src/main/scala/wvlet/airframe/jmx/JMXMBean.scala
+++ b/airframe-jmx/src/main/scala/wvlet/airframe/jmx/JMXMBean.scala
@@ -64,7 +64,7 @@ case class JMXMBean(obj: AnyRef, mBeanInfo: MBeanInfo, attributes: Seq[MBeanPara
 //    }
   }
   override def invoke(actionName: String, params: Array[AnyRef], signature: Array[String]): AnyRef = {
-    throw new UnsupportedOperationException(s"JMXMBean.invoke is not supported")
+    throw new UnsupportedOperationException("JMXMBean.invoke is not supported")
   }
 }
 

--- a/airframe-json/src/test/scala/wvlet/airframe/json/JSONScannerTest.scala
+++ b/airframe-json/src/test/scala/wvlet/airframe/json/JSONScannerTest.scala
@@ -42,7 +42,7 @@ class JSONScannerTest extends AirframeSpec {
       scan("[true, false, null]")
       scan("""{"elem":[0, 1], "data":{"id":"0x0x", "val":0.1234}}""")
 
-      scan(s"""["\\u0fA9\\u0123", "\\u0123"]""")
+      scan("""["\\u0fA9\\u0123", "\\u0123"]""")
     }
 
     "throw unexpected error" in {

--- a/airframe-launcher/src/test/scala/wvlet/airframe/launcher/LauncherTest.scala
+++ b/airframe-launcher/src/test/scala/wvlet/airframe/launcher/LauncherTest.scala
@@ -315,7 +315,7 @@ object LauncherTest {
 
     @command(description = "exception test")
     def errorTest: Unit = {
-      throw new IllegalArgumentException(s"error test")
+      throw new IllegalArgumentException("error test")
     }
   }
 

--- a/airframe-log/shared/src/test/scala/wvlet/log/WvletLog.scala
+++ b/airframe-log/shared/src/test/scala/wvlet/log/WvletLog.scala
@@ -38,18 +38,18 @@ class WvletLog extends Spec with LogSupport {
       logger.setLogLevel(LogLevel.ALL)
 
       info("Hello wvlet-log!")
-      debug(s"wvlet-log adds fancy logging to your Scala applications.")
+      debug("wvlet-log adds fancy logging to your Scala applications.")
       trace("You can see the source code location here ==>")
       error("That makes easy to track your application behavior")
       logger.setFormatter(IntelliJLogFormatter)
-      warn(s"And also, customizing log format is easy")
+      warn("And also, customizing log format is easy")
       info("This is the log format suited to IntelliJ IDEA")
       debug("This format adds links to the source code ->")
       logger.setFormatter(SourceCodeLogFormatter)
-      info(s"wvlet-log uses Scala macro to output log messages only when necessary")
+      info("wvlet-log uses Scala macro to output log messages only when necessary")
       error("And also it can show the stack trace", new Exception("Test message"))
-      info(s"Usage is simple")
-      warn(s"Just add wvlet.log.LogSupport trait to your application")
+      info("Usage is simple")
+      warn("Just add wvlet.log.LogSupport trait to your application")
     }
 
     "show log format examples" in {

--- a/airframe-msgpack-benchmark/src/main/scala/wvlet/airframe/benchmark/msgpack/MsgpackBenchmarkMain.scala
+++ b/airframe-msgpack-benchmark/src/main/scala/wvlet/airframe/benchmark/msgpack/MsgpackBenchmarkMain.scala
@@ -66,7 +66,7 @@ class MsgpackBenchmarkMain(
             warmupIteration: Int = 5,
             @option(prefix = "-f,--fork-count", description = "Fork Count (default: 5)")
             forkCount: Int = 5): Unit = {
-    info(s"Starting the benchmark")
+    info("Starting the benchmark")
     var opt = new OptionsBuilder()
       .forks(forkCount)
       .measurementIterations(iteration)

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/SQLAnonymizer.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/SQLAnonymizer.scala
@@ -54,7 +54,7 @@ object SQLAnonymizer extends LogSupport {
   }
 
   def buildAnonymizationDictionary(sql: Seq[String]): Map[Expression, Expression] = {
-    debug(s"Building a token dictionary")
+    debug("Building a token dictionary")
     val b = new DictBuilder()
     sql.foreach { x =>
       try {
@@ -73,7 +73,7 @@ object SQLAnonymizer extends LogSupport {
     val identifierTable    = new SymbolTable("i")
     var stringLiteralTable = new SymbolTable("s")
     var longLiteralTable   = new SymbolTable("l")
-    var qnameTable         = new SymbolTable(s"t")
+    var qnameTable         = new SymbolTable("t")
 
     def build = m.result()
 

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLInterpreter.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLInterpreter.scala
@@ -218,7 +218,7 @@ class SQLInterpreter extends SqlBaseBaseVisitor[Any] with LogSupport {
         val gb = ctx.groupBy()
         assert(gb != null)
         if (inputRelation == EmptyRelation) {
-          throw new IllegalArgumentException(s"group by statement requires input relation")
+          throw new IllegalArgumentException("group by statement requires input relation")
         }
 
         // group by

--- a/airframe/src/main/scala/wvlet/airframe/LifeCycleManager.scala
+++ b/airframe/src/main/scala/wvlet/airframe/LifeCycleManager.scala
@@ -57,7 +57,7 @@ class LifeCycleManager(private[airframe] val eventHandler: LifeCycleEventHandler
 
   def start: Unit = {
     if (!state.compareAndSet(INIT, STARTING)) {
-      throw new IllegalStateException(s"LifeCycle is already starting")
+      throw new IllegalStateException("LifeCycle is already starting")
     }
 
     tracer.onSessionStart(session)

--- a/airframe/src/test/scala/wvlet/airframe/AirframeTest.scala
+++ b/airframe/src/test/scala/wvlet/airframe/AirframeTest.scala
@@ -190,7 +190,7 @@ object ServiceMixinExample {
   }
 
   trait NonAbstractModule extends LogSupport {
-    info(s"This should be built")
+    info("This should be built")
   }
 
   object SingletonOfNonAbstractModules extends NonAbstractModule {
@@ -325,7 +325,7 @@ class AirframeTest extends AirframeSpec {
     }
 
     "forbid binding to the same type" in {
-      warn(s"Running cyclic dependency check test")
+      warn("Running cyclic dependency check test")
       val ex = intercept[CYCLIC_DEPENDENCY] {
         val d = newDesign
           .bind[Printer].to[Printer]
@@ -352,7 +352,7 @@ class AirframeTest extends AirframeSpec {
       // This will be shown as compilation error in Surface
       pending
 //      val c = newDesign.newSession
-//      warn(s"Running cyclic dependency test: A->B->A")
+//      warn("Running cyclic dependency test: A->B->A")
 //
 //      val caught = intercept[CYCLIC_DEPENDENCY] {
 //        c.build[HasCycle]
@@ -364,7 +364,7 @@ class AirframeTest extends AirframeSpec {
 
     "detect missing dependencies" in {
       val d = newDesign
-      warn(s"Running missing dependency check")
+      warn("Running missing dependency check")
       val caught = intercept[MISSING_DEPENDENCY] {
         d.newSession.build[MissingDep]
       }

--- a/examples/src/main/scala/wvlet/airframe/examples/di/DI_07_JSR250Annotation.scala
+++ b/examples/src/main/scala/wvlet/airframe/examples/di/DI_07_JSR250Annotation.scala
@@ -26,12 +26,12 @@ object DI_07_JSR250Annotation extends App {
   trait MyService extends LogSupport {
     @PostConstruct
     def start = {
-      info(s"starting the service")
+      info("starting the service")
     }
 
     @PreDestroy
     def stop = {
-      info(s"stopping the service")
+      info("stopping the service")
     }
   }
 

--- a/examples/src/main/scala/wvlet/airframe/examples/di/DI_11_ProductionMode.scala
+++ b/examples/src/main/scala/wvlet/airframe/examples/di/DI_11_ProductionMode.scala
@@ -35,12 +35,12 @@ object DI_11_ProductionMode extends App with LogSupport {
   val d = newSilentDesign
     .bind[MyService].toSingleton // To eagerly initialize the service, you must bind it to the design
 
-  info(s"Production mode")
+  info("Production mode")
   d.withProductionMode.build[MyApp] { app =>
     // MyService is already initialized
   }
 
-  info(s"Lazy mode")
+  info("Lazy mode")
   d.build[MyApp] { app =>
     // MyService will not be initialized here
   }

--- a/examples/src/main/scala/wvlet/airframe/examples/di/DI_12_ReusingService.scala
+++ b/examples/src/main/scala/wvlet/airframe/examples/di/DI_12_ReusingService.scala
@@ -31,7 +31,7 @@ object DI_12_ReusingService extends App {
   trait DB extends LogSupport {
     def query(sql: String) = {}
     def connect: Unit = {
-      info(s"connected")
+      info("connected")
     }
     def close(): Unit = {
       info("closed")
@@ -40,7 +40,7 @@ object DI_12_ReusingService extends App {
   trait HttpClient extends LogSupport {
     def send(request: String) = {}
     def connect: Unit = {
-      info(s"connected")
+      info("connected")
     }
     def close(): Unit = {
       info("closed")

--- a/examples/src/main/scala/wvlet/airframe/examples/di/DI_20_BindSession.scala
+++ b/examples/src/main/scala/wvlet/airframe/examples/di/DI_20_BindSession.scala
@@ -26,7 +26,7 @@ object DI_20_BindSession extends App {
     private val session = bind[Session]
 
     def shutdown = {
-      warn(s"shutdown is called")
+      warn("shutdown is called")
       session.shutdown
     }
   }


### PR DESCRIPTION
- Master Branch v19.6 (https://github.com/wvlet/airframe/commit/61a0316e9d3bf07d3d71bc36fbd1ec70332d1fb1) 
 
```
grep -r "(s\"" * .scala |  grep -v "\$."  

grep: .scala: No such file or directory
airframe/src/test/scala/wvlet/airframe/AirframeTest.scala:    info(s"This should be built")
airframe/src/test/scala/wvlet/airframe/AirframeTest.scala:      warn(s"Running cyclic dependency check test")
airframe/src/test/scala/wvlet/airframe/AirframeTest.scala://      warn(s"Running cyclic dependency test: A->B->A")
airframe/src/test/scala/wvlet/airframe/AirframeTest.scala:      warn(s"Running missing dependency check")
airframe/src/main/scala/wvlet/airframe/LifeCycleManager.scala:      throw new IllegalStateException(s"LifeCycle is already starting")
airframe-codec/src/main/scala/wvlet/airframe/codec/JSONCodec.scala:      throw new IllegalArgumentException(s"Failed to read as json")
airframe-fluentd/src/main/scala/wvlet/airframe/fluentd/MetricLogger.scala:    debug(s"Closing MetricLoggerFactory")
airframe-fluentd/src/main/scala/wvlet/airframe/fluentd/FluentdLogger.scala:  debug(s"Starting Fluency")
airframe-fluentd/src/main/scala/wvlet/airframe/fluentd/FluentdLogger.scala:    debug(s"Stopping Fluency")
airframe-http/src/test/scala/wvlet/airframe/http/RouterTest.scala:    warn(s"Ambiguous HTTP path pattern test")
airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/FinagleClientTest.scala:        warn(s"Starting http client failure tests")
airframe-http-recorder/src/main/scala/wvlet/airframe/http/recorder/HttpRecorder.scala:        .name(s"airframe-http-recorder-proxy")
airframe-jmx/src/main/scala/wvlet/airframe/jmx/JMXMBean.scala:    throw new UnsupportedOperationException(s"JMXMBean.invoke is not supported")
airframe-json/src/test/scala/wvlet/airframe/json/JSONScannerTest.scala:      scan(s"""["\\u0fA9\\u0123", "\\u0123"]""")
airframe-launcher/src/test/scala/wvlet/airframe/launcher/LauncherTest.scala:      throw new IllegalArgumentException(s"error test")
airframe-log/shared/src/test/scala/wvlet/log/WvletLog.scala:      debug(s"wvlet-log adds fancy logging to your Scala applications.")
airframe-log/shared/src/test/scala/wvlet/log/WvletLog.scala:      warn(s"And also, customizing log format is easy")
airframe-log/shared/src/test/scala/wvlet/log/WvletLog.scala:      info(s"wvlet-log uses Scala macro to output log messages only when necessary")
airframe-log/shared/src/test/scala/wvlet/log/WvletLog.scala:      info(s"Usage is simple")
airframe-log/shared/src/test/scala/wvlet/log/WvletLog.scala:      warn(s"Just add wvlet.log.LogSupport trait to your application")
airframe-msgpack-benchmark/src/main/scala/wvlet/airframe/benchmark/msgpack/MsgpackBenchmarkMain.scala:    info(s"Starting the benchmark")
airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLInterpreter.scala:          throw new IllegalArgumentException(s"group by statement requires input relation")
airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/SQLAnonymizer.scala:    debug(s"Building a token dictionary")
airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/SQLAnonymizer.scala:    var qnameTable         = new SymbolTable(s"t")
Binary file docs/src/main/resources/microsite/img/sea.png matches
examples/src/main/scala/wvlet/airframe/examples/di/DI_20_BindSession.scala:      warn(s"shutdown is called")
examples/src/main/scala/wvlet/airframe/examples/di/DI_07_JSR250Annotation.scala:      info(s"starting the service")
examples/src/main/scala/wvlet/airframe/examples/di/DI_07_JSR250Annotation.scala:      info(s"stopping the service")
examples/src/main/scala/wvlet/airframe/examples/di/DI_11_ProductionMode.scala:  info(s"Production mode")
examples/src/main/scala/wvlet/airframe/examples/di/DI_11_ProductionMode.scala:  info(s"Lazy mode")
examples/src/main/scala/wvlet/airframe/examples/di/DI_12_ReusingService.scala:      info(s"connected")
examples/src/main/scala/wvlet/airframe/examples/di/DI_12_ReusingService.scala:      info(s"connected")
Binary file scalafmt matches
```

- This P/R
```
grep -r "(s\"" * .scala |  grep -v "\$."                                                                                                                             5.1s  木  7/ 4 13:23:16 2019
grep: .scala: No such file or directory
Binary file docs/src/main/resources/microsite/img/sea.png matches
Binary file scalafmt matches
```