### PR TITLE
Use airframe-log for AirSpec logging

### DIFF
--- a/airspec/src/main/scala/wvlet/airframe/spec/runner/AirSpecLogger.scala
+++ b/airspec/src/main/scala/wvlet/airframe/spec/runner/AirSpecLogger.scala
@@ -18,14 +18,16 @@ import wvlet.airframe.log.AnsiColorPalette
 import wvlet.airframe.metrics.ElapsedTime
 import wvlet.airframe.spec.runner.AirSpecTask.AirSpecEvent
 import wvlet.airframe.spec.spi.AirSpecException
-import wvlet.log.LogFormatter
+import wvlet.log.{LogFormatter, LogRecord, Logger}
 
 /**
   *
   */
 private[spec] class AirSpecLogger(sbtLoggers: Array[sbt.testing.Logger]) extends AnsiColorPalette {
-
   private val useAnciColor = sbtLoggers.forall(_.ansiCodesSupported())
+
+  private val airSpecLogger = Logger("wvlet.airframe.spec.AirSpec")
+  airSpecLogger.setFormatter(LogFormatter.BareFormatter)
 
   def withColor(colorEsc: String, s: String) = {
     if (useAnciColor)
@@ -34,24 +36,18 @@ private[spec] class AirSpecLogger(sbtLoggers: Array[sbt.testing.Logger]) extends
       s
   }
 
-  private def log(body: sbt.testing.Logger => Unit) {
-    for (l <- sbtLoggers) {
-      body(l)
-    }
-  }
-
   private def info(m: String): Unit = {
-    log(_.info(m))
+    airSpecLogger.info(m)
   }
 
   private def warn(m: String): Unit = {
     val msg = withColor(YELLOW, m)
-    log(_.warn(msg))
+    airSpecLogger.warn(msg)
   }
 
   private def error(m: String): Unit = {
     val msg = withColor(BRIGHT_RED, m)
-    log(_.error(msg))
+    airSpecLogger.error(msg)
   }
 
   def logSpecName(specName: String): Unit = {


### PR DESCRIPTION
This PR improves the log display of AirSpec:
![image](https://user-images.githubusercontent.com/57538/62817652-08da8700-baef-11e9-88ed-4e86eba4cca1.png)

Using sbt's logger add `[info]` header for each line and wastes the space. And also it is not synchronized with other airframe-log messages, so it makes difficult to debug test cases.