### PR TITLE
airspec: Rename to wvlet.airspec

### DIFF
--- a/airframe-benchmark/src/test/scala/wvlet/airframe/benchmark/BenchmarkMainTest.scala
+++ b/airframe-benchmark/src/test/scala/wvlet/airframe/benchmark/BenchmarkMainTest.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.benchmark
 
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 
 /**
   *

--- a/airframe-canvas/src/test/scala/wvlet/airframe/canvas/CanvasTest.scala
+++ b/airframe-canvas/src/test/scala/wvlet/airframe/canvas/CanvasTest.scala
@@ -15,8 +15,8 @@ package wvlet.airframe.canvas
 import java.nio.ByteBuffer
 
 import wvlet.airframe.control.Control
-import wvlet.airframe.spec.AirSpec
-import wvlet.airframe.spec.spi.PropertyCheck
+import wvlet.airspec.spi.PropertyCheck
+import wvlet.airspec.AirSpec
 
 /**
   *

--- a/airframe-canvas/src/test/scala/wvlet/airframe/canvas/OffHeapMemoryAllocatorTest.scala
+++ b/airframe-canvas/src/test/scala/wvlet/airframe/canvas/OffHeapMemoryAllocatorTest.scala
@@ -12,7 +12,8 @@
  * limitations under the License.
  */
 package wvlet.airframe.canvas
-import wvlet.airframe.spec.AirSpec
+
+import wvlet.airspec.AirSpec
 
 /**
   *

--- a/airframe-codec/.jvm/src/test/scala/wvlet/airframe/codec/CodecSpec.scala
+++ b/airframe-codec/.jvm/src/test/scala/wvlet/airframe/codec/CodecSpec.scala
@@ -12,9 +12,9 @@
  * limitations under the License.
  */
 package wvlet.airframe.codec
-import wvlet.airframe.spec.AirSpec
 import wvlet.airframe.msgpack.spi.MessagePack
 import wvlet.airframe.surface.Surface
+import wvlet.airspec.AirSpec
 
 /**
   *

--- a/airframe-codec/.jvm/src/test/scala/wvlet/airframe/codec/JDBCCodecTest.scala
+++ b/airframe-codec/.jvm/src/test/scala/wvlet/airframe/codec/JDBCCodecTest.scala
@@ -16,10 +16,11 @@ package wvlet.airframe.codec
 import java.sql.{DriverManager, ResultSet}
 import java.util
 
-import wvlet.airframe.spec.AirSpec
 import wvlet.airframe.codec.JDBCCodec._
 import wvlet.airframe.msgpack.spi.MessagePack
+import wvlet.airspec.AirSpec
 import wvlet.log.io.IOUtil.withResource
+
 import scala.collection.compat._
 
 /**

--- a/airframe-codec/.jvm/src/test/scala/wvlet/airframe/codec/JSONCodecTest.scala
+++ b/airframe-codec/.jvm/src/test/scala/wvlet/airframe/codec/JSONCodecTest.scala
@@ -13,9 +13,9 @@
  */
 package wvlet.airframe.codec
 
-import wvlet.airframe.spec.AirSpec
 import wvlet.airframe.codec.JSONCodecTest.WithRawJSON
 import wvlet.airframe.json.{JSON, Json}
+import wvlet.airspec.AirSpec
 
 /**
   *

--- a/airframe-codec/.jvm/src/test/scala/wvlet/airframe/codec/MessageCodecTest.scala
+++ b/airframe-codec/.jvm/src/test/scala/wvlet/airframe/codec/MessageCodecTest.scala
@@ -13,9 +13,9 @@
  */
 package wvlet.airframe.codec
 
-import wvlet.airframe.spec.AirSpec
 import wvlet.airframe.codec.MessageCodecTest.ExtractTest
 import wvlet.airframe.codec.PrimitiveCodec.LongCodec
+import wvlet.airspec.AirSpec
 
 /**
   *

--- a/airframe-codec/.jvm/src/test/scala/wvlet/airframe/codec/MetricsCodecTest.scala
+++ b/airframe-codec/.jvm/src/test/scala/wvlet/airframe/codec/MetricsCodecTest.scala
@@ -12,10 +12,10 @@
  * limitations under the License.
  */
 package wvlet.airframe.codec
-import wvlet.airframe.spec.AirSpec
 import wvlet.airframe.metrics.{DataSize, ElapsedTime}
 import wvlet.airframe.msgpack.spi.MessagePack
 import wvlet.airframe.surface.{Surface, Zero}
+import wvlet.airspec.AirSpec
 
 /**
   *

--- a/airframe-codec/.jvm/src/test/scala/wvlet/airframe/codec/PrimitiveCodecTest.scala
+++ b/airframe-codec/.jvm/src/test/scala/wvlet/airframe/codec/PrimitiveCodecTest.scala
@@ -20,7 +20,7 @@ import org.scalacheck.util.Pretty
 import wvlet.airframe.json.JSON.JSONString
 import wvlet.airframe.msgpack.spi.MessagePack
 import wvlet.airframe.msgpack.spi.Value.StringValue
-import wvlet.airframe.spec.spi.PropertyCheck
+import wvlet.airspec.spi.PropertyCheck
 import wvlet.airframe.surface.{ArraySurface, GenericSurface, Surface}
 
 /**

--- a/airframe-codec/src/test/scala/wvlet/airframe/codec/DataTypeTest.scala
+++ b/airframe-codec/src/test/scala/wvlet/airframe/codec/DataTypeTest.scala
@@ -13,8 +13,8 @@
  */
 package wvlet.airframe.codec
 
-import wvlet.airframe.spec.AirSpec
 import wvlet.airframe.codec.DataType.Column
+import wvlet.airspec.AirSpec
 
 /**
   *

--- a/airframe-config/src/test/scala/wvlet/airframe/config/AirframeBootstrapTest.scala
+++ b/airframe-config/src/test/scala/wvlet/airframe/config/AirframeBootstrapTest.scala
@@ -13,8 +13,8 @@
  */
 package wvlet.airframe.config
 
-import wvlet.airframe.spec.AirSpec
 import wvlet.airframe.surface._
