### PR TITLE
airframe-http-recorder: Support custom recording 

### DIFF
--- a/airframe-http-recorder/README.md
+++ b/airframe-http-recorder/README.md
@@ -35,7 +35,6 @@ import com.twitter.finagle.http.{Request,Response}
 // and make actual requests the destination for non-recorded requests.
 val recorderConfig = HttpRecorderConfig(destUri = "https://www.google.com")
 withResource(HttpRecorder.createRecorderProxy(recorderConfig)) { server =>
-  server.start
 
   // Create an HTTP client. This example uses Finagle's http client implementation
   val client = FinagleClient.newSyncClient(server.localAddress)  // "localhost:(port number)"
@@ -50,7 +49,6 @@ withResource(HttpRecorder.createRecorderProxy(recorderConfig)) { server =>
 
 // Create a proxy server only for recording server responses
 withResource(HttpRecorder.createRecordOnlyServer(recorderConfig)) { server =>
-  server.start
   val addr = server.localAddress // "localhost:(port number)"
   // Requests to the local server will be recorded
 
@@ -60,7 +58,6 @@ withResource(HttpRecorder.createRecordOnlyServer(recorderConfig)) { server =>
 
 // Create a replay server that returns recorded responses for matching requests 
 withResource(HttpRecorder.createReplayOnlyServer(recorderConfig)) { server =>
-  server.start
   val addr = server.localAddress // "localhost:(port number)"
   // Requests to the local server will return the recorded responses
 }
@@ -76,8 +73,6 @@ import com.twitter.finagle.http.{Request,Response}
 
 val recorderConfig = HttpRecorderConfig(sessionName="my-recording")
 val response = withResource(HttpRecorder.createProgrammableServer(recorderConfig)) { server =>
-  server.start
-
   // Add custom server responses
   val request = Request("/index.html")
   val response = Response()

--- a/airframe-http-recorder/README.md
+++ b/airframe-http-recorder/README.md
@@ -53,7 +53,8 @@ import wvlet.airframe.http.recorder._
 import wvlet.airframe.control.Control._
 import com.twitter.finagle.http.{Request,Response}
 
-val response = withResource(HttpRecorder.createProgrammableServer { recorder =>
+val recorderConfig = HttpRecorderConfig(destUri = "localhost")
+val response = withResource(HttpRecorder.createProgrammableServer(recorderConfig) { recorder =>
   // Program server responses instead of recodring
   val request = Request("/index.html")
   val response = Response()

--- a/airframe-http-recorder/README.md
+++ b/airframe-http-recorder/README.md
@@ -4,6 +4,14 @@ airframe-http-recorder
 airframe-http-recorder is an HTTP server for recording and replaying HTTP responses.
 This is useful for testing HTTP server interactions in an environment with limited resources (e.g., CI servers) 
 
+With HttpRecorder, you can:
+- Create a proxy server to the actual server and record the responses automatically.
+  - This reduces the burden of writing mock servers and dummy responses.
+- Record custom HTTP request/response pairs. 
+  - This is useful for simulating server failures (e.g., returning 5xx responses)
+- Replay recorded responses, stored in SQLite databases.
+  - This is useful for running HTTP server/client integration tests on CI, without actually accessing the real destination servers.
+
 ## Usage
 
 **build.sbt**
@@ -16,18 +24,27 @@ libraryDependencies += "org.wvlet.airframe" %% "airframe-http-recorder" %% (vers
 ### Record & Replay
 
 ```scala
-import wvlet.airframe.http.recorder._
-import wvlet.airframe.control.Control._
 
-val recorderConfig = 
-  HttpRecorderConfig(destUri = "https://wvlet.org", sessionName = "airframe")
+import wvlet.airframe.control.Control._
+import wvlet.airframe.http.recorder.{HttpRecorder,HttpRecorderConfig}
+import wvlet.airframe.http.finagle.FinagleClient
+import com.twitter.finagle.http.Status
+import com.twitter.finagle.http.{Request,Response}
 
 // Create a proxy server that will record responses for matching requests,
 // and make actual requests the destination for non-recorded requests.
+val recorderConfig = HttpRecorderConfig(destUri = "https://www.google.com")
 withResource(HttpRecorder.createRecorderProxy(recorderConfig)) { server =>
   server.start
-  val addr = server.localAddress // "localhost:(port number)"
+
+  // Create an HTTP client. This example uses Finagle's http client implementation
+  val client = FinagleClient.newSyncClient(server.localAddress)  // "localhost:(port number)"
+
   // Requests to the local server will be recorded
+  val response = client.send(Request("/"))
+
+  // You can record your own dummy responses
+  server.record(Request("/dummy"), Response(Status.NotFound))
 }
 
 
@@ -36,6 +53,9 @@ withResource(HttpRecorder.createRecordOnlyServer(recorderConfig)) { server =>
   server.start
   val addr = server.localAddress // "localhost:(port number)"
   // Requests to the local server will be recorded
+
+  // If necessary, add custom request-response pairs
+  server.recordIfNotExists(Request("/dummy"), Response(Status.Ok))
 }
 
 // Create a replay server that returns recorded responses for matching requests 
@@ -44,30 +64,34 @@ withResource(HttpRecorder.createReplayOnlyServer(recorderConfig)) { server =>
   val addr = server.localAddress // "localhost:(port number)"
   // Requests to the local server will return the recorded responses
 }
+
 ```
 
-### Programmable
+### Programmable HttpRecorderServer
 
 ```scala
 import wvlet.airframe.http.recorder._
 import wvlet.airframe.control.Control._
 import com.twitter.finagle.http.{Request,Response}
 
-val recorderConfig = HttpRecorderConfig(destUri = "localhost")
-val response = withResource(HttpRecorder.createProgrammableServer(recorderConfig) { recorder =>
-  // Program server responses instead of recodring
+val recorderConfig = HttpRecorderConfig(sessionName="my-recording")
+val response = withResource(HttpRecorder.createProgrammableServer(recorderConfig)) { server =>
+  server.start
+
+  // Add custom server responses
   val request = Request("/index.html")
   val response = Response()
   response.setContentString("Hello World!")
-  
-  recorder.record(request, response)
-  
-}) { server =>
-  server.start
+  server.record(request, response)
+
   val addr = server.localAddress // "localhost:(port number)"
   // Requests to the local server will return the programmed responses
 }
 ```
+
+If you don't need to persist your recoded responsoe (e.g., in unit tests), use
+`HttpRecorder.createInMemoryProgrammableServer`. The recorded responses wiil be
+discarded after closing the server.
 
 
 ## Related Projects

--- a/airframe-http-recorder/src/main/scala/wvlet/airframe/http/recorder/HttpRecordStore.scala
+++ b/airframe-http-recorder/src/main/scala/wvlet/airframe/http/recorder/HttpRecordStore.scala
@@ -38,7 +38,7 @@ class HttpRecordStore(val recorderConfig: HttpRecorderConfig, dropSession: Boole
     s"create index if not exists ${recordTableName}_index on ${recordTableName} (session, requestHash)")
   // TODO: Detect schema change
   if (dropSession) {
-    dropSession
+    clearSession
   }
 
   def clearSession: Unit = {

--- a/airframe-http-recorder/src/main/scala/wvlet/airframe/http/recorder/HttpRecordStore.scala
+++ b/airframe-http-recorder/src/main/scala/wvlet/airframe/http/recorder/HttpRecordStore.scala
@@ -38,6 +38,10 @@ class HttpRecordStore(val recorderConfig: HttpRecorderConfig, dropSession: Boole
     s"create index if not exists ${recordTableName}_index on ${recordTableName} (session, requestHash)")
   // TODO: Detect schema change
   if (dropSession) {
+    dropSession
+  }
+
+  def clearSession: Unit = {
     warn(s"Deleting old session records for session:${recorderConfig.sessionName}")
     connectionPool.executeUpdate(s"delete from ${recordTableName} where session = '${recorderConfig.sessionName}'")
   }
@@ -75,13 +79,13 @@ class HttpRecordStore(val recorderConfig: HttpRecorderConfig, dropSession: Boole
     }
   }
 
-  def findNext(request: Request): Option[HttpRecord] = {
+  def findNext(request: Request, incrementHitCount: Boolean = true): Option[HttpRecord] = {
     val rh = requestHash(request)
 
     // If there are multiple records for the same request, use the counter to find
     // n-th request, where n is the access count to the same path
     val counter  = requestCounter.getOrElseUpdate(rh, new AtomicInteger())
-    val hitCount = counter.getAndIncrement()
+    val hitCount = if (incrementHitCount) counter.getAndIncrement() else counter.get()
     trace(s"findNext: request hash: ${rh} for ${request}, hitCount: ${hitCount}")
     connectionPool.queryWith(
       // Get the next request matching the requestHash
@@ -115,6 +119,8 @@ class HttpRecordStore(val recorderConfig: HttpRecorderConfig, dropSession: Boole
       responseBody = response.contentString,
       createdAt = Instant.now()
     )
+
+    trace(s"Recording ${request} -> ${entry}")
     connectionPool.withConnection { conn =>
       entry.insertInto(recordTableName, conn)
     }
@@ -139,6 +145,8 @@ class HttpRecordStore(val recorderConfig: HttpRecorderConfig, dropSession: Boole
     val prefix = HttpRecorder.computeRequestHash(request, recorderConfig)
 
     val httpHeadersForHash = filterHeaders(request, recorderConfig.lowerCaseHeaderExcludePrefixes)
+
+    trace(s"http headers for request ${request}: ${httpHeadersForHash.mkString(",")}")
 
     httpHeadersForHash match {
       case headers if headers.isEmpty => prefix.hashCode * 13

--- a/airframe-http-recorder/src/main/scala/wvlet/airframe/http/recorder/HttpRecorder.scala
+++ b/airframe-http-recorder/src/main/scala/wvlet/airframe/http/recorder/HttpRecorder.scala
@@ -103,7 +103,11 @@ object HttpRecorder extends LogSupport {
   def createRecorderProxy(recorderConfig: HttpRecorderConfig,
                           dropExistingSession: Boolean = false): HttpRecorderServer = {
     val recorder = newRecordStoreForRecording(recorderConfig, dropExistingSession)
-    new HttpRecorderServer(recorder, HttpRecorderServer.newRecordProxyService(recorder, newDestClient(recorderConfig)))
+    val server = new HttpRecorderServer(
+      recorder,
+      HttpRecorderServer.newRecordProxyService(recorder, newDestClient(recorderConfig)))
+    server.start
+    server
   }
 
   /**
@@ -112,7 +116,10 @@ object HttpRecorder extends LogSupport {
   def createRecordOnlyServer(recorderConfig: HttpRecorderConfig,
                              dropExistingSession: Boolean = true): HttpRecorderServer = {
     val recorder = newRecordStoreForRecording(recorderConfig, dropExistingSession)
-    new HttpRecorderServer(recorder, HttpRecorderServer.newRecordingService(recorder, newDestClient(recorderConfig)))
+    val server =
+      new HttpRecorderServer(recorder, HttpRecorderServer.newRecordingService(recorder, newDestClient(recorderConfig)))
+    server.start
+    server
   }
 
   /**
@@ -122,7 +129,9 @@ object HttpRecorder extends LogSupport {
   def createReplayOnlyServer(recorderConfig: HttpRecorderConfig): FinagleServer = {
     val recorder = new HttpRecordStore(recorderConfig)
     // Return the server instance as FinagleServer to avoid further recording
-    new HttpRecorderServer(recorder, HttpRecorderServer.newReplayService(recorder))
+    val server = new HttpRecorderServer(recorder, HttpRecorderServer.newReplayService(recorder))
+    server.start
+    server
   }
 
   /**
@@ -131,7 +140,9 @@ object HttpRecorder extends LogSupport {
     */
   def createProgrammableServer(recorderConfig: HttpRecorderConfig): HttpRecorderServer = {
     val recorder = new HttpRecordStore(recorderConfig)
-    new HttpRecorderServer(recorder, HttpRecorderServer.newReplayService(recorder))
+    val server   = new HttpRecorderServer(recorder, HttpRecorderServer.newReplayService(recorder))
+    server.start
+    server
   }
 
   /**

--- a/airframe-http-recorder/src/main/scala/wvlet/airframe/http/recorder/HttpRecorder.scala
+++ b/airframe-http-recorder/src/main/scala/wvlet/airframe/http/recorder/HttpRecorder.scala
@@ -113,8 +113,8 @@ object HttpRecorder extends LogSupport {
     * Creates an HTTP server that returns programmed HTTP responses.
     * If no matching record is found, use the given fallback handler.
     */
-  def createProgrammableServer(programmer: HttpRecordStore => Unit): FinagleServer = {
-    val recorderConfig = HttpRecorderConfig("localhost")
+  def createProgrammableServer(recorderConfig: HttpRecorderConfig = HttpRecorderConfig(destUri = "localhost"))(
+      programmer: HttpRecordStore => Unit): FinagleServer = {
     val recorder = new HttpRecordStore(recorderConfig, true) {
       override def requestHash(request: Request): Int = {
         computeRequestHash(request, recorderConfig)

--- a/airframe-http-recorder/src/main/scala/wvlet/airframe/http/recorder/HttpRecorder.scala
+++ b/airframe-http-recorder/src/main/scala/wvlet/airframe/http/recorder/HttpRecorder.scala
@@ -26,9 +26,9 @@ import wvlet.airframe.http.finagle.FinagleServer
 import wvlet.log.LogSupport
 import wvlet.log.io.IOUtil
 
-case class HttpRecorderConfig(destUri: String,
+case class HttpRecorderConfig(destUri: String = "localhost",
                               sessionName: String = "default",
-                              expirationTime: String = "1w",
+                              expirationTime: String = "1w", // Delete recorded response in a week by default
                               // the folder to store response records
                               storageFolder: String = "fixtures",
                               recordTableName: String = "record",
@@ -53,8 +53,14 @@ case class HttpRecorderConfig(destUri: String,
   */
 object HttpRecorder extends LogSupport {
 
-  // Ignore Finagle's tracing IDs.
-  def defaultExcludeHeaderPrefixes: Seq[String] = Seq("date", "x-b3-", "finagle-")
+  // Http headers to ignore for recording and hashing purposes
+  def defaultExcludeHeaderPrefixes: Seq[String] = Seq(
+    "date", // unstable header
+    "x-b3-", // Finagle's tracing IDs
+    "finagle-", // Finagle specific headers
+    "host", // The host value can be changed
+    "content-length" // this can be 0 (or missing)
+  )
 
   private def newDestClient(recorderConfig: HttpRecorderConfig): Service[Request, Response] = {
     debug(s"dest: ${recorderConfig.destAddress}")
@@ -87,7 +93,8 @@ object HttpRecorder extends LogSupport {
     * Creates an HTTP proxy server that will return recorded responses. If no record is found, it will
     * actually send the request to the destination server and record the response.
     */
-  def createRecorderProxy(recorderConfig: HttpRecorderConfig, dropExistingSession: Boolean = false): FinagleServer = {
+  def createRecorderProxy(recorderConfig: HttpRecorderConfig,
+                          dropExistingSession: Boolean = false): HttpRecorderServer = {
     val recorder = newRecordStoreForRecording(recorderConfig, dropExistingSession)
     new HttpRecorderServer(recorder, HttpRecorderServer.newRecordProxyService(recorder, newDestClient(recorderConfig)))
   }
@@ -95,7 +102,8 @@ object HttpRecorder extends LogSupport {
   /**
     * Creates an HTTP server that will record HTTP responses.
     */
-  def createRecordOnlyServer(recorderConfig: HttpRecorderConfig, dropExistingSession: Boolean = true): FinagleServer = {
+  def createRecordOnlyServer(recorderConfig: HttpRecorderConfig,
+                             dropExistingSession: Boolean = true): HttpRecorderServer = {
     val recorder = newRecordStoreForRecording(recorderConfig, dropExistingSession)
     new HttpRecorderServer(recorder, HttpRecorderServer.newRecordingService(recorder, newDestClient(recorderConfig)))
   }
@@ -106,6 +114,7 @@ object HttpRecorder extends LogSupport {
     */
   def createReplayOnlyServer(recorderConfig: HttpRecorderConfig): FinagleServer = {
     val recorder = new HttpRecordStore(recorderConfig)
+    // Return the server instance as FinagleServer to avoid further recording
     new HttpRecorderServer(recorder, HttpRecorderServer.newReplayService(recorder))
   }
 
@@ -113,15 +122,17 @@ object HttpRecorder extends LogSupport {
     * Creates an HTTP server that returns programmed HTTP responses.
     * If no matching record is found, use the given fallback handler.
     */
-  def createProgrammableServer(recorderConfig: HttpRecorderConfig = HttpRecorderConfig(destUri = "localhost"))(
-      programmer: HttpRecordStore => Unit): FinagleServer = {
-    val recorder = new HttpRecordStore(recorderConfig, true) {
-      override def requestHash(request: Request): Int = {
-        computeRequestHash(request, recorderConfig)
-      }
-    }
-    programmer(recorder)
+  def createProgrammableServer(recorderConfig: HttpRecorderConfig): HttpRecorderServer = {
+    val recorder = new HttpRecordStore(recorderConfig)
     new HttpRecorderServer(recorder, HttpRecorderServer.newReplayService(recorder))
+  }
+
+  /**
+    * Create an in-memory programmable server, whose recorded response will be discarded after closing the server.
+    * This is useful for debugging HTTP clients
+    */
+  def createInMemoryProgrammableServer: HttpRecorderServer = {
+    createProgrammableServer(HttpRecorderConfig(sessionName = ":memory:"))
   }
 
   def defaultFallBackHandler = {

--- a/airframe-http-recorder/src/main/scala/wvlet/airframe/http/recorder/HttpRecorder.scala
+++ b/airframe-http-recorder/src/main/scala/wvlet/airframe/http/recorder/HttpRecorder.scala
@@ -39,7 +39,14 @@ case class HttpRecorderConfig(destUri: String = "localhost",
                               excludeHeaderPrefixes: Seq[String] = HttpRecorder.defaultExcludeHeaderPrefixes,
                               fallBackHandler: Service[Request, Response] = HttpRecorder.defaultFallBackHandler) {
 
-  def sqliteFilePath   = s"${storageFolder}/${sessionName}.sqlite"
+  def sqliteFilePath = {
+    if (sessionName == ":memory:") {
+      ":memory:"
+    } else {
+      s"${storageFolder}/${sessionName}.sqlite"
+    }
+  }
+
   lazy val serverPort  = if (port == -1) IOUtil.unusedPort else port
   lazy val destAddress = ServerAddress(destUri)
 

--- a/airframe-http-recorder/src/test/scala/wvlet/airframe/http/recorder/HttpRecorderTest.scala
+++ b/airframe-http-recorder/src/test/scala/wvlet/airframe/http/recorder/HttpRecorderTest.scala
@@ -123,7 +123,7 @@ class HttpRecorderTest extends AirframeSpec {
 
   }
 
-  "programmable server" taggedAs working in {
+  "programmable server" in {
     val response = withResource(HttpRecorder.createInMemoryProgrammableServer) { server =>
       server.clearSession
       server.start

--- a/airframe-http-recorder/src/test/scala/wvlet/airframe/http/recorder/HttpRecorderTest.scala
+++ b/airframe-http-recorder/src/test/scala/wvlet/airframe/http/recorder/HttpRecorderTest.scala
@@ -123,17 +123,16 @@ class HttpRecorderTest extends AirframeSpec {
 
   }
 
-  "programmable server" in {
-    val response = withResource(HttpRecorder.createProgrammableServer() { recorder =>
-      val request = Request("/index.html")
+  "programmable server" taggedAs working in {
+    val response = withResource(HttpRecorder.createInMemoryProgrammableServer) { server =>
+      server.clearSession
+      server.start
 
+      val request  = Request("/index.html")
       val response = Response()
       response.setContentString("Hello World!")
+      server.recordIfNotExists(request, response)
 
-      recorder.record(request, response)
-
-    }) { server =>
-      server.start
       withClient(server.localAddress) { client =>
         val request = Request("/index.html")
 

--- a/airframe-http-recorder/src/test/scala/wvlet/airframe/http/recorder/HttpRecorderTest.scala
+++ b/airframe-http-recorder/src/test/scala/wvlet/airframe/http/recorder/HttpRecorderTest.scala
@@ -49,7 +49,6 @@ class HttpRecorderTest extends AirframeSpec {
     val path = "/airframe/"
     val response: Response =
       withResource(HttpRecorder.createRecordOnlyServer(recorderConfig, dropExistingSession = true)) { server =>
-        server.start
         withClient(server.localAddress) { client =>
           val response = client(Request(path)).map { response =>
             debug(response)
@@ -60,7 +59,6 @@ class HttpRecorderTest extends AirframeSpec {
       }
 
     val replayResponse: Response = withResource(HttpRecorder.createReplayOnlyServer(recorderConfig)) { server =>
-      server.start
       withClient(server.localAddress) { client =>
         val response = client(Request(path)).map { response =>
           debug(response)
@@ -78,7 +76,6 @@ class HttpRecorderTest extends AirframeSpec {
 
     // Check non-recorded response
     val errorResponse = withResource(HttpRecorder.createReplayOnlyServer(recorderConfig)) { server =>
-      server.start
       withClient(server.localAddress) { client =>
         val response = client(Request("/non-recorded-path.html")).map { response =>
           debug(response)
@@ -97,7 +94,6 @@ class HttpRecorderTest extends AirframeSpec {
 
     // Recording
     withResource(HttpRecorder.createRecorderProxy(recorderConfig, dropExistingSession = true)) { server =>
-      server.start
       withClient(server.localAddress) { client =>
         val request = Request("/airframe/")
         val r1      = Await.result(client(request))
@@ -111,7 +107,6 @@ class HttpRecorderTest extends AirframeSpec {
     val replayConfig =
       HttpRecorderConfig(destUri = "https://wvlet.org", sessionName = "airframe-path-through")
     withResource(HttpRecorder.createRecorderProxy(replayConfig)) { server =>
-      server.start
       withClient(server.localAddress) { client =>
         val request = Request("/airframe/")
         val r1      = Await.result(client(request))
@@ -126,7 +121,6 @@ class HttpRecorderTest extends AirframeSpec {
   "programmable server" in {
     val response = withResource(HttpRecorder.createInMemoryProgrammableServer) { server =>
       server.clearSession
-      server.start
 
       val request  = Request("/index.html")
       val response = Response()

--- a/airframe-http-recorder/src/test/scala/wvlet/airframe/http/recorder/HttpRecorderTest.scala
+++ b/airframe-http-recorder/src/test/scala/wvlet/airframe/http/recorder/HttpRecorderTest.scala
@@ -124,7 +124,7 @@ class HttpRecorderTest extends AirframeSpec {
   }
 
   "programmable server" in {
-    val response = withResource(HttpRecorder.createProgrammableServer { recorder =>
+    val response = withResource(HttpRecorder.createProgrammableServer() { recorder =>
       val request = Request("/index.html")
 
       val response = Response()


### PR DESCRIPTION
- [x] Support custom recorder configs in the programmable server
- [x] Add in-memory programmable server for debugging purpose
- [x] Support recording custom request/response pairs in HttpRecorderServer

@takezoe This PR enables combining real server responses + programmed responses, which will be useful for simulating server failures. 