### PR TITLE
airframe-http-recorder: Support binary requests and responses

### DIFF
--- a/airframe-http-recorder/src/main/scala/wvlet/airframe/http/recorder/HttpRecord.scala
+++ b/airframe-http-recorder/src/main/scala/wvlet/airframe/http/recorder/HttpRecord.scala
@@ -12,11 +12,10 @@
  * limitations under the License.
  */
 package wvlet.airframe.http.recorder
-import java.nio.charset.StandardCharsets
 import java.sql.{Connection, ResultSet}
 import java.time.Instant
 
-import com.twitter.finagle.http.{MediaType, Request, Response, Status, Version}
+import com.twitter.finagle.http.{Response, Status, Version}
 import com.twitter.io.Buf
 import wvlet.airframe.codec._
 import wvlet.airframe.control.Control.withResource
@@ -49,15 +48,8 @@ case class HttpRecord(session: String,
       r.headerMap.set(x._1, x._2)
     }
 
-    val contentBytes = responseHeader.find(h => h._1.equalsIgnoreCase("content-type")) match {
-      case Some(x) if x._2 == MediaType.OctetStream =>
-        // Decode binary contents with Base64
-        HttpRecordStore.decodeFromBase64(responseBody)
-      case _ =>
-        // Read as regular strings
-        responseBody.getBytes(StandardCharsets.UTF_8)
-    }
-
+    // Decode binary contents with Base64
+    val contentBytes = HttpRecordStore.decodeFromBase64(responseBody)
     r.content = Buf.ByteArray.Owned(contentBytes)
     r.contentLength = contentBytes.length
     r

--- a/airframe-http-recorder/src/main/scala/wvlet/airframe/http/recorder/HttpRecorder.scala
+++ b/airframe-http-recorder/src/main/scala/wvlet/airframe/http/recorder/HttpRecorder.scala
@@ -16,7 +16,7 @@ package wvlet.airframe.http.recorder
 import java.util.Locale
 
 import com.twitter.finagle.builder.ClientBuilder
-import com.twitter.finagle.http.{Request, Response, Status}
+import com.twitter.finagle.http.{MediaType, Request, Response, Status}
 import com.twitter.finagle.service.RetryPolicy
 import com.twitter.finagle.{Http, Service}
 import com.twitter.util.Future
@@ -162,7 +162,14 @@ object HttpRecorder extends LogSupport {
   }
 
   private[recorder] def computeRequestHash(request: Request, recorderConfig: HttpRecorderConfig): Int = {
-    s"${request.method.toString()}:${recorderConfig.destAddress.hostAndPort}${request.uri}:${request.contentString.hashCode}".hashCode
+    val contentHash = request.contentType match {
+      case Some(MediaType.OctetStream) =>
+        request.content.hashCode()
+      case _ =>
+        request.contentString.hashCode
+    }
+
+    s"${request.method.toString()}:${recorderConfig.destAddress.hostAndPort}${request.uri}:${contentHash}".hashCode
   }
 
 }

--- a/airframe-http-recorder/src/main/scala/wvlet/airframe/http/recorder/HttpRecorder.scala
+++ b/airframe-http-recorder/src/main/scala/wvlet/airframe/http/recorder/HttpRecorder.scala
@@ -39,8 +39,10 @@ case class HttpRecorderConfig(destUri: String = "localhost",
                               excludeHeaderPrefixes: Seq[String] = HttpRecorder.defaultExcludeHeaderPrefixes,
                               fallBackHandler: Service[Request, Response] = HttpRecorder.defaultFallBackHandler) {
 
+  def isInMemory: Boolean = sessionName == ":memory:"
+
   def sqliteFilePath = {
-    if (sessionName == ":memory:") {
+    if (isInMemory) {
       ":memory:"
     } else {
       s"${storageFolder}/${sessionName}.sqlite"


### PR DESCRIPTION
@takezoe This will be useful to record binary responses (e.g., from S3) 