### PR TITLE
airframe-http-client: Add HOST header if missing

### DIFF
--- a/airframe-http-finagle/src/main/scala/wvlet/airframe/http/finagle/FinagleClient.scala
+++ b/airframe-http-finagle/src/main/scala/wvlet/airframe/http/finagle/FinagleClient.scala
@@ -54,7 +54,12 @@ class FinagleClient(address: ServerAddress, config: FinagleClientConfig)
   }
 
   override def send(req: Request): Future[Response] = {
-    client.apply(config.requestFilter(req))
+    val request = config.requestFilter(req)
+    // Add HOST header if missing
+    if (request.host.isEmpty) {
+      request.host = address.hostAndPort
+    }
+    client.apply(request)
   }
 
   /**


### PR DESCRIPTION
nginx proxy requires HOST header