### PR TITLE
Seq[JSONValue].value

### DIFF
--- a/airframe-json/src/main/scala/wvlet/airframe/json/package.scala
+++ b/airframe-json/src/main/scala/wvlet/airframe/json/package.scala
@@ -76,5 +76,9 @@ package object json {
         jsonValue.value
       }
     }
+
+    def value: Any = {
+      jsonValues.head.value
+    }
   }
 }

--- a/airframe-json/src/test/scala/wvlet/airframe/json/JSONTest.scala
+++ b/airframe-json/src/test/scala/wvlet/airframe/json/JSONTest.scala
@@ -38,11 +38,16 @@ class JSONTest extends AirframeSpec {
   }
 
   "JSON DSL" in {
-    val json: Json = """{"user": [{ "id": 1 }, { "id": 2 }]}"""
+    val json: Json = """{"user": [{ "id": 1, "name": "a" }, { "id": 2, "name": "b" }]}"""
     val jsonValue  = JSON.parse(json)
 
     val id = (jsonValue / "user" / "id")(0).value
-
     id shouldBe 1
+
+    val name = (jsonValue / "user" / "name")(1).value
+    name shouldBe "b"
+
+    val users = (jsonValue / "user").value
+    users shouldBe Seq(Map("id" -> 1, "name" -> "a"), Map("id" -> 2, "name" -> "b"))
   }
 }


### PR DESCRIPTION
Another `.value` method for JSON DSL added in #538 that allows getting a value of the first element of `Seq[JSONValue]`.

This is useful when we know that the json value has a single child element.

```scala
// before
val id = (jsonValue / "user" / "id")(0).value
// after
val id = (jsonValue / "user" / "id").value
```