### PR TITLE
json performance tuning

### DIFF
--- a/airframe-json-benchmark/src/test/scala/wvlet/airframe/json/JSONBenchmark.scala
+++ b/airframe-json-benchmark/src/test/scala/wvlet/airframe/json/JSONBenchmark.scala
@@ -55,7 +55,7 @@ class JSONBenchmark extends AirframeSpec with Timer {
 
   lazy val twitterJson = IOUtil.readAsString("airframe-json/src/test/resources/twitter.json")
 
-  "JSONScannerBenchmarhk" should {
+  "JSONScannerBenchmark" should {
     "parse twitter.json" taggedAs ("comparison") in {
       bench("twitter.json", twitterJson)
     }


### PR DESCRIPTION
Fix for uses same StringBuilder instances. It looks like the performance has improved slightly.

## This P/R
```
2019-07-13 22:24:11.843+0900  info [JSONBenchmark] -twitter.json        total:8.057 sec. , count:   10, avg:0.806 sec. , min:0.346 sec. , median:0.397 sec. , max:3.688 sec. 
  -airframe             total:1.122 sec. , count:  100, avg:0.011 sec. , min:3.811 msec., median:5.813 msec., max:0.094 sec. 
  -airframe scan        total:0.908 sec. , count:  100, avg:9.081 msec., min:2.160 msec., median:3.868 msec., max:0.066 sec. 
  -circe                total:0.926 sec. , count:  100, avg:9.256 msec., min:1.600 msec., median:2.459 msec., max:0.416 sec. 
  -jawn                 total:0.610 sec. , count:  100, avg:6.098 msec., min:1.596 msec., median:2.314 msec., max:0.109 sec. 
  -json4s-jackson rk / Ttotal:1.164 sec. , count:  100, avg:0.012 sec. , min:1.588 msec., median:2.696 msec., max:0.518 sec. 
  -json4s-native        total:2.150 sec. , count:  100, avg:0.021 sec. , min:8.814 msec., median:0.013 sec. , max:0.174 sec. 
  -uJson                total:1.080 sec. , count:  100, avg:0.011 sec. , min:2.524 msec., median:3.925 msec., max:0.158 sec.  
2019-07-13 22:24:13.121+0900  info [JSONBenchmark] -boolean array       total:1.250 sec. , count:   10, avg:0.125 sec. , min:0.032 sec. , median:0.091 sec. , max:0.605 sec. 
  -airframe             total:0.150 sec. , count:  100, avg:1.502 msec., min:0.246 msec., median:0.418 msec., max:0.041 sec. 
  -airframe scan        total:0.044 sec. , count:  100, avg:0.435 msec., min:0.202 msec., median:0.345 msec., max:5.499 msec.
  -circe                total:0.267 sec. , count:  100, avg:2.671 msec., min:0.175 msec., median:0.286 msec., max:0.065 sec. 
  -jawn                 total:0.107 sec. , count:  100, avg:1.073 msec., min:0.176 msec., median:0.281 msec., max:0.034 sec. 
  -json4s-jackson rk / Ttotal:0.061 sec. , count:  100, avg:0.605 msec., min:0.251 msec., median:0.412 msec., max:4.702 msec.
  -json4s-native        total:0.188 sec. , count:  100, avg:1.878 msec., min:0.504 msec., median:0.900 msec., max:0.028 sec. 
  -uJson                total:0.427 sec. , count:  100, avg:4.267 msec., min:0.412 msec., median:3.474 msec., max:0.025 sec.  
2019-07-13 22:24:16.458+0900  info [JSONBenchmark] -string array        total:3.020 sec. , count:   10, avg:0.302 sec. , min:0.170 sec. , median:0.216 sec. , max:1.026 sec. 
  -airframe             total:0.702 sec. , count:  100, avg:7.018 msec., min:2.327 msec., median:3.667 msec., max:0.049 sec. 
  -airframe scan        total:0.358 sec. , count:  100, avg:3.576 msec., min:1.610 msec., median:2.338 msec., max:0.027 sec. 
  -circe                total:0.424 sec. , count:  100, avg:4.242 msec., min:0.786 msec., median:1.448 msec., max:0.056 sec. 
  -jawn                 total:0.158 sec. , count:  100, avg:1.577 msec., min:0.780 msec., median:1.279 msec., max:9.066 msec.
  -json4s-jackson rk / Ttotal:0.168 sec. , count:  100, avg:1.675 msec., min:0.910 msec., median:1.394 msec., max:8.549 msec.
  -json4s-native        total:0.768 sec. , count:  100, avg:7.680 msec., min:3.479 msec., median:4.791 msec., max:0.038 sec. 
  -uJson                total:0.428 sec. , count:  100, avg:4.284 msec., min:1.051 msec., median:1.708 msec., max:0.055 sec.  
```

## Current Master
```
2019-07-13 22:25:49.227+0900  info [JSONBenchmark] -twitter.json        total:9.790 sec. , count:   10, avg:0.979 sec. , min:0.373 sec. , median:0.579 sec. , max:4.702 sec. 
  -airframe             total:1.180 sec. , count:  100, avg:0.012 sec. , min:4.081 msec., median:6.053 msec., max:0.174 sec. 
  -airframe scan        total:1.132 sec. , count:  100, avg:0.011 sec. , min:2.354 msec., median:3.962 msec., max:0.099 sec. 
  -circe                total:1.318 sec. , count:  100, avg:0.013 sec. , min:1.689 msec., median:2.830 msec., max:0.505 sec. 
  -jawn                 total:0.869 sec. , count:  100, avg:8.693 msec., min:1.617 msec., median:2.978 msec., max:0.086 sec. 
  -json4s-jackson rk / Ttotal:1.065 sec. , count:  100, avg:0.011 sec. , min:1.590 msec., median:2.734 msec., max:0.615 sec. 
  -json4s-native        total:2.384 sec. , count:  100, avg:0.024 sec. , min:8.978 msec., median:0.015 sec. , max:0.207 sec. 
  -uJson                total:1.812 sec. , count:  100, avg:0.018 sec. , min:3.176 msec., median:5.858 msec., max:0.206 sec.  
2019-07-13 22:25:51.118+0900  info [JSONBenchmark] -boolean array       total:1.866 sec. , count:   10, avg:0.187 sec. , min:0.062 sec. , median:0.157 sec. , max:0.664 sec. 
  -airframe             total:0.186 sec. , count:  100, avg:1.860 msec., min:0.231 msec., median:0.424 msec., max:0.043 sec. 
  -airframe scan        total:0.168 sec. , count:  100, avg:1.675 msec., min:0.212 msec., median:0.376 msec., max:0.032 sec. 
  -circe                total:0.280 sec. , count:  100, avg:2.797 msec., min:0.168 msec., median:0.322 msec., max:0.047 sec. 
  -jawn                 total:0.137 sec. , count:  100, avg:1.368 msec., min:0.168 msec., median:0.314 msec., max:0.046 sec. 
  -json4s-jackson rk / Ttotal:0.175 sec. , count:  100, avg:1.747 msec., min:0.247 msec., median:0.471 msec., max:0.031 sec. 
  -json4s-native        total:0.165 sec. , count:  100, avg:1.652 msec., min:0.563 msec., median:1.035 msec., max:9.416 msec.
  -uJson                total:0.749 sec. , count:  100, avg:7.493 msec., min:0.433 msec., median:5.549 msec., max:0.052 sec.  
2019-07-13 22:25:55.610+0900  info [JSONBenchmark] -string array        total:4.253 sec. , count:   10, avg:0.425 sec. , min:0.184 sec. , median:0.301 sec. , max:1.609 sec. 
  -airframe             total:0.832 sec. , count:  100, avg:8.318 msec., min:2.493 msec., median:4.380 msec., max:0.062 sec. 
  -airframe scan        total:0.641 sec. , count:  100, avg:6.407 msec., min:1.787 msec., median:2.994 msec., max:0.074 sec. 
  -circe                total:0.473 sec. , count:  100, avg:4.730 msec., min:0.779 msec., median:1.522 msec., max:0.067 sec. 
  -jawn                 total:0.385 sec. , count:  100, avg:3.850 msec., min:0.775 msec., median:1.168 msec., max:0.055 sec. 
  -json4s-jackson rk / Ttotal:0.214 sec. , count:  100, avg:2.139 msec., min:0.916 msec., median:1.267 msec., max:0.023 sec. 
  -json4s-native        total:0.972 sec. , count:  100, avg:9.718 msec., min:3.937 msec., median:5.559 msec., max:0.050 sec. 
  -uJson                total:0.730 sec. , count:  100, avg:7.298 msec., min:1.122 msec., median:3.013 msec., max:0.050 sec.  
[info] JSONBenchmark:
```