### PR TITLE
airframe-http-client: Add getResource for GET with query strings

### DIFF
--- a/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/FinagleClientTest.scala
+++ b/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/FinagleClientTest.scala
@@ -47,6 +47,11 @@ trait FinagleClientTestApi extends LogSupport {
     User(id, name, getRequestId(request))
   }
 
+  @Endpoint(method = HttpMethod.GET, path = "/user/info2")
+  def getResource(query: UserRequest, request: Request): User = {
+    User(query.id, query.name, getRequestId(request))
+  }
+
   @Endpoint(method = HttpMethod.GET, path = "/user")
   def list(request: Request): Seq[User] = {
     Seq(User(1, "leo", getRequestId(request)))
@@ -105,6 +110,7 @@ class FinagleClientTest extends AirframeSpec {
         // Using HTTP request wrappers
         client.get[User]("/user/1") shouldBe User(1, "leo", "N/A")
         client.getResource[UserRequest, User]("/user/info", UserRequest(2, "kai")) shouldBe User(2, "kai", "N/A")
+        client.getResource[UserRequest, User]("/user/info2", UserRequest(2, "kai")) shouldBe User(2, "kai", "N/A")
         client.list[Seq[User]]("/user") shouldBe Seq(User(1, "leo", "N/A"))
 
         client.post[User]("/user", User(2, "yui", "N/A")) shouldBe User(2, "yui", "N/A")
@@ -120,6 +126,9 @@ class FinagleClientTest extends AirframeSpec {
         client.getResource[UserRequest, User]("/user/info", UserRequest(2, "kai"), addRequestId) shouldBe User(2,
                                                                                                                "kai",
                                                                                                                "10")
+        client.getResource[UserRequest, User]("/user/info2", UserRequest(2, "kai"), addRequestId) shouldBe User(2,
+                                                                                                                "kai",
+                                                                                                                "10")
 
         client.list[Seq[User]]("/user", addRequestId) shouldBe Seq(User(1, "leo", "10"))
 

--- a/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/FinagleClientTest.scala
+++ b/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/FinagleClientTest.scala
@@ -24,6 +24,8 @@ case class User(id: Int, name: String, requestId: String) {
   def withRequestId(newRequestId: String): User = User(id, name, newRequestId)
 }
 
+case class UserRequest(id: Int, name: String)
+
 trait FinagleClientTestApi extends LogSupport {
 
   @Endpoint(method = HttpMethod.GET, path = "/")
@@ -38,6 +40,11 @@ trait FinagleClientTestApi extends LogSupport {
   @Endpoint(method = HttpMethod.GET, path = "/user/:id")
   def get(id: Int, request: Request): User = {
     User(id, "leo", getRequestId(request))
+  }
+
+  @Endpoint(method = HttpMethod.GET, path = "/user/info")
+  def getResource(id: Int, name: String, request: Request): User = {
+    User(id, name, getRequestId(request))
   }
 
   @Endpoint(method = HttpMethod.GET, path = "/user")
@@ -97,6 +104,7 @@ class FinagleClientTest extends AirframeSpec {
 
         // Using HTTP request wrappers
         client.get[User]("/user/1") shouldBe User(1, "leo", "N/A")
+        client.getResource[UserRequest, User]("/user/info", UserRequest(2, "kai")) shouldBe User(2, "kai", "N/A")
         client.list[Seq[User]]("/user") shouldBe Seq(User(1, "leo", "N/A"))
 
         client.post[User]("/user", User(2, "yui", "N/A")) shouldBe User(2, "yui", "N/A")
@@ -109,7 +117,12 @@ class FinagleClientTest extends AirframeSpec {
 
         // Using a custom HTTP header
         client.get[User]("/user/1", addRequestId) shouldBe User(1, "leo", "10")
+        client.getResource[UserRequest, User]("/user/info", UserRequest(2, "kai"), addRequestId) shouldBe User(2,
+                                                                                                               "kai",
+                                                                                                               "10")
+
         client.list[Seq[User]]("/user", addRequestId) shouldBe Seq(User(1, "leo", "10"))
+
         client.post[User]("/user", User(2, "yui", "N/A"), addRequestId) shouldBe User(2, "yui", "10")
         client.postOps[User, User]("/user", User(2, "yui", "N/A"), addRequestId) shouldBe User(2, "yui", "10")
 

--- a/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/FinagleRouterTest.scala
+++ b/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/FinagleRouterTest.scala
@@ -56,6 +56,11 @@ trait MyApi extends LogSupport {
     Future.value(request.toString)
   }
 
+  @Endpoint(method = HttpMethod.GET, path = "/v1/json_api")
+  def jsonApiForGet(request: RichRequest): Future[String] = {
+    Future.value(request.toString)
+  }
+
   @Endpoint(method = HttpMethod.POST, path = "/v1/raw_string_arg")
   def rawString(body: String): String = {
     body
@@ -147,6 +152,14 @@ class FinagleRouterTest extends AirframeSpec {
         request.method = Method.Post
         val ret = Await.result(client(request).map(_.contentString))
         ret shouldBe """RichRequest(100,dummy)"""
+      }
+
+      // GET requests with query parameters
+      {
+        val request = Request("/v1/json_api?id=10&name=leo")
+        request.method = Method.Get
+        val ret = Await.result(client(request).map(_.contentString))
+        ret shouldBe """RichRequest(10,leo)"""
       }
 
       // JSON requests with POST

--- a/airframe-http/src/main/scala/wvlet/airframe/http/Route.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/Route.scala
@@ -53,6 +53,7 @@ case class Route(controllerSurface: Surface, method: HttpMethod, path: String, m
       implicit adapter: HttpRequestAdapter[Req]): Seq[Any] = {
     // Collect URL query parameters and other parameters embedded inside URL.
     val requestParams: Map[String, String] = adapter.queryOf(request) ++ params
+    lazy val queryParamMsgpack             = Route.stringMapCodec.toMsgPack(requestParams)
 
     // Build the function arguments
     val methodArgs: Seq[Any] =
@@ -73,7 +74,6 @@ case class Route(controllerSurface: Surface, method: HttpMethod, path: String, m
               case None =>
                 if (adapter.methodOf(request) == HttpMethod.GET) {
                   // Build the method argument instance from the query strings for GET requests
-                  val queryParamMsgpack = MessageCodec.of[Map[String, String]].toMsgPack(requestParams)
                   argCodec.unpackMsgPack(queryParamMsgpack)
                 } else {
                   // Build the method argument instance from the content body for non GET requests
@@ -124,4 +124,8 @@ case class Route(controllerSurface: Surface, method: HttpMethod, path: String, m
       call(controller, buildControllerMethodArgs(controller, request, params))
     }
   }
+}
+
+object Route {
+  private[Route] val stringMapCodec = MessageCodec.of[Map[String, String]]
 }

--- a/airframe-http/src/main/scala/wvlet/airframe/http/Route.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/Route.scala
@@ -72,11 +72,11 @@ case class Route(controllerSurface: Surface, method: HttpMethod, path: String, m
                 argCodec.unpackMsgPack(StringCodec.toMsgPack(paramValue))
               case None =>
                 if (adapter.methodOf(request) == HttpMethod.GET) {
-                  // Build the method argument instance from the query strings
+                  // Build the method argument instance from the query strings for GET requests
                   val queryParamMsgpack = MessageCodec.of[Map[String, String]].toMsgPack(requestParams)
                   argCodec.unpackMsgPack(queryParamMsgpack)
                 } else {
-                  // Build the method argument instance from the content body
+                  // Build the method argument instance from the content body for non GET requests
                   val contentBytes = adapter.contentBytesOf(request)
 
                   if (contentBytes.nonEmpty) {


### PR DESCRIPTION
For passing GET request objects as URL query strings.

This will add two more convenient mappings:
- binding URL query strings (?p1=v1&p2=v2& ...) as method arguments
- binding URL query strings to a method object (ResourceRequest(p1, p2, ...))