### PR TITLE
airspec: #612: Fixes java.lang.ClassNotFoundException: scala.reflect.api.Trees

### DIFF
--- a/airspec/src/main/scala/wvlet/airspec/AirSpec.scala
+++ b/airspec/src/main/scala/wvlet/airspec/AirSpec.scala
@@ -16,6 +16,7 @@ package wvlet.airspec
 import wvlet.airframe.Design
 import wvlet.airspec.spi.{Asserts, RichAsserts}
 import wvlet.airframe.surface.MethodSurface
+import wvlet.airspec
 
 import scala.language.experimental.macros
 import scala.reflect.macros.{blackbox => sm}
@@ -84,7 +85,7 @@ private[airspec] trait AirSpecSpi {
   protected def afterAll: Unit  = {}
 
   // Returns true if this is running in TravisCI
-  protected def inTravisCI: Boolean = AirSpecSpi.inTravisCI
+  protected def inTravisCI: Boolean = airspec.inTravisCI
 
   protected def isScalaJS: Boolean = compat.isScalaJs
 }
@@ -111,10 +112,6 @@ private[airspec] object AirSpecSpi {
     import c.universe._
     val t = c.prefix.actualType.typeSymbol
     q"if(wvlet.airspec.compat.isScalaJs) { ${c.prefix}._methodSurfaces = wvlet.airframe.surface.Surface.methodsOf[${t}] }"
-  }
-
-  private[airspec] def inTravisCI: Boolean = {
-    sys.env.get("TRAVIS").map(_.toBoolean).getOrElse(false)
   }
 
   private[airspec] def decodeClassName(clsName: String): String = {

--- a/airspec/src/main/scala/wvlet/airspec/package.scala
+++ b/airspec/src/main/scala/wvlet/airspec/package.scala
@@ -19,4 +19,8 @@ package wvlet
 package object airspec {
   // For Scala, Scala.js compatibility
   val compat: CompatApi = wvlet.airspec.Compat
+
+  private[airspec] lazy val inTravisCI: Boolean = {
+    sys.env.get("TRAVIS").map(_.toBoolean).getOrElse(false)
+  }
 }

--- a/airspec/src/main/scala/wvlet/airspec/runner/AirSpecLogger.scala
+++ b/airspec/src/main/scala/wvlet/airspec/runner/AirSpecLogger.scala
@@ -18,9 +18,8 @@ import java.util.concurrent.TimeUnit
 import sbt.testing._
 import wvlet.airframe.log.AnsiColorPalette
 import wvlet.airframe.metrics.ElapsedTime
-import wvlet.airspec.AirSpecSpi
 import wvlet.airspec.spi.AirSpecFailureBase
-import wvlet.log.{ConsoleLogHandler, LogFormatter, Logger}
+import wvlet.log.{LogFormatter, Logger}
 
 private[airspec] case class AirSpecEvent(taskDef: TaskDef,
                                          override val fullyQualifiedName: String,
@@ -38,9 +37,7 @@ private[airspec] case class AirSpecEvent(taskDef: TaskDef,
   */
 private[airspec] class AirSpecLogger() extends AnsiColorPalette {
   // Always use ANSI color log for Travis because sbt's ansiCodeSupported() returns false even though it can show ANSI colors
-  private val useAnciColor = {
-    AirSpecSpi.inTravisCI || true //|| sbtLoggers.forall(_.ansiCodesSupported())
-  }
+  private val useAnciColor = true
 
   private val airSpecLogger = {
     val l = Logger("wvlet.airspec.runner.AirSpecLogger")

--- a/airspec/src/main/scala/wvlet/airspec/runner/AirSpecRunner.scala
+++ b/airspec/src/main/scala/wvlet/airspec/runner/AirSpecRunner.scala
@@ -25,7 +25,7 @@ import scala.util.matching.Regex
 private[airspec] class AirSpecRunner(config: AirSpecConfig, val remoteArgs: Array[String], classLoader: ClassLoader)
     extends sbt.testing.Runner {
 
-  private val taskLogger = new AirSpecLogger()
+  private lazy val taskLogger = new AirSpecLogger()
 
   override def args: Array[String] = config.args
 


### PR DESCRIPTION
sbt detaches the classloader early while lazy initialization of AirSpecLogger is running