### PR TITLE
airspec: Properly filter test methods of sub specs

### DIFF
--- a/airspec/src/main/scala/wvlet/airframe/spec/AirSpec.scala
+++ b/airspec/src/main/scala/wvlet/airframe/spec/AirSpec.scala
@@ -40,7 +40,7 @@ private[spec] trait AirSpecSpi {
    */
   protected var _methodSurfaces: Seq[MethodSurface] = compat.methodSurfacesOf(this.getClass)
   private[spec] def testMethods: Seq[MethodSurface] = {
-    _methodSurfaces.filter(x => x.isPublic)
+    AirSpecSpi.collectTestMethods(_methodSurfaces)
   }
 
   private[spec] var specName: String = {
@@ -90,6 +90,10 @@ private[spec] trait AirSpecSpi {
 }
 
 private[spec] object AirSpecSpi {
+
+  private[spec] def collectTestMethods(methodSurfaces: Seq[MethodSurface]): Seq[MethodSurface] = {
+    methodSurfaces.filter(_.isPublic)
+  }
 
   /**
     * This wrapper is used for accessing protected methods in AirSpec

--- a/airspec/src/main/scala/wvlet/airframe/spec/runner/AirSpecLogger.scala
+++ b/airspec/src/main/scala/wvlet/airframe/spec/runner/AirSpecLogger.scala
@@ -71,7 +71,7 @@ private[spec] class AirSpecLogger(sbtLoggers: Array[sbt.testing.Logger]) extends
   }
 
   def logSpecName(specName: String, indentLevel: Int): Unit = {
-    info(s"${indent(indentLevel)} ${withColor(BRIGHT_GREEN, specName)}${withColor(GRAY, ":")}")
+    info(s"${indent(indentLevel)}${withColor(BRIGHT_GREEN, specName)}${withColor(GRAY, ":")}")
   }
 
   def logEvent(e: AirSpecEvent, indentLevel: Int = 0): Unit = {

--- a/airspec/src/main/scala/wvlet/airframe/spec/spi/AirSpecContext.scala
+++ b/airspec/src/main/scala/wvlet/airframe/spec/spi/AirSpecContext.scala
@@ -76,8 +76,8 @@ trait AirSpecContext {
 object AirSpecContext {
 
   implicit class AirSpecContextAccess(val context: AirSpecContext) extends AnyVal {
-    def callRunInternal(spec: AirSpecSpi, testMethods: Seq[MethodSurface]): AirSpecSpi = {
-      context.runInternal(spec, testMethods)
+    def callRunInternal(spec: AirSpecSpi, specMethods: Seq[MethodSurface]): AirSpecSpi = {
+      context.runInternal(spec, AirSpecSpi.collectTestMethods(specMethods))
     }
     def callNewSpec(specSurface: Surface): AirSpecSpi = context.newSpec(specSurface)
   }

--- a/examples/src/test/scala/wvlet/airframe/examples/airspec/AIrSpec_01_Basic.scala
+++ b/examples/src/test/scala/wvlet/airframe/examples/airspec/AIrSpec_01_Basic.scala
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.examples.airspec
+
+import wvlet.airframe.spec.AirSpec
+
+/**
+  *
+  */
+object AirSpec_01_Basic extends AirSpec {
+
+  def testWithAssertion: Unit = {
+    assert(1 == 1)
+    assert("hello" == "hello")
+  }
+
+  def testWithShouldBe: Unit = {
+    Seq().size shouldBe 0
+    Seq() shouldBe empty
+  }
+
+  def testObjectEquality: Unit = {
+    val s1 = new String("hello")
+    val s2 = s1
+    val s3 = new String("hello")
+
+    s1 shouldBe s2
+    s1 shouldBeTheSameInstanceAs s2
+    s1 shouldNotBeTheSameInstanceAs s3
+  }
+}

--- a/examples/src/test/scala/wvlet/airframe/examples/airspec/AirSpec_02_ReuseTests.scala
+++ b/examples/src/test/scala/wvlet/airframe/examples/airspec/AirSpec_02_ReuseTests.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.examples.airspec
+
+import wvlet.airframe.spec.AirSpec
+import wvlet.airframe.spec.spi.AirSpecContext
+
+/**
+  *
+  */
+class AirSpec_02_ReuseTests extends AirSpec {
+
+  // A template for reusable test cases
+  class Fixture[A](data: Seq[A]) extends AirSpec {
+    override protected def beforeAll: Unit = {
+      info(s"Run tests for ${data}")
+    }
+    def emptyTest: Unit = {
+      data shouldNotBe empty
+    }
+    def sizeTest: Unit = {
+      data.length shouldBe data.size
+    }
+  }
+
+  def test(context: AirSpecContext): Unit = {
+    context.run(new Fixture(Seq(1, 2)))
+    context.run(new Fixture(Seq("A", "B", "C")))
+  }
+}

--- a/examples/src/test/scala/wvlet/airframe/examples/airspec/AirSpec_03_DI.scala
+++ b/examples/src/test/scala/wvlet/airframe/examples/airspec/AirSpec_03_DI.scala
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.examples.airspec
+
+import wvlet.airframe.Design
+import wvlet.airframe.spec.AirSpec
+
+/**
+  *
+  */
+object AirSpec_03_DI extends AirSpec {
+
+  case class Config(port: Int)
+  class MyService(val config: Config)
+
+  override protected def configure(design: Design): Design = {
+    design
+      .bind[Config].toInstance(Config(port = 8080))
+      .bind[MyService].toSingleton
+  }
+
+  // Injecting a service using DI
+  def test(service: MyService): Unit = {
+    info(s"service id: ${service.hashCode()}")
+    service.config.port shouldBe 8080
+  }
+
+  // The same service instance will be passed
+  def test2(service: MyService): Unit = {
+    info(s"service id: ${service.hashCode()}")
+    service.config.port shouldBe 8080
+  }
+}


### PR DESCRIPTION
- Fixing a bug that beforeAll can be called multiple times in forked tests.
- Add more examples 