+import wvlet.airspec.AirSpec
 
 object AirframeBootstrapTest {
   case class AppConfig(name: String)

--- a/airframe-config/src/test/scala/wvlet/airframe/config/ConfigOverrideTest.scala
+++ b/airframe-config/src/test/scala/wvlet/airframe/config/ConfigOverrideTest.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.config
 
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 
 object ConfigOverrideTest {
   case class MyAppConfig(

--- a/airframe-config/src/test/scala/wvlet/airframe/config/ConfigPackageTest.scala
+++ b/airframe-config/src/test/scala/wvlet/airframe/config/ConfigPackageTest.scala
@@ -13,8 +13,8 @@
  */
 package wvlet.airframe.config
 import wvlet.airframe._
-import wvlet.airframe.spec.AirSpec
 import wvlet.airframe.surface.tag._
+import wvlet.airspec.AirSpec
 
 trait AppTag
 

--- a/airframe-config/src/test/scala/wvlet/airframe/config/ConfigProviderTest.scala
+++ b/airframe-config/src/test/scala/wvlet/airframe/config/ConfigProviderTest.scala
@@ -13,8 +13,6 @@
  */
 package wvlet.airframe.config
 
-import wvlet.airframe.spec.AirSpec
-
 object ConfigProviderTest {
 
   case class ConfigA(id: Int, fullName: String)
@@ -24,6 +22,7 @@ object ConfigProviderTest {
   }
 }
 import ConfigProviderTest._
+import wvlet.airspec.AirSpec
 
 /**
   *

--- a/airframe-config/src/test/scala/wvlet/airframe/config/ConfigTest.scala
+++ b/airframe-config/src/test/scala/wvlet/airframe/config/ConfigTest.scala
@@ -17,9 +17,9 @@ import java.io.{FileNotFoundException, FileOutputStream}
 import java.util.Properties
 
 import wvlet.airframe.config.PropertiesConfig.{ConfigKey, Prefix}
-import wvlet.airframe.spec.AirSpec
 import wvlet.log.io.IOUtil
 import wvlet.airframe.surface.tag._
+import wvlet.airspec.AirSpec
 
 trait AppScope
 trait SessionScope

--- a/airframe-config/src/test/scala/wvlet/airframe/config/NestedConfigTest.scala
+++ b/airframe-config/src/test/scala/wvlet/airframe/config/NestedConfigTest.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.config
 
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 
 /**
   *

--- a/airframe-config/src/test/scala/wvlet/airframe/config/NestedOverrideTest.scala
+++ b/airframe-config/src/test/scala/wvlet/airframe/config/NestedOverrideTest.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.config
 import wvlet.airframe.config.ConfigOverrideTest.MyAppConfig
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 
 object NestedOverrideTest {
   case class LogConfig(file: LogFileConfig)

--- a/airframe-config/src/test/scala/wvlet/airframe/config/YamlReaderTest.scala
+++ b/airframe-config/src/test/scala/wvlet/airframe/config/YamlReaderTest.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.config
 
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 import wvlet.log.io.Resource
 
 case class MyConfig(id: Int, fullName: String, port: Int = 8989)

--- a/airframe-control/src/test/scala/wvlet/airframe/control/ControlTest.scala
+++ b/airframe-control/src/test/scala/wvlet/airframe/control/ControlTest.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.control
 
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 
 object ControlTest {
   class A extends AutoCloseable {

--- a/airframe-control/src/test/scala/wvlet/airframe/control/ParallelTest.scala
+++ b/airframe-control/src/test/scala/wvlet/airframe/control/ParallelTest.scala
@@ -15,7 +15,7 @@ package wvlet.airframe.control
 
 import java.util.concurrent.atomic.AtomicInteger
 
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 
 import scala.language.postfixOps
 import scala.util.{Failure, Success, Try}

--- a/airframe-control/src/test/scala/wvlet/airframe/control/RetryTest.scala
+++ b/airframe-control/src/test/scala/wvlet/airframe/control/RetryTest.scala
@@ -14,7 +14,7 @@
 package wvlet.airframe.control
 
 import wvlet.airframe.control.Retry.{MaxRetryException, RetryContext}
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 
 /**
   *

--- a/airframe-di-macros/src/main/scala/wvlet/airframe/AirframeMacros.scala
+++ b/airframe-di-macros/src/main/scala/wvlet/airframe/AirframeMacros.scala
@@ -19,7 +19,7 @@ import scala.reflect.macros.{blackbox => sm}
 
 private[wvlet] object AirframeMacros {
 
-  private[airframe] class BindHelper[C <: Context](val c: C) {
+  private[wvlet] class BindHelper[C <: Context](val c: C) {
 
     import c.universe._
 

--- a/airframe-fluentd/src/test/scala/wvlet/airframe/fluentd/FluencyTest.scala
+++ b/airframe-fluentd/src/test/scala/wvlet/airframe/fluentd/FluencyTest.scala
@@ -18,8 +18,8 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 import javax.annotation.{PostConstruct, PreDestroy}
 import wvlet.airframe.codec.PrimitiveCodec.ValueCodec
-import wvlet.airframe.spec.AirSpec
 import wvlet.airframe._
+import wvlet.airspec.AirSpec
 import wvlet.log.LogSupport
 import wvlet.log.io.IOUtil
 

--- a/airframe-fluentd/src/test/scala/wvlet/airframe/fluentd/FluentdLoggerTest.scala
+++ b/airframe-fluentd/src/test/scala/wvlet/airframe/fluentd/FluentdLoggerTest.scala
@@ -12,9 +12,9 @@
  * limitations under the License.
  */
 package wvlet.airframe.fluentd
-import wvlet.airframe.spec.AirSpec
 import wvlet.airframe._
 import wvlet.airframe.fluentd.FluentdLoggerTest.{Logger1, Logger2, LoggerFactory1, LoggerFactory2}
+import wvlet.airspec.AirSpec
 import wvlet.log.LogLevel
 
 /**

--- a/airframe-fluentd/src/test/scala/wvlet/airframe/fluentd/MetricLoggerTest.scala
+++ b/airframe-fluentd/src/test/scala/wvlet/airframe/fluentd/MetricLoggerTest.scala
@@ -15,7 +15,7 @@ package wvlet.airframe.fluentd
 import java.lang.reflect.InvocationTargetException
 
 import wvlet.airframe.{Design, fluentd}
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 
 case class SampleMetric(time: Long, value: String) extends TaggedMetric {
   def metricTag = "sample"

--- a/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/FinagleClientTest.scala
+++ b/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/FinagleClientTest.scala
@@ -14,9 +14,9 @@
 package wvlet.airframe.http.finagle
 
 import com.twitter.finagle.http.{Request, Response, Status}
-import wvlet.airframe.spec.AirSpec
 import wvlet.airframe.control.Control.withResource
 import wvlet.airframe.http._
+import wvlet.airspec.AirSpec
 import wvlet.log.LogSupport
 import wvlet.log.io.IOUtil
 

--- a/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/FinagleRouterTest.scala
+++ b/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/FinagleRouterTest.scala
@@ -19,10 +19,10 @@ import com.twitter.finagle.Http
 import com.twitter.finagle.http.{Method, Request}
 import com.twitter.io.Buf.ByteArray
 import com.twitter.util.{Await, Future}
-import wvlet.airframe.spec.AirSpec
 import wvlet.airframe.codec.JSONCodec
 import wvlet.airframe.http._
 import wvlet.airframe.msgpack.spi.MessagePack
+import wvlet.airspec.AirSpec
 import wvlet.log.{LogLevel, LogSupport, Logger}
 
 case class RichInfo(version: String, name: String, details: RichNestedInfo)

--- a/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/FinagleServerFactoryTest.scala
+++ b/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/FinagleServerFactoryTest.scala
@@ -16,9 +16,9 @@ import com.twitter.finagle.{Http, Service}
 import com.twitter.finagle.http.{Request, Response, Status}
 import com.twitter.finagle.tracing.ConsoleTracer
 import com.twitter.util.{Await, Future}
-import wvlet.airframe.spec.AirSpec
 import wvlet.airframe.http.Router
 import wvlet.airframe.http.finagle.FinagleServer.FinagleService
+import wvlet.airspec.AirSpec
 import wvlet.log.io.IOUtil
 
 /**

--- a/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/FinagleTest.scala
+++ b/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/FinagleTest.scala
@@ -17,8 +17,8 @@ import java.nio.charset.StandardCharsets
 
 import com.twitter.finagle.http
 import com.twitter.finagle.http.Status
-import wvlet.airframe.spec.AirSpec
 import wvlet.airframe.http.HttpStatus
+import wvlet.airspec.AirSpec
 
 /**
   *

--- a/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/HttpFilterTest.scala
+++ b/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/HttpFilterTest.scala
@@ -16,8 +16,8 @@ package wvlet.airframe.http.finagle
 import com.twitter.finagle.Http
 import com.twitter.finagle.http.{Request, Response, Status, Version}
 import com.twitter.util.{Await, Future}
-import wvlet.airframe.spec.AirSpec
 import wvlet.airframe.http._
+import wvlet.airspec.AirSpec
 import wvlet.log.LogSupport
 import wvlet.log.io.IOUtil
 

--- a/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/MessagePackResponseTest.scala
+++ b/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/MessagePackResponseTest.scala
@@ -14,9 +14,9 @@
 package wvlet.airframe.http.finagle
 import com.twitter.finagle.{Http, http}
 import com.twitter.util.Await
-import wvlet.airframe.spec.AirSpec
 import wvlet.airframe.codec.MessageCodec
 import wvlet.airframe.http.{Endpoint, Router}
+import wvlet.airspec.AirSpec
 
 case class SampleResponse(id: Int, name: String)
 

--- a/airframe-http-recorder/src/test/scala/wvlet/airframe/http/recorder/HttpRecorderTest.scala
+++ b/airframe-http-recorder/src/test/scala/wvlet/airframe/http/recorder/HttpRecorderTest.scala
@@ -17,10 +17,9 @@ import com.twitter.finagle.Http
 import com.twitter.finagle.http.{MediaType, Request, Response, Status}
 import com.twitter.io.Buf
 import com.twitter.util.Await
-
-import wvlet.airframe.spec.AirSpec
 import wvlet.airframe.control.Control.withResource
 import wvlet.airframe.http.finagle.FinagleServer.FinagleService
+import wvlet.airspec.AirSpec
 
 import scala.util.Random
 

--- a/airframe-http/src/test/scala/wvlet/airframe/http/HttpClientTest.scala
+++ b/airframe-http/src/test/scala/wvlet/airframe/http/HttpClientTest.scala
@@ -18,7 +18,7 @@ import java.net._
 import java.util.concurrent.{ExecutionException, TimeoutException}
 
 import javax.net.ssl.{SSLHandshakeException, SSLKeyException, SSLPeerUnverifiedException}
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 
 /**
   *

--- a/airframe-http/src/test/scala/wvlet/airframe/http/HttpStatusTest.scala
+++ b/airframe-http/src/test/scala/wvlet/airframe/http/HttpStatusTest.scala
@@ -12,7 +12,8 @@
  * limitations under the License.
  */
 package wvlet.airframe.http
-import wvlet.airframe.spec.AirSpec
+
+import wvlet.airspec.AirSpec
 
 /**
   *

--- a/airframe-http/src/test/scala/wvlet/airframe/http/LongPathTest.scala
+++ b/airframe-http/src/test/scala/wvlet/airframe/http/LongPathTest.scala
@@ -14,7 +14,7 @@
 package wvlet.airframe.http
 
 import wvlet.airframe.http.example.LongPathExample
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 
 /**
   *

--- a/airframe-http/src/test/scala/wvlet/airframe/http/RouterTest.scala
+++ b/airframe-http/src/test/scala/wvlet/airframe/http/RouterTest.scala
@@ -15,8 +15,8 @@ package wvlet.airframe.http
 
 import wvlet.airframe.http.example.ControllerExample.User
 import wvlet.airframe.http.example._
-import wvlet.airframe.spec.AirSpec
 import wvlet.airframe.surface.Surface
+import wvlet.airspec.AirSpec
 
 /**
   *

--- a/airframe-http/src/test/scala/wvlet/airframe/http/ServerAddressTest.scala
+++ b/airframe-http/src/test/scala/wvlet/airframe/http/ServerAddressTest.scala
@@ -12,7 +12,8 @@
  * limitations under the License.
  */
 package wvlet.airframe.http
-import wvlet.airframe.spec.AirSpec
+
+import wvlet.airspec.AirSpec
 
 /**
   *

--- a/airframe-jdbc/src/test/scala/wvlet/airframe/jdbc/ConnectionPoolFactoryTest.scala
+++ b/airframe-jdbc/src/test/scala/wvlet/airframe/jdbc/ConnectionPoolFactoryTest.scala
@@ -13,9 +13,9 @@
  */
 package wvlet.airframe.jdbc
 
-import wvlet.airframe.spec.AirSpec
 import wvlet.log.LogSupport
 import wvlet.airframe._
+import wvlet.airspec.AirSpec
 
 object ConnectionPoolFactoryTest {
   type MyDbConfig1 = DbConfig

--- a/airframe-jmx/src/test/scala/wvlet/airframe/jmx/JMXAgentTest.scala
+++ b/airframe-jmx/src/test/scala/wvlet/airframe/jmx/JMXAgentTest.scala
@@ -14,7 +14,7 @@
 package wvlet.airframe.jmx
 
 import javax.management.ObjectName
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 
 /**
   *

--- a/airframe-jmx/src/test/scala/wvlet/airframe/jmx/JMXRegistryTest.scala
+++ b/airframe-jmx/src/test/scala/wvlet/airframe/jmx/JMXRegistryTest.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.jmx
 
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 import wvlet.log.LogSupport
 
 import scala.util.Random

--- a/airframe-json/.jvm/src/test/scala/wvlet/airframe/json/TwitterJSONTest.scala
+++ b/airframe-json/.jvm/src/test/scala/wvlet/airframe/json/TwitterJSONTest.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.json
 
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 import wvlet.log.io.IOUtil
 
 /**

--- a/airframe-json/src/test/scala/wvlet/airframe/json/JSONParserTest.scala
+++ b/airframe-json/src/test/scala/wvlet/airframe/json/JSONParserTest.scala
@@ -13,8 +13,8 @@
  */
 package wvlet.airframe.json
 
-import wvlet.airframe.spec.AirSpec
 import wvlet.airframe.json.JSON._
+import wvlet.airspec.AirSpec
 
 /**
   *

--- a/airframe-json/src/test/scala/wvlet/airframe/json/JSONScannerTest.scala
+++ b/airframe-json/src/test/scala/wvlet/airframe/json/JSONScannerTest.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.json
 
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 
 /**
   *

--- a/airframe-json/src/test/scala/wvlet/airframe/json/JSONTest.scala
+++ b/airframe-json/src/test/scala/wvlet/airframe/json/JSONTest.scala
@@ -12,8 +12,8 @@
  * limitations under the License.
  */
 package wvlet.airframe.json
-import wvlet.airframe.spec.AirSpec
 import wvlet.airframe.json.JSON.{JSONArray, JSONLong, JSONNumber, JSONObject}
+import wvlet.airspec.AirSpec
 
 /**
   *

--- a/airframe-launcher/src/test/scala/wvlet/airframe/launcher/ArgProcessorTest.scala
+++ b/airframe-launcher/src/test/scala/wvlet/airframe/launcher/ArgProcessorTest.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.launcher
 import wvlet.airframe.launcher.LauncherTest.capture
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 import wvlet.log.LogSupport
 import wvlet.log.io.IOUtil
 

--- a/airframe-launcher/src/test/scala/wvlet/airframe/launcher/LauncherTest.scala
+++ b/airframe-launcher/src/test/scala/wvlet/airframe/launcher/LauncherTest.scala
@@ -23,7 +23,7 @@ package wvlet.airframe.launcher
 
 import java.io.ByteArrayOutputStream
 
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 import wvlet.log.{LogLevel, LogSupport, Logger}
 
 class LauncherTest extends AirSpec {

--- a/airframe-launcher/src/test/scala/wvlet/airframe/launcher/OptionBuilderTest.scala
+++ b/airframe-launcher/src/test/scala/wvlet/airframe/launcher/OptionBuilderTest.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.launcher
 
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 
 object OptionBuilderTest {
 

--- a/airframe-launcher/src/test/scala/wvlet/airframe/launcher/StringTreeTest.scala
+++ b/airframe-launcher/src/test/scala/wvlet/airframe/launcher/StringTreeTest.scala
@@ -21,7 +21,7 @@
 
 package wvlet.airframe.launcher
 
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 
 class StringTreeTest extends AirSpec {
 

--- a/airframe-log/shared/src/test/scala/wvlet/airframe/log/AirframeLogDemo.scala
+++ b/airframe-log/shared/src/test/scala/wvlet/airframe/log/AirframeLogDemo.scala
@@ -15,7 +15,7 @@ package wvlet.airframe.log
 
 import java.util.logging
 
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 import wvlet.log.LogFormatter._
 import wvlet.log.{LocalLogSupport, LogFormatter, LogLevel, LogSupport, NullHandler}
 

--- a/airframe-log/shared/src/test/scala/wvlet/log/Spec.scala
+++ b/airframe-log/shared/src/test/scala/wvlet/log/Spec.scala
@@ -12,7 +12,8 @@
  * limitations under the License.
  */
 package wvlet.log
-import wvlet.airframe.spec.AirSpec
+
+import wvlet.airspec.AirSpec
 
 /**
   *

--- a/airframe-metrics/jvm/src/test/scala/wvlet/airframe/metrics/TimeParserTest.scala
+++ b/airframe-metrics/jvm/src/test/scala/wvlet/airframe/metrics/TimeParserTest.scala
@@ -15,7 +15,7 @@ package wvlet.airframe.metrics
 
 import java.time.ZonedDateTime
 
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 
 /**
   *

--- a/airframe-metrics/jvm/src/test/scala/wvlet/airframe/metrics/TimeWindowTest.scala
+++ b/airframe-metrics/jvm/src/test/scala/wvlet/airframe/metrics/TimeWindowTest.scala
@@ -17,8 +17,8 @@ import java.time.ZoneOffset
 import java.time.temporal.ChronoUnit
 import java.util.TimeZone
 
-import wvlet.airframe.spec.AirSpec
-import wvlet.airframe.spec.spi.AirSpecException
+import wvlet.airspec.spi.AirSpecException
+import wvlet.airspec.AirSpec
 
 /**
   *

--- a/airframe-metrics/shared/src/test/scala/wvlet/airframe/metrics/DataSizeTest.scala
+++ b/airframe-metrics/shared/src/test/scala/wvlet/airframe/metrics/DataSizeTest.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.metrics
 
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 
 /**
   *

--- a/airframe-metrics/shared/src/test/scala/wvlet/airframe/metrics/ElapsedTimeTest.scala
+++ b/airframe-metrics/shared/src/test/scala/wvlet/airframe/metrics/ElapsedTimeTest.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.metrics
 
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 
 import scala.concurrent.duration.TimeUnit
 import scala.concurrent.duration._

--- a/airframe-msgpack/src/test/scala/wvlet/airframe/msgpack/io/ByteArrayBufferTest.scala
+++ b/airframe-msgpack/src/test/scala/wvlet/airframe/msgpack/io/ByteArrayBufferTest.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.msgpack.io
 
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 
 /**
   *

--- a/airframe-msgpack/src/test/scala/wvlet/airframe/msgpack/spi/MessageFormatTest.scala
+++ b/airframe-msgpack/src/test/scala/wvlet/airframe/msgpack/spi/MessageFormatTest.scala
@@ -13,8 +13,8 @@
  */
 package wvlet.airframe.msgpack.spi
 
-import wvlet.airframe.spec.AirSpec
-import wvlet.airframe.spec.spi.{AirSpecException, AssertionFailure}
+import wvlet.airspec.spi.{AirSpecException, AssertionFailure}
+import wvlet.airspec.AirSpec
 import wvlet.log.LogLevel
 import wvlet.log.io.Timer
 

--- a/airframe-msgpack/src/test/scala/wvlet/airframe/msgpack/spi/RoundTripTest.scala
+++ b/airframe-msgpack/src/test/scala/wvlet/airframe/msgpack/spi/RoundTripTest.scala
@@ -19,9 +19,9 @@ import java.time.Instant
 
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen
-import wvlet.airframe.spec.AirSpec
 import wvlet.airframe.msgpack.io.ByteArrayBuffer
-import wvlet.airframe.spec.spi.PropertyCheck
+import wvlet.airspec.spi.PropertyCheck
+import wvlet.airspec.AirSpec
 
 /**
   *

--- a/airframe-msgpack/src/test/scala/wvlet/airframe/msgpack/spi/ValueTest.scala
+++ b/airframe-msgpack/src/test/scala/wvlet/airframe/msgpack/spi/ValueTest.scala
@@ -19,8 +19,8 @@ import org.scalacheck.Gen
 import wvlet.airframe.msgpack.io.ByteArrayBuffer
 import wvlet.airframe.msgpack.spi.Value._
 import wvlet.airframe.msgpack.spi.ValueFactory._
-import wvlet.airframe.spec.AirSpec
-import wvlet.airframe.spec.spi.PropertyCheck
+import wvlet.airspec.spi.PropertyCheck
+import wvlet.airspec.AirSpec
 
 /**
   *

--- a/airframe-msgpack/src/test/scala/wvlet/airframe/msgpack/spi/ValueTypeTest.scala
+++ b/airframe-msgpack/src/test/scala/wvlet/airframe/msgpack/spi/ValueTypeTest.scala
@@ -13,8 +13,8 @@
  */
 package wvlet.airframe.msgpack.spi
 
-import wvlet.airframe.spec.AirSpec
 import wvlet.airframe.msgpack.spi.Code._
+import wvlet.airspec.AirSpec
 
 /**
   *

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/QuerySignatureTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/QuerySignatureTest.scala
@@ -14,10 +14,10 @@
 
 package wvlet.airframe.sql.analyzer
 
-import wvlet.airframe.spec.AirSpec
 import wvlet.airframe.sql.SQLBenchmark
 import wvlet.airframe.sql.model.SQLSig
 import wvlet.airframe.sql.parser.SQLParser
+import wvlet.airspec.AirSpec
 
 /**
   *

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/SQLAnonymizerTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/SQLAnonymizerTest.scala
@@ -13,11 +13,11 @@
  */
 
 package wvlet.airframe.sql.analyzer
-import wvlet.airframe.spec.AirSpec
 import wvlet.airframe.sql.SQLBenchmark
 import wvlet.airframe.sql.SQLBenchmark.TestQuery
 import wvlet.airframe.sql.model.Expression
 import wvlet.airframe.sql.parser.{SQLGenerator, SQLParser}
+import wvlet.airspec.AirSpec
 
 /**
   *

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/catalog/DataTypeTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/catalog/DataTypeTest.scala
@@ -13,8 +13,8 @@
  */
 
 package wvlet.airframe.sql.catalog
-import wvlet.airframe.spec.AirSpec
 import wvlet.airframe.sql.catalog.DataType._
+import wvlet.airspec.AirSpec
 
 /**
   *

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/parser/SQLParserTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/parser/SQLParserTest.scala
@@ -13,10 +13,10 @@
  */
 package wvlet.airframe.sql.parser
 
-import wvlet.airframe.spec.AirSpec
 import wvlet.airframe.sql.SQLBenchmark
 import wvlet.airframe.sql.SQLBenchmark.TestQuery
 import wvlet.airframe.sql.analyzer.QuerySignature
+import wvlet.airspec.AirSpec
 
 /**
   *

--- a/airframe-surface/shared/src/test/scala/wvlet/airframe/surface/CNameTest.scala
+++ b/airframe-surface/shared/src/test/scala/wvlet/airframe/surface/CNameTest.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.surface
 
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 
 class CNameTest extends AirSpec {
   scalaJsSupport

--- a/airframe-surface/shared/src/test/scala/wvlet/airframe/surface/SurfaceSpec.scala
+++ b/airframe-surface/shared/src/test/scala/wvlet/airframe/surface/SurfaceSpec.scala
@@ -14,7 +14,7 @@
 
 package wvlet.airframe.surface
 
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 import wvlet.log.LogSupport
 
 import scala.language.implicitConversions

--- a/airframe-tablet/src/test/scala/wvlet/airframe/tablet/jdbc/SQLObjectMapperTest.scala
+++ b/airframe-tablet/src/test/scala/wvlet/airframe/tablet/jdbc/SQLObjectMapperTest.scala
@@ -15,8 +15,8 @@ package wvlet.airframe.tablet.jdbc
 
 import java.sql.{DriverManager, JDBCType}
 
-import wvlet.airframe.spec.AirSpec
 import wvlet.airframe.tablet.obj.ObjectTabletWriter
+import wvlet.airspec.AirSpec
 import wvlet.log.io.IOUtil._
 
 /**

--- a/airframe-tablet/src/test/scala/wvlet/airframe/tablet/msgpack/MessagePackTabletTest.scala
+++ b/airframe-tablet/src/test/scala/wvlet/airframe/tablet/msgpack/MessagePackTabletTest.scala
@@ -13,8 +13,8 @@
  */
 package wvlet.airframe.tablet.msgpack
 
-import wvlet.airframe.spec.AirSpec
 import wvlet.airframe.tablet.obj.{ObjectTabletReader, ObjectTabletWriter}
+import wvlet.airspec.AirSpec
 import wvlet.log.io.IOUtil
 
 /**

--- a/airframe-tablet/src/test/scala/wvlet/airframe/tablet/obj/MapConverterTest.scala
+++ b/airframe-tablet/src/test/scala/wvlet/airframe/tablet/obj/MapConverterTest.scala
@@ -13,8 +13,8 @@
  */
 package wvlet.airframe.tablet.obj
 
-import wvlet.airframe.spec.AirSpec
 import wvlet.airframe.tablet.obj.MapConverterTest.Sample
+import wvlet.airspec.AirSpec
 
 object MapConverterTest {
   case class Sample(name: String, id: Int)

--- a/airframe-tablet/src/test/scala/wvlet/airframe/tablet/text/ArrayJSONCodecTest.scala
+++ b/airframe-tablet/src/test/scala/wvlet/airframe/tablet/text/ArrayJSONCodecTest.scala
@@ -14,7 +14,7 @@
 package wvlet.airframe.tablet.text
 
 import wvlet.airframe.codec.MessageHolder
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 
 class ArrayJSONCodecTest extends AirSpec {
   private def assertEncode[T](codec: ArrayJSONCodec[T], input: Array[T]) = {

--- a/airframe-tablet/src/test/scala/wvlet/airframe/tablet/text/JSONObjectPrinterTest.scala
+++ b/airframe-tablet/src/test/scala/wvlet/airframe/tablet/text/JSONObjectPrinterTest.scala
@@ -14,7 +14,7 @@
 package wvlet.airframe.tablet.text
 
 import wvlet.airframe.msgpack.spi.MessagePack
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 
 /**
   *

--- a/airframe-tablet/src/test/scala/wvlet/airframe/tablet/text/ObjectJSONCodecTest.scala
+++ b/airframe-tablet/src/test/scala/wvlet/airframe/tablet/text/ObjectJSONCodecTest.scala
@@ -14,7 +14,7 @@
 package wvlet.airframe.tablet.text
 
 import wvlet.airframe.codec.MessageHolder
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 
 object ObjectJSONCodecTest {
   case class A(id: Int, name: String)

--- a/airframe-tablet/src/test/scala/wvlet/airframe/tablet/text/PrettyPrintTest.scala
+++ b/airframe-tablet/src/test/scala/wvlet/airframe/tablet/text/PrettyPrintTest.scala
@@ -13,12 +13,11 @@
  */
 package wvlet.airframe.tablet.text
 
-import wvlet.airframe.spec.AirSpec
-
 /**
   *
   */
 import wvlet.airframe.tablet.text.PrettyPrintTest._
+import wvlet.airspec.AirSpec
 class PrettyPrintTest extends AirSpec {
   def `print objects`: Unit = {
     //PrettyPrint.pp(Seq(1, 2, 3))

--- a/airframe-tablet/src/test/scala/wvlet/airframe/tablet/text/TextTabletWriterTest.scala
+++ b/airframe-tablet/src/test/scala/wvlet/airframe/tablet/text/TextTabletWriterTest.scala
@@ -13,8 +13,8 @@
  */
 package wvlet.airframe.tablet.text
 
-import wvlet.airframe.spec.AirSpec
 import wvlet.airframe.tablet.Tablet._
+import wvlet.airspec.AirSpec
 
 import scala.io.Source
 

--- a/airframe/.jvm/src/test/scala/wvlet/airframe/ConstructorBindingTest.scala
+++ b/airframe/.jvm/src/test/scala/wvlet/airframe/ConstructorBindingTest.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe
 
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 
 /**
   * TODO: This works only in JVM,

--- a/airframe/.jvm/src/test/scala/wvlet/airframe/DesignSerializationTest.scala
+++ b/airframe/.jvm/src/test/scala/wvlet/airframe/DesignSerializationTest.scala
@@ -16,7 +16,7 @@ package wvlet.airframe
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream}
 
 import DesignTest._
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 
 object DesignSerializationTest {
 

--- a/airframe/.jvm/src/test/scala/wvlet/airframe/FactoryBindingLifecycleTest.scala
+++ b/airframe/.jvm/src/test/scala/wvlet/airframe/FactoryBindingLifecycleTest.scala
@@ -15,7 +15,7 @@ package wvlet.airframe
 import java.util.concurrent.atomic.AtomicInteger
 
 import javax.annotation.{PostConstruct, PreDestroy}
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 import wvlet.log.LogSupport
 
 object FactoryBindingLifecycleTest {

--- a/airframe/.jvm/src/test/scala/wvlet/airframe/HigherKindedTypeBindingTest.scala
+++ b/airframe/.jvm/src/test/scala/wvlet/airframe/HigherKindedTypeBindingTest.scala
@@ -13,8 +13,8 @@
  */
 package wvlet.airframe
 
-import wvlet.airframe.spec.AirSpec
 import wvlet.airframe.surface.Surface
+import wvlet.airspec.AirSpec
 
 import scala.concurrent.Future
 import scala.language.higherKinds

--- a/airframe/.jvm/src/test/scala/wvlet/airframe/JSR250LifeCycleExecutorTest.scala
+++ b/airframe/.jvm/src/test/scala/wvlet/airframe/JSR250LifeCycleExecutorTest.scala
@@ -14,7 +14,7 @@
 package wvlet.airframe
 
 import javax.annotation.{PostConstruct, PreDestroy}
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 
 trait JSR250Test {
   var initialized = false

--- a/airframe/.jvm/src/test/scala/wvlet/airframe/LocalCaseClassTest.scala
+++ b/airframe/.jvm/src/test/scala/wvlet/airframe/LocalCaseClassTest.scala
@@ -13,8 +13,8 @@
  */
 package wvlet.airframe
 
-import wvlet.airframe.spec.AirSpec
 import wvlet.airframe.surface.Surface
+import wvlet.airspec.AirSpec
 
 /**
   * Reproduction of https://github.com/wvlet/airframe/pull/423

--- a/airframe/.jvm/src/test/scala/wvlet/airframe/ProviderSerializationTest.scala
+++ b/airframe/.jvm/src/test/scala/wvlet/airframe/ProviderSerializationTest.scala
@@ -16,7 +16,7 @@ package wvlet.airframe
 import wvlet.airframe.ProviderSerializationExample._
 import wvlet.airframe.ProviderVal._
 import DesignSerializationTest._
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 
 /**
   *

--- a/airframe/.jvm/src/test/scala/wvlet/airframe/SerializationTest.scala
+++ b/airframe/.jvm/src/test/scala/wvlet/airframe/SerializationTest.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe
 
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 import wvlet.log.LogSupport
 
 object SerializationTest extends LogSupport {

--- a/airframe/.jvm/src/test/scala/wvlet/airframe/TracerTest.scala
+++ b/airframe/.jvm/src/test/scala/wvlet/airframe/TracerTest.scala
@@ -12,8 +12,8 @@
  * limitations under the License.
  */
 package wvlet.airframe
-import wvlet.airframe.spec.AirSpec
 import wvlet.airframe.tracing.{ChromeTracer, DIStats}
+import wvlet.airspec.AirSpec
 import wvlet.log.LogSupport
 
 object TracerTest extends LogSupport {

--- a/airframe/src/test/scala/example/BindFactory.scala
+++ b/airframe/src/test/scala/example/BindFactory.scala
@@ -13,7 +13,7 @@
  */
 package example
 import javax.annotation.{PostConstruct, PreDestroy}
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 import wvlet.log.LogSupport
 
 /**

--- a/airframe/src/test/scala/example/BindSingleton.scala
+++ b/airframe/src/test/scala/example/BindSingleton.scala
@@ -14,8 +14,7 @@
 package example
 
 import javax.annotation.{PostConstruct, PreDestroy}
-
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 import wvlet.log.LogSupport
 
 /**

--- a/airframe/src/test/scala/wvlet/airframe/AirframeMacrosTest.scala
+++ b/airframe/src/test/scala/wvlet/airframe/AirframeMacrosTest.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe
 
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 import wvlet.log.LogSupport
 
 trait NonAbstractTrait extends LogSupport {

--- a/airframe/src/test/scala/wvlet/airframe/AirframeTest.scala
+++ b/airframe/src/test/scala/wvlet/airframe/AirframeTest.scala
@@ -17,9 +17,9 @@ import java.io.PrintStream
 import java.util.concurrent.atomic.AtomicInteger
 
 import wvlet.airframe.AirframeException.{CYCLIC_DEPENDENCY, MISSING_DEPENDENCY, MISSING_SESSION}
-import wvlet.airframe.spec.AirSpec
 import wvlet.log.LogSupport
 import wvlet.airframe.surface.{Primitive, Surface}
+import wvlet.airspec.AirSpec
 
 import scala.util.Random
 

--- a/airframe/src/test/scala/wvlet/airframe/AssistedInjectionTest.scala
+++ b/airframe/src/test/scala/wvlet/airframe/AssistedInjectionTest.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe
 
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 import wvlet.log.LogSupport
 
 /**

--- a/airframe/src/test/scala/wvlet/airframe/BindTest.scala
+++ b/airframe/src/test/scala/wvlet/airframe/BindTest.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe
 
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 
 object BindTest {
   class X {

--- a/airframe/src/test/scala/wvlet/airframe/ChildSessionTest.scala
+++ b/airframe/src/test/scala/wvlet/airframe/ChildSessionTest.scala
@@ -14,7 +14,7 @@
 package wvlet.airframe
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
 
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 import wvlet.log.LogSupport
 
 import scala.util.Random

--- a/airframe/src/test/scala/wvlet/airframe/DefaultValueTest.scala
+++ b/airframe/src/test/scala/wvlet/airframe/DefaultValueTest.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe
 
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 
 object DefaultValueTest {
   case class A(a: Long = 10, b: Long = 100, c: Long = 1000)

--- a/airframe/src/test/scala/wvlet/airframe/DependencyTest.scala
+++ b/airframe/src/test/scala/wvlet/airframe/DependencyTest.scala
@@ -14,7 +14,7 @@
 package wvlet.airframe
 
 import wvlet.airframe.AirframeException.MISSING_DEPENDENCY
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 
 object DependencyTest1 {
   trait A {

--- a/airframe/src/test/scala/wvlet/airframe/DesignBuildTest.scala
+++ b/airframe/src/test/scala/wvlet/airframe/DesignBuildTest.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe
 
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 
 /**
   *

--- a/airframe/src/test/scala/wvlet/airframe/DesignTest.scala
+++ b/airframe/src/test/scala/wvlet/airframe/DesignTest.scala
@@ -13,9 +13,9 @@
  */
 package wvlet.airframe
 import wvlet.airframe.Alias.{HelloRef, StringHello}
-import wvlet.airframe.spec.AirSpec
 import wvlet.airframe.surface.Surface
 import wvlet.airframe.tracing.DefaultTracer
+import wvlet.airspec.AirSpec
 
 trait Message
 case class Hello(message: String) extends Message

--- a/airframe/src/test/scala/wvlet/airframe/FactoryBindingTest.scala
+++ b/airframe/src/test/scala/wvlet/airframe/FactoryBindingTest.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe
 
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 
 object FactoryBindingTest {
 

--- a/airframe/src/test/scala/wvlet/airframe/HigherKindTypeTest.scala
+++ b/airframe/src/test/scala/wvlet/airframe/HigherKindTypeTest.scala
@@ -12,7 +12,8 @@
  * limitations under the License.
  */
 package wvlet.airframe
-import wvlet.airframe.spec.AirSpec
+
+import wvlet.airspec.AirSpec
 
 import scala.language.higherKinds
 

--- a/airframe/src/test/scala/wvlet/airframe/ImplicitArgTest.scala
+++ b/airframe/src/test/scala/wvlet/airframe/ImplicitArgTest.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe
 
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 
 object ImplicitArgTest {
 

--- a/airframe/src/test/scala/wvlet/airframe/LazyStartTest.scala
+++ b/airframe/src/test/scala/wvlet/airframe/LazyStartTest.scala
@@ -15,7 +15,7 @@ package wvlet.airframe
 
 import java.util.concurrent.atomic.AtomicBoolean
 
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 import wvlet.log.LogSupport
 
 object LazyStartTest {

--- a/airframe/src/test/scala/wvlet/airframe/LifeCycleManagerTest.scala
+++ b/airframe/src/test/scala/wvlet/airframe/LifeCycleManagerTest.scala
@@ -15,7 +15,7 @@ package wvlet.airframe
 
 import java.util.concurrent.atomic.AtomicInteger
 
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 import wvlet.log.{LogLevel, LogSupport, Logger}
 
 class Counter extends LogSupport {

--- a/airframe/src/test/scala/wvlet/airframe/MapBindingTest.scala
+++ b/airframe/src/test/scala/wvlet/airframe/MapBindingTest.scala
@@ -13,9 +13,9 @@
  */
 package wvlet.airframe
 
-import wvlet.airframe.spec.AirSpec
 import wvlet.log.LogSupport
 import wvlet.airframe.surface.tag._
+import wvlet.airspec.AirSpec
 
 /**
   *

--- a/airframe/src/test/scala/wvlet/airframe/PathDependentTypeTest.scala
+++ b/airframe/src/test/scala/wvlet/airframe/PathDependentTypeTest.scala
@@ -12,8 +12,8 @@
  * limitations under the License.
  */
 package wvlet.airframe
-import wvlet.airframe.spec.AirSpec
 import wvlet.airframe.surface.Surface
+import wvlet.airspec.AirSpec
 
 /**
   *

--- a/airframe/src/test/scala/wvlet/airframe/ProviderTest.scala
+++ b/airframe/src/test/scala/wvlet/airframe/ProviderTest.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe
 
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 import wvlet.log.LogSupport
 
 object ProviderExample extends Serializable {

--- a/airframe/src/test/scala/wvlet/airframe/SessionBuilderTest.scala
+++ b/airframe/src/test/scala/wvlet/airframe/SessionBuilderTest.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe
 
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 
 /**
   *

--- a/airframe/src/test/scala/wvlet/airframe/SessionTest.scala
+++ b/airframe/src/test/scala/wvlet/airframe/SessionTest.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe
 
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 
 trait HelloBind {}
 

--- a/airframe/src/test/scala/wvlet/airframe/SingletonTest.scala
+++ b/airframe/src/test/scala/wvlet/airframe/SingletonTest.scala
@@ -16,7 +16,7 @@ package wvlet.airframe
 import java.util.concurrent.atomic.AtomicInteger
 
 import wvlet.airframe.SingletonTest._
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 import wvlet.log.{LogLevel, LogSupport, Logger}
 
 object SingletonTest {

--- a/airframe/src/test/scala/wvlet/airframe/TaggedBindingTest.scala
+++ b/airframe/src/test/scala/wvlet/airframe/TaggedBindingTest.scala
@@ -12,9 +12,9 @@
  * limitations under the License.
  */
 package wvlet.airframe
-import wvlet.airframe.spec.AirSpec
 import wvlet.airframe.surface.Surface
 import wvlet.airframe.surface.tag._
+import wvlet.airspec.AirSpec
 
 object TaggedBindingTest {
 

--- a/airspec/.js/src/main/scala/wvlet/airspec/Compat.scala
+++ b/airspec/.js/src/main/scala/wvlet/airspec/Compat.scala
@@ -11,9 +11,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.airframe.spec
+package wvlet.airspec
 
-import org.portablescala.reflect._
+import org.portablescala.reflect.Reflect
 import wvlet.airframe.surface.MethodSurface
 import wvlet.log.LogFormatter.SourceCodeLogFormatter
 import wvlet.log.{ConsoleLogHandler, LogSupport, Logger}
@@ -21,33 +21,33 @@ import wvlet.log.{ConsoleLogHandler, LogSupport, Logger}
 /**
   *
   */
-private[spec] object Compat extends CompatApi with LogSupport {
+private[airspec] object Compat extends CompatApi with LogSupport {
   override def isScalaJs = true
-  private[spec] def findCompanionObjectOf(fullyQualifiedName: String, classLoader: ClassLoader): Option[Any] = {
+  private[airspec] def findCompanionObjectOf(fullyQualifiedName: String, classLoader: ClassLoader): Option[Any] = {
     val clsOpt = Reflect.lookupLoadableModuleClass(fullyQualifiedName + "$", classLoader)
     clsOpt.map {
       _.loadModule()
     }
   }
 
-  private[spec] def newInstanceOf(fullyQualifiedName: String, classLoader: ClassLoader): Option[Any] = {
+  private[airspec] def newInstanceOf(fullyQualifiedName: String, classLoader: ClassLoader): Option[Any] = {
     // Scala.js needs to use @EnableReflectiveInstantiation annotation to support .newInstance
     val clsOpt = Reflect.lookupInstantiatableClass(fullyQualifiedName)
     clsOpt.map(_.newInstance())
   }
 
-  private[spec] def withLogScanner[U](block: => U): U = {
+  private[airspec] def withLogScanner[U](block: => U): U = {
     Logger.setDefaultHandler(new ConsoleLogHandler(SourceCodeLogFormatter))
     block
   }
 
-  private[spec] def findCause(e: Throwable): Throwable = {
+  private[airspec] def findCause(e: Throwable): Throwable = {
     // Scala.js has no InvocationTargetException
     e
   }
-  override private[spec] def methodSurfacesOf(cls: Class[_]) = Seq.empty[MethodSurface]
+  override private[airspec] def methodSurfacesOf(cls: Class[_]) = Seq.empty[MethodSurface]
 
-  override private[spec] def getSpecName(cl: Class[_]): String = {
+  override private[airspec] def getSpecName(cl: Class[_]): String = {
     var name = cl.getName
 
     // In Scala.js we cannot use cl.getInterfaces to find the actual type

--- a/airspec/.js/src/main/scala/wvlet/airspec/PlatformAirSpec.scala
+++ b/airspec/.js/src/main/scala/wvlet/airspec/PlatformAirSpec.scala
@@ -11,12 +11,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.airframe
+package wvlet.airspec
+
+import org.portablescala.reflect.annotation.EnableReflectiveInstantiation
 
 /**
+  * Scala.js platform-specific implementation
   *
+  * EnableReflectiveInstantiation annotation is necessary to support (test class).getInstance() in Scala.js
   */
-package object spec {
-  // For Scala, Scala.js compatibility
-  val compat: CompatApi = wvlet.airframe.spec.Compat
+@EnableReflectiveInstantiation
+trait PlatformAirSpec {
+  this: AirSpecSpi =>
 }

--- a/airspec/.jvm/src/main/scala/wvlet/airspec/Compat.scala
+++ b/airspec/.jvm/src/main/scala/wvlet/airspec/Compat.scala
@@ -11,33 +11,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.airframe.spec
+package wvlet.airspec
 
 import java.lang.reflect.InvocationTargetException
 
-import wvlet.airframe.surface.reflect.{ReflectSurfaceFactory, ReflectTypeUtil}
 import wvlet.log.LogFormatter.SourceCodeLogFormatter
 import wvlet.log.Logger
 
 import scala.annotation.tailrec
 import scala.util.Try
+import wvlet.airframe.surface.reflect.{ReflectTypeUtil, ReflectSurfaceFactory}
 
 /**
   *
   */
-private[spec] object Compat extends CompatApi {
+private[airspec] object Compat extends CompatApi {
   override def isScalaJs = false
 
-  private[spec] def findCompanionObjectOf(fullyQualifiedName: String, classLoader: ClassLoader): Option[Any] = {
+  private[airspec] def findCompanionObjectOf(fullyQualifiedName: String, classLoader: ClassLoader): Option[Any] = {
     val cls = classLoader.loadClass(fullyQualifiedName)
     ReflectTypeUtil.companionObject(cls)
   }
 
-  private[spec] def newInstanceOf(fullyQualifiedName: String, classLoader: ClassLoader): Option[Any] = {
+  private[airspec] def newInstanceOf(fullyQualifiedName: String, classLoader: ClassLoader): Option[Any] = {
     Try(classLoader.loadClass(fullyQualifiedName).getDeclaredConstructor().newInstance()).toOption
   }
 
-  private[spec] def withLogScanner[U](block: => U): U = {
+  private[airspec] def withLogScanner[U](block: => U): U = {
     Logger.setDefaultFormatter(SourceCodeLogFormatter)
 
     // Periodically scan log level file
@@ -49,17 +49,17 @@ private[spec] object Compat extends CompatApi {
     }
   }
 
-  @tailrec private[spec] def findCause(e: Throwable): Throwable = {
+  @tailrec private[airspec] def findCause(e: Throwable): Throwable = {
     e match {
       case i: InvocationTargetException => findCause(i.getTargetException)
       case _                            => e
     }
   }
-  override private[spec] def methodSurfacesOf(cls: Class[_]) = {
+  override private[airspec] def methodSurfacesOf(cls: Class[_]) = {
     ReflectSurfaceFactory.methodsOfClass(cls)
   }
 
-  override private[spec] def getSpecName(cl: Class[_]): String = {
+  override private[airspec] def getSpecName(cl: Class[_]): String = {
     var name = cl.getName
 
     if (name.endsWith("$")) {
@@ -69,7 +69,6 @@ private[spec] object Compat extends CompatApi {
 
     // When class is an anonymous trait
     if (name.contains("$anon$")) {
-      import collection.JavaConverters._
       val interfaces = cl.getInterfaces
       if (interfaces != null && interfaces.length > 0) {
         // Use the first interface name instead of the anonymous name and Airframe SessionHolder (injected at compile-time)

--- a/airspec/.jvm/src/main/scala/wvlet/airspec/PlatformAirSpec.scala
+++ b/airspec/.jvm/src/main/scala/wvlet/airspec/PlatformAirSpec.scala
@@ -11,16 +11,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.airframe.spec
-
-import org.portablescala.reflect.annotation.EnableReflectiveInstantiation
+package wvlet.airspec
 
 /**
-  * Scala.js platform-specific implementation
-  *
-  * EnableReflectiveInstantiation annotation is necessary to support (test class).getInstance() in Scala.js
+  * Platform-specific AirSpecApi implementation
   */
-@EnableReflectiveInstantiation
 trait PlatformAirSpec {
   this: AirSpecSpi =>
 }

--- a/airspec/.jvm/src/test/scala/wvlet/airspec/ServiceSpec.scala
+++ b/airspec/.jvm/src/test/scala/wvlet/airspec/ServiceSpec.scala
@@ -11,11 +11,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.airframe.spec
+package wvlet.airspec
 
+import javax.annotation._
 import wvlet.airframe.Design
 import wvlet.log.LogSupport
-import javax.annotation._
 
 case class ServiceConfig(port: Int)
 

--- a/airspec/.jvm/src/test/scala/wvlet/airspec/TestExtension.scala
+++ b/airspec/.jvm/src/test/scala/wvlet/airspec/TestExtension.scala
@@ -11,7 +11,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.airframe.spec
+package wvlet.airspec
+
 import java.util.concurrent.atomic.AtomicInteger
 
 import javax.annotation.{PostConstruct, PreDestroy}

--- a/airspec/README.md
+++ b/airspec/README.md
@@ -12,7 +12,7 @@ AirSpec
 **build.sbt**
 ```
 libraryDependencies += "org.wvlet.airframe" %% "airspec" % "(version)"
-testFrameworks += new TestFramework("wvlet.airframe.spec.AirSpecFramework")
+testFrameworks += new TestFramework("wvlet.airspec.Framework")
 ```
 
 For Scala.js, use `%%%`:
@@ -20,7 +20,7 @@ For Scala.js, use `%%%`:
 libraryDependencies += "org.wvlet.airframe" %%% "airspec" % "(version)"
 ```
 To run your tests, you only need the following steps:
-- Create a class (or object) by extending **`wvlet.airframe.spec.AirSpec`**.
+- Create a class (or object) by extending **`wvlet.airspec.AirSpec`**.
 - Define your test cases as ___functions___ (public methods) in this class.
 - Use **sbt `> testOnly -- (pattern)`** to run your tests!
 
@@ -44,7 +44,7 @@ In AirSpec test cases are defined as functions in a class (or an object) extendi
 All public functions (methods) in the class will be executed as test cases:
 
 ```scala
-import wvlet.airframe.spec._
+import wvlet.airspec._
 
 class MyTest extends AirSpec {
   // Basic assertion
@@ -89,7 +89,7 @@ Basically this command finds matches from the list of all `(test class full name
 If you prefer natural language descriptions for your test cases, use symbols for function names:
 
 ```scala
-import wvlet.airframe.spec._
+import wvlet.airspec._
 
 class SeqSpec extends AirSpec {
   def `the size of empty Seq should be 0`: Unit = {
@@ -108,7 +108,7 @@ class SeqSpec extends AirSpec {
 It is also possible to use Symbol for test class names:
 
 ```scala
-import wvlet.airframe.spec._
+import wvlet.airspec._
 
 class `Seq[X] test spec` extends AirSpec {
   def `the size of empty Seq should be 0`: Unit = {
@@ -121,7 +121,7 @@ class `Seq[X] test spec` extends AirSpec {
 
 AirSpec supports handy assertions with `shouldBe` or `shouldNotBe`:
 ```scala
-import wvlet.airframe.spec._
+import wvlet.airspec._
 
 class MyTest extends AirSpec {
   def test: Unit = {
@@ -155,28 +155,6 @@ class MyTest extends AirSpec {
   }
 }
 ```
-
-## Scala.js
-
-To use AirSpec in Scala.js, `scalaJsSupport` must be called inside your spec classes:
- 
-```scala
-import wvlet.airframe.spec._
-
-class ScalaJSSpec extends AirSpec {
-  // This is necessary to find test methods in Scala.js
-  scalaJsSupport  
-
-  def myTest: Unit = assert(1 == 1)
-}
-```
-
-Scala.js has no runtime reflection to find methods in AirSpec classes.
-So calling `scalaJsSupport` will generate `MethodSurface`s (airframe-surface), so that 
-AirSpec can find test methods at runtime. 
-
-Calling `scalaJsSupport` has no effect in Scala JVM platform, so you can use the
-same test spec both for Scala and Scala.js.
 
 
 ## Dependency Injection with Airframe DI
@@ -216,10 +194,7 @@ AirSpec manages global/local sessions in this order:
 
 This is an example to utilize a global session to share the same service instance between test methods:
 ```scala
-import wvlet.airframe.spec._
-import wvlet.airframe.Design
-import wvlet.log.LogSupport
-import javax.annotation._
+
 
 case class ServiceConfig(port:Int)
 
@@ -271,8 +246,7 @@ To reuse test cases, create a fixture, which is a class, object, or trait extend
 AirSpec. Then call AirSpecContext.run(AirSpec instance), which can be injected to test method arguments:
 
 ```scala
-import wvlet.airframe.spec._
-import wvlet.airframe.spec.spi.AirSpecContext
+import wvlet.airspec._
 
 class MySpec extends AirSpec {
   // A template for reusable test cases
@@ -313,16 +287,16 @@ MySpec:
 ## Property Based Testing with ScalaCheck
 
 Optionally AirSpec can integrate with [ScalaCheck](https://github.com/typelevel/scalacheck/blob/master/doc/UserGuide.md).
-Add `wvlet.airframe.spec.spi.PropertyCheck` trait to your spec, and use `forAll` methods.
+Add `wvlet.airspec.spi.PropertyCheck` trait to your spec, and use `forAll` methods.
 
 __build.sbt__
 ```scala
-libraryDependencies += "org.scalacheck" %%% "scalacheck" % "1.14.0" % "test"
+# Use %%% for Scala.js
+libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.14.0" % "test"
 ```
 
 ```scala
-import wvlet.airframe.spec._
-import wvlet.airframe.spec.spi.PropertyCheck
+import wvlet.airspec._
 
 class PropertyBasedTest extends AirSpec with PropertyCheck {
   def testAllInt: Unit = {
@@ -339,3 +313,26 @@ class PropertyBasedTest extends AirSpec with PropertyCheck {
   }
 }
 ```
+
+## Scala.js
+
+To use AirSpec in Scala.js, `scalaJsSupport` must be called inside your spec classes:
+ 
+```scala
+import wvlet.airspec._
+
+class ScalaJSSpec extends AirSpec {
+  // This is necessary to find test methods in Scala.js
+  scalaJsSupport  
+
+  def myTest: Unit = assert(1 == 1)
+}
+```
+
+Scala.js has no runtime reflection to find methods in AirSpec classes.
+So calling `scalaJsSupport` will generate `MethodSurface`s (airframe-surface), so that 
+AirSpec can find test methods at runtime. 
+
+Calling `scalaJsSupport` has no effect in Scala JVM platform, so you can use the
+same test spec both for Scala and Scala.js.
+

--- a/airspec/src/main/scala/wvlet/airspec/AirSpec.scala
+++ b/airspec/src/main/scala/wvlet/airspec/AirSpec.scala
@@ -11,10 +11,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.airframe.spec
+package wvlet.airspec
 
 import wvlet.airframe.Design
-import wvlet.airframe.spec.spi.{Asserts, RichAsserts}
+import wvlet.airspec.spi.{Asserts, RichAsserts}
 import wvlet.airframe.surface.MethodSurface
 
 import scala.language.experimental.macros
@@ -30,7 +30,7 @@ trait AirSpec extends AirSpecBase with Asserts with RichAsserts
   */
 trait AirSpecBase extends AirSpecSpi with PlatformAirSpec
 
-private[spec] trait AirSpecSpi {
+private[airspec] trait AirSpecSpi {
   /*
    * Design note: Ideally we should list test methods just by using the name of classes implementing AirSpecSpi without
    * instantiating test instances. However, this was impossible in Scala.js, which has only limited reflection support.
@@ -39,19 +39,19 @@ private[spec] trait AirSpecSpi {
    * If we don't need to support Scala.js, we will just use RuntimeSurface to get a list of test methods.
    */
   protected var _methodSurfaces: Seq[MethodSurface] = compat.methodSurfacesOf(this.getClass)
-  private[spec] def testMethods: Seq[MethodSurface] = {
+  private[airspec] def testMethods: Seq[MethodSurface] = {
     AirSpecSpi.collectTestMethods(_methodSurfaces)
   }
 
-  private[spec] var specName: String = {
+  private[airspec] var specName: String = {
     AirSpecSpi.decodeClassName(compat.getSpecName(this.getClass))
   }
 
-  private[spec] def setSpecName(newSpecName: String): Unit = {
+  private[airspec] def setSpecName(newSpecName: String): Unit = {
     specName = newSpecName
   }
 
-  private[spec] def leafSpecName: String = {
+  private[airspec] def leafSpecName: String = {
     AirSpecSpi.leafClassName(specName)
   }
 
@@ -89,16 +89,16 @@ private[spec] trait AirSpecSpi {
   protected def isScalaJS: Boolean = compat.isScalaJs
 }
 
-private[spec] object AirSpecSpi {
+private[airspec] object AirSpecSpi {
 
-  private[spec] def collectTestMethods(methodSurfaces: Seq[MethodSurface]): Seq[MethodSurface] = {
+  private[airspec] def collectTestMethods(methodSurfaces: Seq[MethodSurface]): Seq[MethodSurface] = {
     methodSurfaces.filter(_.isPublic)
   }
 
   /**
     * This wrapper is used for accessing protected methods in AirSpec
     */
-  private[spec] implicit class AirSpecAccess(val airSpec: AirSpecSpi) extends AnyVal {
+  private[airspec] implicit class AirSpecAccess(val airSpec: AirSpecSpi) extends AnyVal {
     def callDesignAll(design: Design): Design  = airSpec.configure(design)
     def callDesignEach(design: Design): Design = airSpec.configureLocal(design)
     def callBeforeAll: Unit                    = airSpec.beforeAll
@@ -110,14 +110,14 @@ private[spec] object AirSpecSpi {
   def scalaJsSupportImpl(c: sm.Context): c.Tree = {
     import c.universe._
     val t = c.prefix.actualType.typeSymbol
-    q"if(wvlet.airframe.spec.compat.isScalaJs) { ${c.prefix}._methodSurfaces = wvlet.airframe.surface.Surface.methodsOf[${t}] }"
+    q"if(wvlet.airspec.compat.isScalaJs) { ${c.prefix}._methodSurfaces = wvlet.airframe.surface.Surface.methodsOf[${t}] }"
   }
 
-  private[spec] def inTravisCI: Boolean = {
+  private[airspec] def inTravisCI: Boolean = {
     sys.env.get("TRAVIS").map(_.toBoolean).getOrElse(false)
   }
 
-  private[spec] def decodeClassName(clsName: String): String = {
+  private[airspec] def decodeClassName(clsName: String): String = {
     // the full class name
     val decodedClassName = scala.reflect.NameTransformer.decode(clsName)
 
@@ -129,7 +129,7 @@ private[spec] object AirSpecSpi {
     }
   }
 
-  private[spec] def leafClassName(fullClassName: String): String = {
+  private[airspec] def leafClassName(fullClassName: String): String = {
     // the full class name
     val pos = fullClassName.lastIndexOf('.')
     val leafName = {

--- a/airspec/src/main/scala/wvlet/airspec/AirSpecMacros.scala
+++ b/airspec/src/main/scala/wvlet/airspec/AirSpecMacros.scala
@@ -11,16 +11,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.airframe.spec
-import wvlet.airframe.AirframeMacros
+package wvlet.airspec
 
+import wvlet.airframe.AirframeMacros
 import scala.language.experimental.macros
 import scala.reflect.macros.{blackbox => sm}
 
 /**
   *
   */
-private[spec] object AirSpecMacros {
+private[airspec] object AirSpecMacros {
 
   def sourceCode(c: sm.Context): c.Tree = {
     import c.universe._
@@ -32,7 +32,7 @@ private[spec] object AirSpecMacros {
   def pendingImpl(c: sm.Context): c.Tree = {
     import c.universe._
     q"""
-       throw wvlet.airframe.spec.spi.Pending("pending", ${sourceCode(c)})
+       throw wvlet.airspec.spi.Pending("pending", ${sourceCode(c)})
      """
   }
 
@@ -41,7 +41,7 @@ private[spec] object AirSpecMacros {
     val t = implicitly[c.WeakTypeTag[A]].tpe
     q"""{
            ${new AirframeMacros.BindHelper[c.type](c).registerTraitFactory(t)}
-           import wvlet.airframe.spec.spi.AirSpecContext._
+           import wvlet.airspec.spi.AirSpecContext._
            val context = ${c.prefix}
            val surface = wvlet.airframe.surface.Surface.of[${t}]
            val spec = context.callNewSpec(surface)
@@ -55,7 +55,7 @@ private[spec] object AirSpecMacros {
     import c.universe._
     val t = implicitly[c.WeakTypeTag[A]].tpe
     q"""{
-        wvlet.airframe.spec.spi.AirSpecContext.AirSpecContextAccess(${c.prefix})
+        wvlet.airspec.spi.AirSpecContext.AirSpecContextAccess(${c.prefix})
           .callRunInternal(${spec}, wvlet.airframe.surface.Surface.methodsOf[${t}])
           .asInstanceOf[${t}]
         }

--- a/airspec/src/main/scala/wvlet/airspec/CompatApi.scala
+++ b/airspec/src/main/scala/wvlet/airspec/CompatApi.scala
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.airframe.spec
+package wvlet.airspec
 
 import wvlet.airframe.surface.MethodSurface
 
@@ -21,12 +21,12 @@ import wvlet.airframe.surface.MethodSurface
 trait CompatApi {
   def isScalaJs: Boolean
 
-  private[spec] def findCompanionObjectOf(fullyQualifiedName: String, classLoader: ClassLoader): Option[Any]
-  private[spec] def newInstanceOf(fullyQualifiedName: String, classLoader: ClassLoader): Option[Any]
-  private[spec] def withLogScanner[U](block: => U): U
-  private[spec] def findCause(e: Throwable): Throwable
+  private[airspec] def findCompanionObjectOf(fullyQualifiedName: String, classLoader: ClassLoader): Option[Any]
+  private[airspec] def newInstanceOf(fullyQualifiedName: String, classLoader: ClassLoader): Option[Any]
+  private[airspec] def withLogScanner[U](block: => U): U
+  private[airspec] def findCause(e: Throwable): Throwable
 
-  private[spec] def methodSurfacesOf(cls: Class[_]): Seq[MethodSurface]
+  private[airspec] def methodSurfacesOf(cls: Class[_]): Seq[MethodSurface]
 
-  private[spec] def getSpecName(cls: Class[_]): String
+  private[airspec] def getSpecName(cls: Class[_]): String
 }

--- a/airspec/src/main/scala/wvlet/airspec/Framework.scala
+++ b/airspec/src/main/scala/wvlet/airspec/Framework.scala
@@ -11,18 +11,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.airframe.spec
+package wvlet.airspec
 
 import sbt.testing
 import sbt.testing.{Fingerprint, SubclassFingerprint}
-import wvlet.airframe.spec.runner.AirSpecRunner
+import wvlet.airspec.runner.AirSpecRunner
 
 /**
   * Include this class to your build.sbt:
-  * testFrameworks += new TestFramework("wvlet.airframe.spec.AirSpecFramework")
+  * testFrameworks += new TestFramework("wvlet.airspec.AirSpecFramework")
   */
-class AirSpecFramework extends sbt.testing.Framework {
-  import AirSpecFramework._
+class Framework extends sbt.testing.Framework {
+  import Framework._
   override def name(): String                     = "airspec"
   override def fingerprints(): Array[Fingerprint] = Array(AirSpecClassFingerPrint, AirSpecObjectFingerPrint)
   override def runner(args: Array[String], remoteArgs: Array[String], testClassLoader: ClassLoader): testing.Runner = {
@@ -37,17 +37,17 @@ class AirSpecFramework extends sbt.testing.Framework {
     runner(args, remoteArgs, testClassLoader)
 }
 
-object AirSpecFramework {
+object Framework {
 
-  private[spec] object AirSpecClassFingerPrint extends SubclassFingerprint {
+  private[airspec] object AirSpecClassFingerPrint extends SubclassFingerprint {
     override def isModule: Boolean                  = false
-    override def superclassName(): String           = "wvlet.airframe.spec.AirSpec"
+    override def superclassName(): String           = "wvlet.airspec.AirSpec"
     override def requireNoArgConstructor(): Boolean = true
   }
 
-  private[spec] object AirSpecObjectFingerPrint extends SubclassFingerprint {
+  private[airspec] object AirSpecObjectFingerPrint extends SubclassFingerprint {
     override def isModule: Boolean                  = true
-    override def superclassName(): String           = "wvlet.airframe.spec.AirSpec"
+    override def superclassName(): String           = "wvlet.airspec.AirSpec"
     override def requireNoArgConstructor(): Boolean = false
   }
 

--- a/airspec/src/main/scala/wvlet/airspec/package.scala
+++ b/airspec/src/main/scala/wvlet/airspec/package.scala
@@ -11,11 +11,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.airframe.spec
+package wvlet
 
 /**
-  * Platform-specific AirSpecApi implementation
+  *
   */
-trait PlatformAirSpec {
-  this: AirSpecSpi =>
+package object airspec {
+  // For Scala, Scala.js compatibility
+  val compat: CompatApi = wvlet.airspec.Compat
 }

--- a/airspec/src/main/scala/wvlet/airspec/runner/AirSpecContextImpl.scala
+++ b/airspec/src/main/scala/wvlet/airspec/runner/AirSpecContextImpl.scala
@@ -11,12 +11,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.airframe
-package spec.runner
+package wvlet.airspec.runner
 
-import wvlet.airframe.spec.AirSpecSpi
-import wvlet.airframe.spec.spi.AirSpecContext
+import wvlet.airframe.Session
 import wvlet.airframe.surface.{MethodSurface, Surface}
+import wvlet.airspec.AirSpecSpi
+import wvlet.airspec.spi.AirSpecContext
 import wvlet.log.LogSupport
 
 import scala.language.experimental.macros
@@ -24,11 +24,11 @@ import scala.language.experimental.macros
 /**
   *
   */
-private[spec] class AirSpecContextImpl(taskExecutor: AirSpecTaskRunner,
-                                       val parentContext: Option[AirSpecContext],
-                                       val currentSpec: AirSpecSpi,
-                                       val testName: String = "<init>",
-                                       val currentSession: Session)
+private[airspec] class AirSpecContextImpl(taskExecutor: AirSpecTaskRunner,
+                                          val parentContext: Option[AirSpecContext],
+                                          val currentSpec: AirSpecSpi,
+                                          val testName: String = "<init>",
+                                          val currentSession: Session)
     extends AirSpecContext
     with LogSupport {
 

--- a/airspec/src/main/scala/wvlet/airspec/runner/AirSpecLogger.scala
+++ b/airspec/src/main/scala/wvlet/airspec/runner/AirSpecLogger.scala
@@ -11,22 +11,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.airframe.spec.runner
+package wvlet.airspec.runner
 
 import java.util.concurrent.TimeUnit
 
-import sbt.testing.{Event, Fingerprint, OptionalThrowable, Selector, Status, TaskDef}
+import sbt.testing._
 import wvlet.airframe.log.AnsiColorPalette
 import wvlet.airframe.metrics.ElapsedTime
-import wvlet.airframe.spec.AirSpecSpi
-import wvlet.airframe.spec.spi.{AirSpecException, AirSpecFailureBase}
-import wvlet.log.{LogFormatter, LogRecord, Logger}
+import wvlet.airspec.AirSpecSpi
+import wvlet.airspec.spi.AirSpecFailureBase
+import wvlet.log.{LogFormatter, Logger}
 
-private[spec] case class AirSpecEvent(taskDef: TaskDef,
-                                      override val fullyQualifiedName: String,
-                                      override val status: Status,
-                                      override val throwable: OptionalThrowable,
-                                      durationNanos: Long)
+private[airspec] case class AirSpecEvent(taskDef: TaskDef,
+                                         override val fullyQualifiedName: String,
+                                         override val status: Status,
+                                         override val throwable: OptionalThrowable,
+                                         durationNanos: Long)
     extends Event {
   override def fingerprint(): Fingerprint = taskDef.fingerprint()
   override def selector(): Selector       = taskDef.selectors().head
@@ -36,13 +36,13 @@ private[spec] case class AirSpecEvent(taskDef: TaskDef,
 /**
   *
   */
-private[spec] class AirSpecLogger(sbtLoggers: Array[sbt.testing.Logger]) extends AnsiColorPalette {
+private[airspec] class AirSpecLogger(sbtLoggers: Array[sbt.testing.Logger]) extends AnsiColorPalette {
   // Always use ANSI color log for Travis because sbt's ansiCodeSupported() returns false even though it can show ANSI colors
   private val useAnciColor = {
     AirSpecSpi.inTravisCI || sbtLoggers.forall(_.ansiCodesSupported())
   }
 
-  private val airSpecLogger = Logger("wvlet.airframe.spec.AirSpec")
+  private val airSpecLogger = Logger("wvlet.airspec.AirSpec")
   airSpecLogger.setFormatter(LogFormatter.BareFormatter)
 
   def withColor(colorEsc: String, s: String) = {
@@ -115,7 +115,7 @@ private[spec] class AirSpecLogger(sbtLoggers: Array[sbt.testing.Logger]) extends
     info(s"${indent(indentLevel)}${prefix}${tail}")
 
     if (showStackTraces) {
-      val ex         = wvlet.airframe.spec.compat.findCause(e.throwable.get())
+      val ex         = wvlet.airspec.compat.findCause(e.throwable.get())
       val stackTrace = LogFormatter.formatStacktrace(ex)
       error(stackTrace)
     }

--- a/airspec/src/main/scala/wvlet/airspec/runner/AirSpecRunner.scala
+++ b/airspec/src/main/scala/wvlet/airspec/runner/AirSpecRunner.scala
@@ -11,9 +11,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.airframe.spec.runner
+package wvlet.airspec.runner
+
 import sbt.testing.{Task, TaskDef}
-import wvlet.airframe.spec.runner.AirSpecRunner.AirSpecConfig
+import wvlet.airspec.runner.AirSpecRunner.AirSpecConfig
 import wvlet.log.{LogSupport, Logger}
 
 import scala.util.matching.Regex
@@ -21,7 +22,7 @@ import scala.util.matching.Regex
 /**
   * AirSpecRunner receives a list of TaskDefs from sbt, then create AirSpecTasks to execute.
   */
-private[spec] class AirSpecRunner(config: AirSpecConfig, val remoteArgs: Array[String], classLoader: ClassLoader)
+private[airspec] class AirSpecRunner(config: AirSpecConfig, val remoteArgs: Array[String], classLoader: ClassLoader)
     extends sbt.testing.Runner {
 
   override def args: Array[String] = config.args
@@ -50,7 +51,7 @@ private[spec] class AirSpecRunner(config: AirSpecConfig, val remoteArgs: Array[S
   }
 }
 
-private[spec] object AirSpecRunner extends LogSupport {
+private[airspec] object AirSpecRunner extends LogSupport {
   def newRunner(args: Array[String], remoteArgs: Array[String], testClassLoader: ClassLoader): AirSpecRunner = {
     debug(s"args: ${args.mkString(", ")}")
     debug(s"remote args: ${args.mkString(", ")}")

--- a/airspec/src/main/scala/wvlet/airspec/runner/AirSpecTask.scala
+++ b/airspec/src/main/scala/wvlet/airspec/runner/AirSpecTask.scala
@@ -11,10 +11,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.airframe.spec.runner
+package wvlet.airspec.runner
+
 import sbt.testing._
 import wvlet.airframe.Design
-import wvlet.airframe.spec.runner.AirSpecRunner.AirSpecConfig
+import wvlet.airspec.runner.AirSpecRunner.AirSpecConfig
 import wvlet.log.LogSupport
 
 import scala.concurrent.duration.Duration
@@ -23,7 +24,7 @@ import scala.concurrent.{Await, Promise}
 /**
   * AirSpecTask is a unit of test execution.
   */
-private[spec] class AirSpecTask(config: AirSpecConfig, override val taskDef: TaskDef, classLoader: ClassLoader)
+private[airspec] class AirSpecTask(config: AirSpecConfig, override val taskDef: TaskDef, classLoader: ClassLoader)
     extends sbt.testing.Task
     with LogSupport {
 

--- a/airspec/src/main/scala/wvlet/airspec/runner/AirSpecTaskRunner.scala
+++ b/airspec/src/main/scala/wvlet/airspec/runner/AirSpecTaskRunner.scala
@@ -11,17 +11,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.airframe.spec.runner
+package wvlet.airspec.runner
 
-import java.util.concurrent.TimeUnit
-
-import sbt.testing.{Event, EventHandler, Fingerprint, OptionalThrowable, Selector, Status, SubclassFingerprint, TaskDef}
+import sbt.testing._
 import wvlet.airframe.AirframeException.MISSING_DEPENDENCY
 import wvlet.airframe.Design
-import wvlet.airframe.spec.{AirSpecSpi, compat}
-import wvlet.airframe.spec.runner.AirSpecRunner.AirSpecConfig
-import wvlet.airframe.spec.spi.{AirSpecContext, AirSpecException, MissingTestDependency}
 import wvlet.airframe.surface.MethodSurface
+import wvlet.airspec.AirSpecSpi
+import wvlet.airspec.runner.AirSpecRunner.AirSpecConfig
+import wvlet.airspec.spi.{AirSpecContext, AirSpecException, MissingTestDependency}
 import wvlet.log.LogSupport
 
 import scala.util.{Failure, Success, Try}
@@ -35,11 +33,12 @@ import scala.util.{Failure, Success, Try}
   * For each test method in the AirSpec instance, it will create a child session so that
   * users can manage test-method local instances, which will be discarded after the completion of the test method.
   */
-private[spec] class AirSpecTaskRunner(taskDef: TaskDef,
-                                      config: AirSpecConfig,
-                                      taskLogger: AirSpecLogger,
-                                      eventHandler: EventHandler)
+private[airspec] class AirSpecTaskRunner(taskDef: TaskDef,
+                                         config: AirSpecConfig,
+                                         taskLogger: AirSpecLogger,
+                                         eventHandler: EventHandler)
     extends LogSupport {
+  import wvlet.airspec._
 
   def runTask(task: TaskDef, classLoader: ClassLoader): Unit = {
     val testClassName = taskDef.fullyQualifiedName()

--- a/airspec/src/main/scala/wvlet/airspec/spi/AirSpecContext.scala
+++ b/airspec/src/main/scala/wvlet/airspec/spi/AirSpecContext.scala
@@ -11,11 +11,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.airframe.spec.spi
+package wvlet.airspec.spi
 
 import wvlet.airframe.Session
-import wvlet.airframe.spec.{AirSpecBase, AirSpecMacros, AirSpecSpi}
 import wvlet.airframe.surface.{MethodSurface, Surface}
+import wvlet.airspec.{AirSpecBase, AirSpecMacros, AirSpecSpi}
 
 import scala.language.experimental.macros
 

--- a/airspec/src/main/scala/wvlet/airspec/spi/AirSpecException.scala
+++ b/airspec/src/main/scala/wvlet/airspec/spi/AirSpecException.scala
@@ -11,11 +11,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.airframe.spec.spi
+package wvlet.airspec.spi
 
 import sbt.testing.Status
 import wvlet.airframe.SourceCode
-import wvlet.airframe.spec.compat
+import wvlet.airspec._
 
 /**
   * Define exceptions that will be used for various test failures
@@ -52,7 +52,7 @@ case class InterceptException(message: String, code: SourceCode) extends AirSpec
 case class MissingTestDependency(message: String) extends AirSpecException {}
 
 object AirSpecException {
-  private[spec] def classifyException(e: Throwable): Status = {
+  private[airspec] def classifyException(e: Throwable): Status = {
     compat.findCause(e) match {
       case a: AssertionFailure => Status.Failure
       case i: Ignored          => Status.Ignored

--- a/airspec/src/main/scala/wvlet/airspec/spi/Asserts.scala
+++ b/airspec/src/main/scala/wvlet/airspec/spi/Asserts.scala
@@ -11,10 +11,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.airframe.spec.spi
+package wvlet.airspec.spi
 
 import wvlet.airframe.SourceCode
-import wvlet.airframe.spec.{AirSpecMacros, AirSpecSpi}
+import wvlet.airspec.{AirSpecMacros, AirSpecSpi}
 
 import scala.language.experimental.macros
 import scala.reflect.ClassTag

--- a/airspec/src/main/scala/wvlet/airspec/spi/PropertyCheck.scala
+++ b/airspec/src/main/scala/wvlet/airspec/spi/PropertyCheck.scala
@@ -11,12 +11,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.airframe.spec.spi
+package wvlet.airspec.spi
 
 import org.scalacheck.Test.{Parameters, PropException, Result}
 import org.scalacheck.util.Pretty
-import wvlet.airframe.spec.AirSpecSpi
 import org.scalacheck.{Arbitrary, Gen, Prop, Shrink, Test}
+import wvlet.airspec.AirSpecSpi
 
 /**
   *

--- a/airspec/src/main/scala/wvlet/airspec/spi/RichAsserts.scala
+++ b/airspec/src/main/scala/wvlet/airspec/spi/RichAsserts.scala
@@ -11,12 +11,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.airframe.spec.spi
+package wvlet.airspec.spi
 
 import java.util
 
 import wvlet.airframe.SourceCode
-import wvlet.airframe.spec.AirSpecSpi
+import wvlet.airspec.AirSpecSpi
 import wvlet.log.LogSupport
 
 /**
@@ -52,12 +52,12 @@ trait RichAsserts extends LogSupport { this: AirSpecSpi =>
     }
   }
 
-  private[spec] sealed trait OptionTarget {
+  private[airspec] sealed trait OptionTarget {
     def check[A](v: A, isEmpty: Boolean, code: SourceCode): Unit
     def flip: OptionTarget
   }
 
-  private[spec] case object DefinedTarget extends OptionTarget {
+  private[airspec] case object DefinedTarget extends OptionTarget {
     override def check[A](v: A, isEmpty: Boolean, code: SourceCode): Unit = {
       if (isEmpty) {
         throw AssertionFailure(s"${v} is empty", code)
@@ -66,7 +66,7 @@ trait RichAsserts extends LogSupport { this: AirSpecSpi =>
     override def flip: OptionTarget = EmptyTarget
   }
 
-  private[spec] case object EmptyTarget extends OptionTarget {
+  private[airspec] case object EmptyTarget extends OptionTarget {
     override def check[A](v: A, isEmpty: Boolean, code: SourceCode): Unit = {
       if (!isEmpty) {
         throw AssertionFailure(s"${v} is not empty", code)

--- a/airspec/src/test/scala/examples/CommonSpec.scala
+++ b/airspec/src/test/scala/examples/CommonSpec.scala
@@ -13,7 +13,7 @@
  */
 package examples
 
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 
 /**
   *

--- a/airspec/src/test/scala/examples/ContextTest.scala
+++ b/airspec/src/test/scala/examples/ContextTest.scala
@@ -14,8 +14,8 @@
 package examples
 
 import wvlet.airframe.Design
-import wvlet.airframe.spec.AirSpec
-import wvlet.airframe.spec.spi.AirSpecContext
+import wvlet.airspec.spi.AirSpecContext
+import wvlet.airspec.AirSpec
 
 /**
   *

--- a/airspec/src/test/scala/examples/PropertyTest.scala
+++ b/airspec/src/test/scala/examples/PropertyTest.scala
@@ -13,8 +13,8 @@
  */
 package examples
 
-import wvlet.airframe.spec.AirSpec
-import wvlet.airframe.spec.spi.PropertyCheck
+import wvlet.airspec.spi.PropertyCheck
+import wvlet.airspec.AirSpec
 
 /**
   *

--- a/airspec/src/test/scala/examples/ShouldBeTest.scala
+++ b/airspec/src/test/scala/examples/ShouldBeTest.scala
@@ -13,8 +13,8 @@
  */
 package examples
 
-import wvlet.airframe.spec.AirSpec
-import wvlet.airframe.spec.spi.AssertionFailure
+import wvlet.airspec.spi.AssertionFailure
+import wvlet.airspec.AirSpec
 
 /**
   *

--- a/airspec/src/test/scala/examples/TestJSSpec.scala
+++ b/airspec/src/test/scala/examples/TestJSSpec.scala
@@ -14,7 +14,7 @@
 package examples
 
 import wvlet.airframe.Design
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 import wvlet.log.LogSupport
 
 /**

--- a/airspec/src/test/scala/examples/TestSpec.scala
+++ b/airspec/src/test/scala/examples/TestSpec.scala
@@ -14,8 +14,8 @@
 package examples
 
 import wvlet.airframe.Design
-import wvlet.airframe.spec.AirSpec
-import wvlet.airframe.spec.spi.AirSpecException
+import wvlet.airspec.spi.AirSpecException
+import wvlet.airspec.AirSpec
 import wvlet.log.LogSupport
 
 /**

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ val SCALA_PARSER_COMBINATOR_VERSION = "1.1.2"
 val SQLITE_JDBC_VERSION             = "3.27.2"
 val SLF4J_VERSION                   = "1.7.25"
 val JS_JAVA_LOGGING_VERSION         = "0.1.5"
-val airSpecFramework                = new TestFramework("wvlet.airframe.spec.AirSpecFramework")
+val airSpecFramework                = new TestFramework("wvlet.airspec.Framework")
 
 // Allow using Ctrl+C in sbt without exiting the prompt
 cancelable in Global := true
@@ -33,6 +33,7 @@ val isRelease: Boolean = sys.env.isDefinedAt("RELEASE")
 dynverSonatypeSnapshots in ThisBuild := !isRelease
 
 // For publishing in Travis CI
+
 lazy val travisSettings = List(
   // For publishing on Travis CI
   useGpg := false,

--- a/examples/src/test/scala/wvlet/airframe/examples/ExamplesSpec.scala
+++ b/examples/src/test/scala/wvlet/airframe/examples/ExamplesSpec.scala
@@ -13,8 +13,8 @@
  */
 package wvlet.airframe.examples
 
-import wvlet.airframe.spec.AirSpec
 import wvlet.airframe.surface.reflect.ReflectTypeUtil
+import wvlet.airspec.AirSpec
 import wvlet.log.io.Resource
 
 /**

--- a/examples/src/test/scala/wvlet/airframe/examples/airspec/AIrSpec_01_Basic.scala
+++ b/examples/src/test/scala/wvlet/airframe/examples/airspec/AIrSpec_01_Basic.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.examples.airspec
 
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 
 /**
   *

--- a/examples/src/test/scala/wvlet/airframe/examples/airspec/AirSpec_02_ReuseTests.scala
+++ b/examples/src/test/scala/wvlet/airframe/examples/airspec/AirSpec_02_ReuseTests.scala
@@ -13,8 +13,8 @@
  */
 package wvlet.airframe.examples.airspec
 
-import wvlet.airframe.spec.AirSpec
-import wvlet.airframe.spec.spi.AirSpecContext
+import wvlet.airspec.spi.AirSpecContext
+import wvlet.airspec.AirSpec
 
 /**
   *

--- a/examples/src/test/scala/wvlet/airframe/examples/airspec/AirSpec_03_DI.scala
+++ b/examples/src/test/scala/wvlet/airframe/examples/airspec/AirSpec_03_DI.scala
@@ -14,7 +14,7 @@
 package wvlet.airframe.examples.airspec
 
 import wvlet.airframe.Design
-import wvlet.airframe.spec.AirSpec
+import wvlet.airspec.AirSpec
 
 /**
   *


### PR DESCRIPTION
This change is for importing airspec with a handy syntax:
```scala
import wvlet.airspec._
````