### PR TITLE
airframe-http: Support Router.add[Filter], andThen[Filter]

### DIFF
--- a/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/HttpFilterTest.scala
+++ b/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/HttpFilterTest.scala
@@ -17,7 +17,6 @@ import com.twitter.finagle.Http
 import com.twitter.finagle.http.{Request, Response, Status, Version}
 import com.twitter.util.{Await, Future}
 import wvlet.airframe.AirframeSpec
-import wvlet.airframe.control.Retry
 import wvlet.airframe.http._
 import wvlet.log.LogSupport
 import wvlet.log.io.IOUtil
@@ -110,10 +109,10 @@ class HttpFilterTest extends AirframeSpec {
 
     val router =
       Router
-        .filter[LogFilterExample]
+        .add[LogFilterExample]
         .andThen(
           Router(
-            Router.filter[AuthFilterExample].andThen[SampleApp],
+            Router.add[AuthFilterExample].andThen[SampleApp],
             Router.add[NoAuth]
           )
         )
@@ -162,7 +161,7 @@ class HttpFilterTest extends AirframeSpec {
   "handle errors in context" in {
     val router =
       Router
-        .filter[ExceptionHandleFilter]
+        .add[ExceptionHandleFilter]
         .andThen[SampleApp]
 
     val d = newFinagleServerDesign(name = "filter-error-test", router = router).noLifeCycleLogging
@@ -179,12 +178,11 @@ class HttpFilterTest extends AirframeSpec {
   "handle errors in filter" taggedAs ("filter-ex") in {
     val router =
       Router
-        .filter[ExceptionHandleFilter]
-        .andThen(
-          Router
-            .filter[ExceptionTestFilter]
-            .andThen[SampleApp]
-        )
+        .add[ExceptionHandleFilter]
+        .andThen[ExceptionTestFilter]
+        .andThen[SampleApp]
+
+    debug(router)
 
     val d = newFinagleServerDesign(name = "filter-error-test", router = router).noLifeCycleLogging
 
@@ -196,5 +194,4 @@ class HttpFilterTest extends AirframeSpec {
       }
     }
   }
-
 }

--- a/airframe-http/src/main/scala/wvlet/airframe/http/HttpFilter.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/HttpFilter.scala
@@ -16,7 +16,7 @@ package wvlet.airframe.http
 import scala.language.higherKinds
 import scala.util.control.NonFatal
 
-private[http] trait HttpFilterType
+trait HttpFilterType
 
 /**
   * A filter interface to define actions for handling HTTP requests and responses

--- a/airframe-http/src/main/scala/wvlet/airframe/http/Router.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/Router.scala
@@ -73,11 +73,16 @@ case class Router(surface: Option[Surface] = None,
   def add[Controller]: Router = macro RouterMacros.add[Controller]
 
   def andThen(next: Router): Router = {
-    if (this.children.nonEmpty) {
-      throw new IllegalStateException(s"The router ${this.toString} already has a child")
+    this.children.size match {
+      case 0 =>
+        this.addChild(next)
+      case 1 =>
+        new Router(surface, Seq(children(0).andThen(next)), localRoutes, filterSurface)
+      case _ =>
+        throw new IllegalStateException(s"The router ${this.toString} already has multiple child routers")
     }
-    this.addChild(next)
   }
+
   def andThen[Controller]: Router = macro RouterMacros.andThen[Controller]
 
   /**
@@ -141,6 +146,7 @@ object Router extends LogSupport {
   def of[Controller]: Router = macro RouterMacros.of[Controller]
   def add[Controller]: Router = macro RouterMacros.of[Controller]
 
-  def filter[Filter <: HttpFilterType]: Router = macro RouterMacros.newFilter[Filter]
+  @deprecated(message = "Use Router.add or Router.of instead", since = "19.8.0")
+  def filter[Filter <: HttpFilterType]: Router = macro RouterMacros.of[Filter]
 
 }

--- a/airframe-http/src/main/scala/wvlet/airframe/http/RouterMacros.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/RouterMacros.scala
@@ -27,12 +27,20 @@ object RouterMacros {
     import c.universe._
     val t = implicitly[c.WeakTypeTag[A]].tpe
 
-    q"""
+    if (t <:< c.typeTag[HttpFilterType].tpe) {
+      q"""{
+           wvlet.airframe.registerTraitFactory[${t}]
+           new wvlet.airframe.http.Router(filterSurface = Some(wvlet.airframe.surface.Surface.of[${t}]))
+          }
+       """
+    } else {
+      q"""
        {
          wvlet.airframe.registerTraitFactory[${t}]
          wvlet.airframe.http.Router.empty.add[${t}]
        }
        """
+    }
   }
 
   def add[A: c.WeakTypeTag](c: sm.Context): c.Tree = {
@@ -43,18 +51,6 @@ object RouterMacros {
        {
          wvlet.airframe.registerTraitFactory[${t}]
          ${c.prefix}.addInternal(wvlet.airframe.surface.Surface.of[${t}], wvlet.airframe.surface.Surface.methodsOf[${t}])
-       }
-     """
-  }
-
-  def newFilter[A: c.WeakTypeTag](c: sm.Context): c.Tree = {
-    import c.universe._
-    val t = implicitly[c.WeakTypeTag[A]].tpe
-
-    q"""
-       {
-          wvlet.airframe.registerTraitFactory[${t}]
-          new wvlet.airframe.http.Router(filterSurface = Some(wvlet.airframe.surface.Surface.of[${t}]))
        }
      """
   }


### PR DESCRIPTION
- Use a consistent syntax for Router.add[X] for both controller and filter
- Deprecate Router.filter[Filter] 
- Support chaining filters with Router.andThen[Filter]