### PR TITLE
Use map type MessagePack for ObjectCodec

### DIFF
--- a/airframe-codec/.jvm/src/test/scala/wvlet/airframe/codec/ObjectCodecTest.scala
+++ b/airframe-codec/.jvm/src/test/scala/wvlet/airframe/codec/ObjectCodecTest.scala
@@ -95,7 +95,7 @@ class ObjectCodecTest extends CodecSpec {
     unpacker.getNextFormat shouldBe FIXMAP
 
     // Succeed to pack to object
-    val a       = codec.unpackMsgPack(msgpack)
+    val a = codec.unpackMsgPack(msgpack)
     a shouldBe Some(a3)
   }
 }

--- a/airframe-codec/.jvm/src/test/scala/wvlet/airframe/codec/ObjectCodecTest.scala
+++ b/airframe-codec/.jvm/src/test/scala/wvlet/airframe/codec/ObjectCodecTest.scala
@@ -94,7 +94,7 @@ class ObjectCodecTest extends CodecSpec {
     // The written message pack should be FIXMAP type for A3 class
     unpacker.getNextFormat shouldBe FIXMAP
 
-    // Succeed to pack to object
+    // Succeed to unpack to object.
     val a = codec.unpackMsgPack(msgpack)
     a shouldBe Some(a3)
   }

--- a/airframe-codec/.jvm/src/test/scala/wvlet/airframe/codec/ObjectCodecTest.scala
+++ b/airframe-codec/.jvm/src/test/scala/wvlet/airframe/codec/ObjectCodecTest.scala
@@ -14,6 +14,7 @@
 package wvlet.airframe.codec
 
 import wvlet.airframe.codec.ObjectCodecTest._
