### PR TITLE
airspec: #610: Avoid registering JVM shutdown hooks in airspec sessions

### DIFF
--- a/airframe/src/main/scala/wvlet/airframe/SessionBuilder.scala
+++ b/airframe/src/main/scala/wvlet/airframe/SessionBuilder.scala
@@ -55,6 +55,8 @@ class SessionBuilder(design: Design,
     new SessionBuilder(design, parent, name, false, lifeCycleEventHandler)
   }
 
+  def build: Session = create
+
   def create: Session = {
     // Remove duplicate bindings in the design
     val d = design.minimize

--- a/airspec/src/main/scala/wvlet/airspec/runner/AirSpecTaskRunner.scala
+++ b/airspec/src/main/scala/wvlet/airspec/runner/AirSpecTaskRunner.scala
@@ -118,7 +118,7 @@ private[airspec] class AirSpecTaskRunner(taskDef: TaskDef,
       val globalSession =
         parentContext
           .map(_.currentSession.newChildSession(d))
-          .getOrElse { d.newSession }
+          .getOrElse { d.newSessionBuilder.noShutdownHook.build } // Do not register JVM shutdown hooks
 
       globalSession.start {
         for (m <- targetMethods) {


### PR DESCRIPTION
Fixes #610