### PR TITLE
airframe-http-recorder: Add createRecorderProxy

### DIFF
--- a/airframe-http-recorder/README.md
+++ b/airframe-http-recorder/README.md
@@ -22,24 +22,37 @@ import wvlet.airframe.control.Control._
 val recorderConfig = 
   HttpRecorderConfig(destUri = "https://wvlet.org", sessionName = "airframe")
 
-// Create a proxy server for recording server responses
-withResource(HttpRecorder.createRecordingServer(recorderConfig)) { server =>
+// Create a proxy server that will record responses for matching requests,
+// and make actual requests the destination for non-recorded requests.
+withResource(HttpRecorder.createRecorderProxyServer(recorderConfig)) { server =>
   server.start
   val addr = server.localAddress // "localhost:(port number)"
-  // Requests to the local server will be recorded 
+  // Requests to the local server will be recorded
+}
+
+
+// Create a proxy server only for recording server responses
+withResource(HttpRecorder.createRecordOnlyServer(recorderConfig)) { server =>
+  server.start
+  val addr = server.localAddress // "localhost:(port number)"
+  // Requests to the local server will be recorded
 }
 
 // Create a replay server that returns recorded responses for matching requests 
-withResource(HttpRecorder.createReplayServer(recorderConfig)) { server =>
+withResource(HttpRecorder.createReplayOnlyServer(recorderConfig)) { server =>
   server.start
   val addr = server.localAddress // "localhost:(port number)"
-  // Requests to the local server will return the recorded responses 
+  // Requests to the local server will return the recorded responses
 }
 ```
 
 ### Programmable
 
 ```scala
+import wvlet.airframe.http.recorder._
+import wvlet.airframe.control.Control._
+import com.twitter.finagle.http.{Request,Response}
+
 val response = withResource(HttpRecorder.createProgrammableServer { recorder =>
   // Program server responses instead of recodring
   val request = Request("/index.html")

--- a/airframe-http-recorder/README.md
+++ b/airframe-http-recorder/README.md
@@ -24,7 +24,7 @@ val recorderConfig =
 
 // Create a proxy server that will record responses for matching requests,
 // and make actual requests the destination for non-recorded requests.
-withResource(HttpRecorder.createRecorderProxyServer(recorderConfig)) { server =>
+withResource(HttpRecorder.createRecorderProxy(recorderConfig)) { server =>
   server.start
   val addr = server.localAddress // "localhost:(port number)"
   // Requests to the local server will be recorded

--- a/airframe-http-recorder/src/main/scala/wvlet/airframe/http/recorder/HttpRecordStore.scala
+++ b/airframe-http-recorder/src/main/scala/wvlet/airframe/http/recorder/HttpRecordStore.scala
@@ -94,9 +94,7 @@ class HttpRecordStore(val recorderConfig: HttpRecorderConfig, dropSession: Boole
     * This value will be used for DB indexes
     */
   protected def requestHash(request: Request): Int = {
-    val content = request.getContentString()
-    val prefix =
-      s"${request.method.toString()}:${recorderConfig.destAddress.hostAndPort}${request.uri}:${content.hashCode}"
+    val prefix = HttpRecorder.computeRequestHash(request, recorderConfig)
 
     request.headerMap.filterNot(x => recorderConfig.headerExcludes(x._1)) match {
       case headers if headers.isEmpty => prefix.hashCode * 13

--- a/airframe-http-recorder/src/main/scala/wvlet/airframe/http/recorder/HttpRecordStore.scala
+++ b/airframe-http-recorder/src/main/scala/wvlet/airframe/http/recorder/HttpRecordStore.scala
@@ -53,6 +53,7 @@ class HttpRecordStore(val recorderConfig: HttpRecorderConfig, dropSession: Boole
     // n-th request, where n is the access count to the same path
     val counter  = requestCounter.getOrElseUpdate(rh, new AtomicInteger())
     val hitCount = counter.getAndIncrement()
+    trace(s"findNext: request hash: ${rh} for ${request}, hitCount: ${hitCount}")
     connectionPool.queryWith(
       // Get the next request matching the requestHash
       s"select * from ${recordTableName} where session = ? and requestHash = ? order by createdAt limit 1 offset ?") {

--- a/airframe-http-recorder/src/main/scala/wvlet/airframe/http/recorder/HttpRecorder.scala
+++ b/airframe-http-recorder/src/main/scala/wvlet/airframe/http/recorder/HttpRecorder.scala
@@ -85,8 +85,7 @@ object HttpRecorder extends LogSupport {
     * Creates an HTTP proxy server that will return recorded responses. If no record is found, it will
     * actually send the request to the destination server and record the response.
     */
-  def createRecorderProxyServer(recorderConfig: HttpRecorderConfig,
-                                dropExistingSession: Boolean = false): FinagleServer = {
+  def createRecorderProxy(recorderConfig: HttpRecorderConfig, dropExistingSession: Boolean = false): FinagleServer = {
     val recorder = newRecordStoreForRecording(recorderConfig, dropExistingSession)
     new HttpRecorderServer(recorder, HttpRecorderServer.newRecordProxyService(recorder, newDestClient(recorderConfig)))
   }

--- a/airframe-http-recorder/src/main/scala/wvlet/airframe/http/recorder/HttpRecorderServer.scala
+++ b/airframe-http-recorder/src/main/scala/wvlet/airframe/http/recorder/HttpRecorderServer.scala
@@ -13,17 +13,18 @@
  */
 package wvlet.airframe.http.recorder
 
-import com.twitter.finagle.Service
+import com.twitter.finagle.{Service, SimpleFilter}
 import com.twitter.finagle.http.{Request, Response}
 import com.twitter.util.Future
 import wvlet.airframe.http.finagle.FinagleServer.FinagleService
-import wvlet.airframe.http.finagle.{FinagleServer, FinagleServerConfig}
+import wvlet.airframe.http.finagle.{FinagleFilter, FinagleServer, FinagleServerConfig}
 import wvlet.log.LogSupport
 
-class HttpRecorderServer(recordStore: HttpRecordStore,
-                         finagleConfig: FinagleServerConfig,
-                         finagleService: FinagleService)
-    extends FinagleServer(finagleConfig, finagleService) {
+/**
+  * A FinagleServer wrapper to close HttpRecordStore when the server terminates
+  */
+class HttpRecorderServer(recordStore: HttpRecordStore, finagleService: FinagleService)
+    extends FinagleServer(FinagleServerConfig(recordStore.recorderConfig.serverPort), finagleService) {
 
   override def close(): Unit = {
     super.close()
@@ -31,37 +32,62 @@ class HttpRecorderServer(recordStore: HttpRecordStore,
   }
 }
 
-/**
-  * An HTTP request filter for recording HTTP responses
-  */
-class RecordingService(recordStore: HttpRecordStore, destination: Service[Request, Response]) extends FinagleService {
+object HttpRecorderServer {
 
-  override def apply(request: Request): Future[Response] = {
-    // Rewrite the target host for proxying
-    request.host = recordStore.recorderConfig.destAddress.hostAndPort
-    destination(request).map { response =>
-      // Record the result
-      recordStore.record(request, response)
-      response
+  def newRecordingService(recordStore: HttpRecordStore, destClient: Service[Request, Response]): FinagleService = {
+    new RecordingFilter(recordStore) andThen destClient
+  }
+
+  def newReplayService(recordStore: HttpRecordStore): FinagleService = {
+    new ReplayFilter(recordStore) andThen new FallbackService(recordStore)
+  }
+
+  /**
+    * A request filter for replaying responses for known requests, and sending the
+    * requests to the destination server for unknown requests.
+    */
+  def newPathThroughService(recordStore: HttpRecordStore, destClient: Service[Request, Response]): FinagleService = {
+    new ReplayFilter(recordStore) andThen new RecordingFilter(recordStore) andThen destClient
+  }
+
+  /**
+    * An HTTP request filter for recording HTTP responses
+    */
+  class RecordingFilter(recordStore: HttpRecordStore) extends SimpleFilter[Request, Response] {
+    override def apply(request: Request, service: Service[Request, Response]): Future[Response] = {
+      // Rewrite the target host for proxying
+      request.host = recordStore.recorderConfig.destAddress.hostAndPort
+      service(request).map { response =>
+        // Record the result
+        recordStore.record(request, response)
+        // Return the original response
+        response
+      }
     }
   }
-}
 
-/**
-  * An HTTP request filter for returning recorded HTTP responses
-  */
-class ReplayService(recordStore: HttpRecordStore) extends FinagleService with LogSupport {
+  /**
+    * An HTTP request filter for returning recorded HTTP responses
+    */
+  class ReplayFilter(recordStore: HttpRecordStore) extends SimpleFilter[Request, Response] with LogSupport {
+    override def apply(request: Request, service: Service[Request, Response]): Future[Response] = {
+      // Rewrite the target host for proxying
+      request.host = recordStore.recorderConfig.destAddress.hostAndPort
+      recordStore.findNext(request) match {
+        case Some(record) =>
+          // Replay the recorded response
+          debug(s"Found a recorded response: ${record.summary}")
+          Future.value(record.toResponse)
+        case None =>
+          // Fallback to the default handler
+          service(request)
+      }
+    }
+  }
 
-  override def apply(request: Request): Future[Response] = {
-    // Rewrite the target host for proxying
-    request.host = recordStore.recorderConfig.destAddress.hostAndPort
-    recordStore.findNext(request) match {
-      case Some(record) =>
-        // Replay the recorded response
-        debug(s"Found a recorded response: ${record.summary}")
-        Future.value(record.toResponse)
-      case None =>
-        recordStore.recorderConfig.fallBackHandler(request)
+  class FallbackService(recordStore: HttpRecordStore) extends Service[Request, Response] {
+    override def apply(request: Request): Future[Response] = {
+      recordStore.recorderConfig.fallBackHandler(request)
     }
   }
 }

--- a/airframe-http-recorder/src/test/scala/wvlet/airframe/http/recorder/HttpRecorderTest.scala
+++ b/airframe-http-recorder/src/test/scala/wvlet/airframe/http/recorder/HttpRecorderTest.scala
@@ -96,7 +96,7 @@ class HttpRecorderTest extends AirframeSpec {
       HttpRecorderConfig(destUri = "https://wvlet.org", sessionName = "airframe-path-through")
 
     // Recording
-    withResource(HttpRecorder.createRecorderProxyServer(recorderConfig, dropExistingSession = true)) { server =>
+    withResource(HttpRecorder.createRecorderProxy(recorderConfig, dropExistingSession = true)) { server =>
       server.start
       withClient(server.localAddress) { client =>
         val request = Request("/airframe/")
@@ -110,7 +110,7 @@ class HttpRecorderTest extends AirframeSpec {
     // Replaying
     val replayConfig =
       HttpRecorderConfig(destUri = "https://wvlet.org", sessionName = "airframe-path-through")
-    withResource(HttpRecorder.createRecorderProxyServer(replayConfig)) { server =>
+    withResource(HttpRecorder.createRecorderProxy(replayConfig)) { server =>
       server.start
       withClient(server.localAddress) { client =>
         val request = Request("/airframe/")


### PR DESCRIPTION
Added a new filter for replaying for known requests or recording for unknown requests. 
- [x] Changed record/replay Services as Finagle filters for composability
- [x] Moved dropSession flag to server factory methods 
- [x] Renamed factory methods: createRecorderProxy, createRecordOnlyServer, createReplayOnlyServer.