### PR TITLE
Fix over routing in airframe-http

### DIFF
--- a/airframe-http/src/main/scala/wvlet/airframe/http/RouteMatcher.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/RouteMatcher.scala
@@ -76,7 +76,7 @@ object RouteMatcher extends LogSupport {
       var params = Map.empty[String, String]
 
       // Traverse the path components and transit the DFA state
-      while ((toContinue || foundRoute.isEmpty) && pathIndex < pc.length) {
+      while (toContinue && pathIndex < pc.length) {
         val token = pc(pathIndex)
         pathIndex += 1
         dfa.nextNode(currentState, token) match {

--- a/airframe-http/src/test/scala/wvlet/airframe/http/RouterTest.scala
+++ b/airframe-http/src/test/scala/wvlet/airframe/http/RouterTest.scala
@@ -76,6 +76,15 @@ class RouterTest extends AirframeSpec {
     debug(r4)
     r4 shouldBe defined
     r4.get.route.method shouldBe HttpMethod.DELETE
+
+    val r5 = router.findRoute(SimpleHttpRequest(HttpMethod.GET, "/v1/config/info"))
+    debug(r5)
+    r5 shouldBe defined
+    r5.get.route.method shouldBe HttpMethod.GET
+
+    val r6 = router.findRoute(SimpleHttpRequest(HttpMethod.GET, "/v1/config/xxxx/info"))
+    debug(r6)
+    r6 shouldNot be(defined)
   }
 
   "call registered methods" in {


### PR DESCRIPTION
Though the following requests are routed to the same action even if only `/v1/config/info` is available, the second request should be 404.

- http://localhost:8080/v1/config/info
- http://localhost:8080/v1/config/xxx/info 