+import wvlet.airframe.msgpack.spi.MessageFormat.FIXMAP
 import wvlet.airframe.msgpack.spi.MessagePack
 
 /**
@@ -85,6 +86,18 @@ class ObjectCodecTest extends CodecSpec {
     }
   }
 
+  "write as map type message pack" in {
+    val codec    = MessageCodec.of[A3]
+    val a3       = A3(Some("optValue"), "strValue")
+    val msgpack  = codec.toMsgPack(a3)
+    val unpacker = MessagePack.newUnpacker(msgpack)
+    // The written message pack should be FIXMAP type for A3 class
+    unpacker.getNextFormat shouldBe FIXMAP
+
+    // Succeed to pack to object
+    val a       = codec.unpackMsgPack(msgpack)
+    a shouldBe Some(a3)
+  }
 }
 
 object ObjectCodecTest {

--- a/airframe-codec/src/main/scala/wvlet/airframe/codec/MessageCodec.scala
+++ b/airframe-codec/src/main/scala/wvlet/airframe/codec/MessageCodec.scala
@@ -62,7 +62,12 @@ trait MessageCodec[A] extends LogSupport {
 
   def toMsgPack(v: A): Array[Byte] = {
     val packer = MessagePack.newBufferPacker
-    pack(packer, v)
+    this match {
+      case c: PackAsMapSupport[_] =>
+        c.asInstanceOf[PackAsMapSupport[A]].packAsMap(packer, v)
+      case _ =>
+        pack(packer, v)
+    }
     packer.toByteArray
   }
 

--- a/airframe-fluentd/src/main/scala/wvlet/airframe/fluentd/MetricLogger.scala
+++ b/airframe-fluentd/src/main/scala/wvlet/airframe/fluentd/MetricLogger.scala
@@ -15,7 +15,7 @@ package wvlet.airframe.fluentd
 import java.util.concurrent.ConcurrentHashMap
 
 import javax.annotation.PreDestroy
-import wvlet.airframe.codec.MessageCodec
+import wvlet.airframe.codec.{MessageCodec, MessageCodecFactory}
 import wvlet.airframe.surface.Surface
 import wvlet.log.LogSupport
 
@@ -65,7 +65,8 @@ class MetricLoggerFactory(fluentdClient: MetricLogger) extends LogSupport {
   def getTypedLogger[T <: TaggedMetric: ru.TypeTag]: TypedMetricLogger[T] = {
     loggerCache
       .getOrElseUpdate(Surface.of[T], {
-        val codec = MessageCodec.of[T]
+        // Ensure to serialize as map type of MessagePack
+        val codec = MessageCodecFactory.defaultFactory.withObjectMapCodec.of[T]
         new TypedMetricLogger[T](getLogger, codec)
       }).asInstanceOf[TypedMetricLogger[T]]
   }
@@ -73,7 +74,8 @@ class MetricLoggerFactory(fluentdClient: MetricLogger) extends LogSupport {
   def getTypedLoggerWithTagPrefix[T <: TaggedMetric: ru.TypeTag](tagPrefix: String): TypedMetricLogger[T] = {
     loggerCache
       .getOrElseUpdate(Surface.of[T], {
-        val codec = MessageCodec.of[T]
+        // Ensure to serialize as map type of MessagePack 
+        val codec = MessageCodecFactory.defaultFactory.withObjectMapCodec.of[T]
         new TypedMetricLogger[T](getLoggerWithTagPrefix(tagPrefix), codec)
       }).asInstanceOf[TypedMetricLogger[T]]
   }

--- a/airframe-fluentd/src/main/scala/wvlet/airframe/fluentd/MetricLogger.scala
+++ b/airframe-fluentd/src/main/scala/wvlet/airframe/fluentd/MetricLogger.scala
@@ -64,20 +64,24 @@ class MetricLoggerFactory(fluentdClient: MetricLogger) extends LogSupport {
 
   def getTypedLogger[T <: TaggedMetric: ru.TypeTag]: TypedMetricLogger[T] = {
     loggerCache
-      .getOrElseUpdate(Surface.of[T], {
-        // Ensure to serialize as map type of MessagePack
-        val codec = MessageCodecFactory.defaultFactory.withObjectMapCodec.of[T]
-        new TypedMetricLogger[T](getLogger, codec)
-      }).asInstanceOf[TypedMetricLogger[T]]
+      .getOrElseUpdate(
+        Surface.of[T], {
+          // Ensure to serialize as map type of MessagePack
+          val codec = MessageCodecFactory.defaultFactory.withObjectMapCodec.of[T]
+          new TypedMetricLogger[T](getLogger, codec)
+        }
+      ).asInstanceOf[TypedMetricLogger[T]]
   }
 
   def getTypedLoggerWithTagPrefix[T <: TaggedMetric: ru.TypeTag](tagPrefix: String): TypedMetricLogger[T] = {
     loggerCache
-      .getOrElseUpdate(Surface.of[T], {
-        // Ensure to serialize as map type of MessagePack 
-        val codec = MessageCodecFactory.defaultFactory.withObjectMapCodec.of[T]
-        new TypedMetricLogger[T](getLoggerWithTagPrefix(tagPrefix), codec)
-      }).asInstanceOf[TypedMetricLogger[T]]
+      .getOrElseUpdate(
+        Surface.of[T], {
+          // Ensure to serialize as map type of MessagePack
+          val codec = MessageCodecFactory.defaultFactory.withObjectMapCodec.of[T]
+          new TypedMetricLogger[T](getLoggerWithTagPrefix(tagPrefix), codec)
+        }
+      ).asInstanceOf[TypedMetricLogger[T]]
   }
 
   @PreDestroy

--- a/airframe-fluentd/src/main/scala/wvlet/airframe/fluentd/MetricLogger.scala
+++ b/airframe-fluentd/src/main/scala/wvlet/airframe/fluentd/MetricLogger.scala
@@ -52,7 +52,9 @@ class TypedMetricLogger[T <: TaggedMetric](fluentdClient: MetricLogger, codec: M
   }
 }
 
-class MetricLoggerFactory(fluentdClient: MetricLogger) extends LogSupport {
+class MetricLoggerFactory(fluentdClient: MetricLogger,
+                          codecFactory: MessageCodecFactory = MessageCodecFactory.defaultFactory.withObjectMapCodec)
+    extends LogSupport {
   def getLogger: MetricLogger = fluentdClient
   def getLoggerWithTagPrefix(tagPrefix: String): MetricLogger =
     fluentdClient.withTagPrefix(tagPrefix)
@@ -67,7 +69,7 @@ class MetricLoggerFactory(fluentdClient: MetricLogger) extends LogSupport {
       .getOrElseUpdate(
         Surface.of[T], {
           // Ensure to serialize as map type of MessagePack
-          val codec = MessageCodecFactory.defaultFactory.withObjectMapCodec.of[T]
+          val codec = codecFactory.withObjectMapCodec.of[T]
           new TypedMetricLogger[T](getLogger, codec)
         }
       ).asInstanceOf[TypedMetricLogger[T]]
@@ -78,7 +80,7 @@ class MetricLoggerFactory(fluentdClient: MetricLogger) extends LogSupport {
       .getOrElseUpdate(
         Surface.of[T], {
           // Ensure to serialize as map type of MessagePack
-          val codec = MessageCodecFactory.defaultFactory.withObjectMapCodec.of[T]
+          val codec = codecFactory.withObjectMapCodec.of[T]
           new TypedMetricLogger[T](getLoggerWithTagPrefix(tagPrefix), codec)
         }
       ).asInstanceOf[TypedMetricLogger[T]]


### PR DESCRIPTION
Currently, MessageCodec serializes the value as array type as default even for ObjectCodec which is supporting `PackAsMapSupport`. It can cause a problem of the cooperability between td-agent and airframe-fluentd because td-agent expects the input record to be map type MessagePack. 

Since `TypedMetricLogger` in airframe-fluentd calls `toMsgPack`, the data is flushed as array type. But it cannot be read by td-agent or fluentd. 

```scala
class TypedMetricLogger[T <: TaggedMetric](fluentdClient: MetricLogger, codec: MessageCodec[T]) {
  def emit(event: T): Unit = {
    fluentdClient.emitMsgPack(event.metricTag, codec.toMsgPack(event))
  }
}
```

As we do for `toJson`, `toMsgPack` can write the value as map type if the codec is `PackAsMapSupport`. 

Additionally, using object map type codec in TypedMetricLogger might be good to resolve the cooperability with td-agent.