### PR TITLE
airframe-http-recorder: Store records to .airframe/http folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ package-lock.json
 pgdata
 travis
 fixtures
+.airframe

--- a/airframe-http-recorder/src/test/scala/wvlet/airframe/http/recorder/HttpRecorderTest.scala
+++ b/airframe-http-recorder/src/test/scala/wvlet/airframe/http/recorder/HttpRecorderTest.scala
@@ -204,8 +204,8 @@ class HttpRecorderTest extends AirSpec {
   }
 
   def `support simple request matcher`: Unit = {
-    val config = HttpRecorderConfig(sessionName = ":memory:", requestMatcher = SimpleRequestMatcher)
-    withResource(HttpRecorder.createProgrammableServer(config)) { server =>
+    val config = HttpRecorderConfig(requestMatcher = SimpleRequestMatcher)
+    withResource(HttpRecorder.createInMemoryServer(config)) { server =>
       val request = Request("/airframe")
       request.accept = "application/v1+json"
       val response = Response()


### PR DESCRIPTION
- And allow configuring in-memory recorders
- Use 1M default expiration range

This change is for not creating too many database files.