### PR TITLE
Upgrade to Scala 2.12.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ matrix:
       jdk: openjdk8
       script:
         - cd $TRAVIS_BUILD_DIR && ./scripts/publish.sh
-    - env: SCALA_VERSION=2.12.8 PROJECT=projectJVM
+    - env: SCALA_VERSION=2.12.9 PROJECT=projectJVM
       jdk: openjdk8
       services: postgresql
       before_script: psql -c 'create database travis_ci_test;' -U postgres
@@ -54,7 +54,7 @@ matrix:
       before_script: psql -c 'create database travis_ci_test;' -U postgres
       # Exclude design serialization tests due to bug https://github.com/scala/bug/issues/11192
       script: ./sbt ++$SCALA_VERSION "${PROJECT}/testOnly * -- -l serde"
-    - env: SCALA_VERSION=2.12.8 PROJECT=projectJS
+    - env: SCALA_VERSION=2.12.9 PROJECT=projectJS
       jdk: openjdk8  # Scala.js 0.6.27 didn't work with jdk11
       script: ./sbt ++$SCALA_VERSION ${PROJECT}/test
     - env: SCALA_VERSION=2.11.12 PROJECT=projectJVM

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbtcrossproject.{CrossType, crossProject}
 
 val SCALA_2_11 = "2.11.12"
-val SCALA_2_12 = "2.12.8"
+val SCALA_2_12 = "2.12.9"
 val SCALA_2_13 = "2.13.0"
 
 val untilScala2_12      = SCALA_2_12 :: SCALA_2_11 :: Nil

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -3,7 +3,7 @@ addSbtPlugin("com.jsuereth"       % "sbt-pgp"                  % "2.0.0-M2")
 addSbtPlugin("org.scoverage"      % "sbt-scoverage"            % "1.5.1")
 addSbtPlugin("com.geirsson"       % "sbt-scalafmt"             % "1.5.1")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.5.0")
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "0.6.27")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "0.6.28")
 addSbtPlugin("com.typesafe.sbt"   % "sbt-ghpages"              % "0.6.2")
 addSbtPlugin("com.eed3si9n"       % "sbt-unidoc"               % "0.4.2")
 


### PR DESCRIPTION
- [x] Scala.js support https://github.com/scala-js/scala-js/issues/3738
  - It hits a bug of Scala compiler https://github.com/scala/bug/issues/11534 so we probably need to wait Scala 2.12.10, which will have this fix https://github.com/scala/scala/pull/8261