### PR TITLE
airframe-surface: Support inner classes

### DIFF
--- a/airframe-codec/.jvm/src/test/scala/wvlet/airframe/codec/InnerClassCodecTest.scala
+++ b/airframe-codec/.jvm/src/test/scala/wvlet/airframe/codec/InnerClassCodecTest.scala
@@ -13,23 +13,14 @@
  */
 package wvlet.airframe.codec
 
-import wvlet.airframe.surface.Surface
 import wvlet.airspec.AirSpec
 
 /**
   *
   */
-class InnerClassFactoryTest extends AirSpec {
+class InnerClassCodecTest extends AirSpec {
 
   case class A(id: Int, name: String)
-
-  def `pass inner class context to Surface`: Unit = {
-    val s = Surface.of[A]
-    val a = s.objectFactory.map { x =>
-      x.newInstance(Seq(1, "leo"))
-    }
-    a shouldBe Some(A(1, "leo"))
-  }
 
   def `support codec for inner classes`: Unit = {
     val codec   = MessageCodec.of[A]
@@ -37,18 +28,5 @@ class InnerClassFactoryTest extends AirSpec {
     val msgpack = codec.toMsgPack(a)
     val a1      = codec.unpackMsgPack(msgpack)
     a1 shouldBe Some(a)
-  }
-
-  def `throw IllegalStateException when failed to find the outer class instance`: Unit = {
-    intercept[IllegalStateException] {
-      new {
-        val s = Surface.of[A]
-        val v = {
-          s.objectFactory.map { x =>
-            x.newInstance(Seq(1, "leo"))
-          }
-        }
-      }
-    }
   }
 }

--- a/airframe-codec/.jvm/src/test/scala/wvlet/airframe/codec/InnerClassFactoryTest.scala
+++ b/airframe-codec/.jvm/src/test/scala/wvlet/airframe/codec/InnerClassFactoryTest.scala
@@ -23,7 +23,7 @@ class InnerClassFactoryTest extends AirSpec {
 
   case class A(id: Int, name: String)
 
-  def `pass contest in Surface`: Unit = {
+  def `pass inner class context to Surface`: Unit = {
     val s = Surface.of[A]
     val a = s.objectFactory.map { x =>
       x.newInstance(Seq(1, "leo"))
@@ -31,7 +31,7 @@ class InnerClassFactoryTest extends AirSpec {
     a shouldBe Some(A(1, "leo"))
   }
 
-  def `support inner class codec`: Unit = {
+  def `support codec for inner classes`: Unit = {
     val codec   = MessageCodec.of[A]
     val a       = A(1, "leo")
     val msgpack = codec.toMsgPack(a)

--- a/airframe-codec/.jvm/src/test/scala/wvlet/airframe/codec/InnerClassFactoryTest.scala
+++ b/airframe-codec/.jvm/src/test/scala/wvlet/airframe/codec/InnerClassFactoryTest.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.codec
+
+import wvlet.airframe.surface.Surface
+import wvlet.airspec.AirSpec
+
+/**
+  *
+  */
+class InnerClassFactoryTest extends AirSpec {
+
+  case class A(id: Int, name: String)
+
+  def `pass contest in Surface`: Unit = {
+    val s = Surface.of[A]
+    val a = s.objectFactory.map { x =>
+      x.newInstance(Seq(1, "leo"))
+    }
+    a shouldBe Some(A(1, "leo"))
+  }
+
+  def `support inner class codec`: Unit = {
+    val codec   = MessageCodec.of[A]
+    val a       = A(1, "leo")
+    val msgpack = codec.toMsgPack(a)
+    val a1      = codec.unpackMsgPack(msgpack)
+    a1 shouldBe Some(a)
+  }
+
+  def `throw IllegalStateException when failed to find the outer class instance`: Unit = {
+    intercept[IllegalStateException] {
+      new {
+        val s = Surface.of[A]
+        val v = {
+          s.objectFactory.map { x =>
+            x.newInstance(Seq(1, "leo"))
+          }
+        }
+      }
+    }
+  }
+}

--- a/airframe-surface/js/src/main/scala/wvlet/airframe/surface/SurfaceFactory.scala
+++ b/airframe-surface/js/src/main/scala/wvlet/airframe/surface/SurfaceFactory.scala
@@ -20,6 +20,7 @@ import scala.language.experimental.macros
   */
 object SurfaceFactory {
   def of[A]: Surface = macro SurfaceMacros.of[A]
-  def localSurfaceOf[A](context: Any): Surface = ???
+  // TODO support inner clases in Scala.js
+  def localSurfaceOf[A](context: Any): Surface = macro SurfaceMacros.localSurfaceOf[A]
   def methodsOf[A]: Seq[MethodSurface] = macro SurfaceMacros.methodsOf[A]
 }

--- a/airframe-surface/js/src/main/scala/wvlet/airframe/surface/SurfaceFactory.scala
+++ b/airframe-surface/js/src/main/scala/wvlet/airframe/surface/SurfaceFactory.scala
@@ -20,5 +20,6 @@ import scala.language.experimental.macros
   */
 object SurfaceFactory {
   def of[A]: Surface = macro SurfaceMacros.of[A]
+  def localSurfaceOf[A](context: Any): Surface = ???
   def methodsOf[A]: Seq[MethodSurface] = macro SurfaceMacros.methodsOf[A]
 }

--- a/airframe-surface/jvm/src/main/scala/wvlet/airframe/surface/SurfaceFactory.scala
+++ b/airframe-surface/jvm/src/main/scala/wvlet/airframe/surface/SurfaceFactory.scala
@@ -21,6 +21,9 @@ import scala.reflect.runtime.{universe => ru}
   *
   */
 object SurfaceFactory {
-  def of[A: ru.WeakTypeTag]: Surface                   = ReflectSurfaceFactory.of[A]
+  def of[A: ru.WeakTypeTag]: Surface                           = ReflectSurfaceFactory.of[A]
+  def localSurfaceOf[A: ru.WeakTypeTag](context: Any): Surface = ReflectSurfaceFactory.localSurfaceOf[A](context)
+
   def methodsOf[A: ru.WeakTypeTag]: Seq[MethodSurface] = ReflectSurfaceFactory.methodsOf[A]
+
 }

--- a/airframe-surface/jvm/src/main/scala/wvlet/airframe/surface/SurfaceFactory.scala
+++ b/airframe-surface/jvm/src/main/scala/wvlet/airframe/surface/SurfaceFactory.scala
@@ -23,7 +23,5 @@ import scala.reflect.runtime.{universe => ru}
 object SurfaceFactory {
   def of[A: ru.WeakTypeTag]: Surface                           = ReflectSurfaceFactory.of[A]
   def localSurfaceOf[A: ru.WeakTypeTag](context: Any): Surface = ReflectSurfaceFactory.localSurfaceOf[A](context)
-
-  def methodsOf[A: ru.WeakTypeTag]: Seq[MethodSurface] = ReflectSurfaceFactory.methodsOf[A]
-
+  def methodsOf[A: ru.WeakTypeTag]: Seq[MethodSurface]         = ReflectSurfaceFactory.methodsOf[A]
 }

--- a/airframe-surface/jvm/src/main/scala/wvlet/airframe/surface/reflect/ReflectSurfaceFactory.scala
+++ b/airframe-surface/jvm/src/main/scala/wvlet/airframe/surface/reflect/ReflectSurfaceFactory.scala
@@ -470,10 +470,6 @@ object ReflectSurfaceFactory extends LogSupport {
         val typeArgs           = typeArgsOf(t).map(surfaceOf(_)).toIndexedSeq
         val methodParams       = methodParametersOf(t, primaryConstructor)
 
-        if (!t.typeSymbol.isStatic) {
-          // t is an inner class
-
-        }
         val s = new RuntimeGenericSurface(
           resolveClass(t),
           typeArgs,

--- a/airframe-surface/jvm/src/test/scala/wvlet/airframe/surface/InnerClassTest.scala
+++ b/airframe-surface/jvm/src/test/scala/wvlet/airframe/surface/InnerClassTest.scala
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.surface
+
+import wvlet.airspec.AirSpec
+
+/**
+  *
+  */
+class InnerClassTest extends AirSpec {
+  case class A(id: Int, name: String)
+
+  def `pass inner class context to Surface`: Unit = {
+    val s = Surface.of[A]
+    val a = s.objectFactory.map { x =>
+      x.newInstance(Seq(1, "leo"))
+    }
+    a shouldBe Some(A(1, "leo"))
+  }
+
+  def `throw IllegalStateException when failed to find the outer class instance`: Unit = {
+    intercept[IllegalStateException] {
+      new {
+        val s = Surface.of[A]
+        s.objectFactory.map { x =>
+          x.newInstance(Seq(1, "leo"))
+        }
+      }
+    }
+  }
+}

--- a/airframe-surface/jvm/src/test/scala/wvlet/airframe/surface/InnerClassTest.scala
+++ b/airframe-surface/jvm/src/test/scala/wvlet/airframe/surface/InnerClassTest.scala
@@ -30,7 +30,7 @@ class InnerClassTest extends AirSpec {
   }
 
   def `throw IllegalStateException when failed to find the outer class instance`: Unit = {
-    intercept[IllegalStateException] {
+    val e = intercept[IllegalStateException] {
       new {
         val s = Surface.of[A]
         s.objectFactory.map { x =>
@@ -38,5 +38,6 @@ class InnerClassTest extends AirSpec {
         }
       }
     }
+    e.getMessage.contains(s"${this.getClass.getSimpleName}") shouldBe true
   }
 }

--- a/airframe-surface/shared/src/main/scala/wvlet/airframe/surface/SurfaceMacros.scala
+++ b/airframe-surface/shared/src/main/scala/wvlet/airframe/surface/SurfaceMacros.scala
@@ -24,7 +24,10 @@ private[surface] object SurfaceMacros {
   def surfaceOf[A: c.WeakTypeTag](c: sm.Context): c.Tree = {
     import c.universe._
     val targetType = implicitly[c.WeakTypeTag[A]].tpe
-    if (targetType.typeSymbol.isStatic) {
+    val t          = targetType.typeSymbol
+    // t can be an inner class (outer instance is necessary) or
+    // a path dependent type (no outer instance is necessary to use path dependent types)
+    if (t.isStatic || targetType.toString.contains("#")) {
       q"wvlet.airframe.surface.SurfaceFactory.of[${targetType}]"
     } else {
       q"wvlet.airframe.surface.SurfaceFactory.localSurfaceOf[${targetType}](this)"

--- a/airframe-surface/shared/src/main/scala/wvlet/airframe/surface/SurfaceMacros.scala
+++ b/airframe-surface/shared/src/main/scala/wvlet/airframe/surface/SurfaceMacros.scala
@@ -25,11 +25,10 @@ private[surface] object SurfaceMacros {
     import c.universe._
     val targetType = implicitly[c.WeakTypeTag[A]].tpe
     val t          = targetType.typeSymbol
-    // t can be an inner class (outer instance is necessary) or
-    // a path dependent type (no outer instance is necessary to use path dependent types)
-    if (t.isStatic || targetType.toString.contains("#")) {
+    if (t.isStatic) {
       q"wvlet.airframe.surface.SurfaceFactory.of[${targetType}]"
     } else {
+      // If t is non-static class (e.g., this.A), we need to pass its outer context instance (as this)
       q"wvlet.airframe.surface.SurfaceFactory.localSurfaceOf[${targetType}](this)"
     }
   }

--- a/airframe-surface/shared/src/main/scala/wvlet/airframe/surface/SurfaceMacros.scala
+++ b/airframe-surface/shared/src/main/scala/wvlet/airframe/surface/SurfaceMacros.scala
@@ -24,7 +24,11 @@ private[surface] object SurfaceMacros {
   def surfaceOf[A: c.WeakTypeTag](c: sm.Context): c.Tree = {
     import c.universe._
     val targetType = implicitly[c.WeakTypeTag[A]].tpe
-    q"wvlet.airframe.surface.SurfaceFactory.of[${targetType}]"
+    if (targetType.typeSymbol.isStatic) {
+      q"wvlet.airframe.surface.SurfaceFactory.of[${targetType}]"
+    } else {
+      q"wvlet.airframe.surface.SurfaceFactory.localSurfaceOf[${targetType}](this)"
+    }
   }
 
   def methodSurfaceOf[A: c.WeakTypeTag](c: sm.Context): c.Tree = {

--- a/airframe-surface/shared/src/main/scala/wvlet/airframe/surface/SurfaceMacros.scala
+++ b/airframe-surface/shared/src/main/scala/wvlet/airframe/surface/SurfaceMacros.scala
@@ -44,6 +44,11 @@ private[surface] object SurfaceMacros {
     new SurfaceGenerator[c.type](c).createSurfaceOf(targetType)
   }
 
+  def localSurfaceOf[A: c.WeakTypeTag](c: sm.Context)(context: c.Tree): c.Tree = {
+    val targetType = implicitly[c.WeakTypeTag[A]].tpe
+    new SurfaceGenerator[c.type](c).createSurfaceOf(targetType)
+  }
+
   def methodsOf[A: c.WeakTypeTag](c: sm.Context): c.Tree = {
     val targetType = implicitly[c.WeakTypeTag[A]].tpe
     new SurfaceGenerator[c.type](c).createMethodSurfaceOf(targetType)

--- a/airframe-tablet/src/main/scala/wvlet/airframe/tablet/obj/MapConverter.scala
+++ b/airframe-tablet/src/main/scala/wvlet/airframe/tablet/obj/MapConverter.scala
@@ -14,6 +14,7 @@
 package wvlet.airframe.tablet.obj
 
 import wvlet.airframe.surface.Surface
+import wvlet.airframe.surface.reflect.RuntimeSurface
 
 import scala.reflect.runtime.{universe => ru}
 
@@ -28,7 +29,7 @@ class MapConverter[A](surface: Surface) {
 }
 
 object MapConverter {
-  def of[A: ru.TypeTag]: MapConverter[A] = new MapConverter(Surface.of[A])
+  def of[A: ru.TypeTag]: MapConverter[A] = new MapConverter(RuntimeSurface.of[A])
 
   def toMap[A: ru.TypeTag](a: A): Map[String, Any] = {
     MapConverter.of[A].toMap(a)

--- a/airframe-tablet/src/test/scala/wvlet/airframe/tablet/obj/MapConverterTest.scala
+++ b/airframe-tablet/src/test/scala/wvlet/airframe/tablet/obj/MapConverterTest.scala
@@ -20,12 +20,9 @@ object MapConverterTest {
   case class Sample(name: String, id: Int)
 }
 
-/**
-  *
-  */
 class MapConverterTest extends AirSpec {
   def `convert to Map`: Unit = {
-    val s  = Sample("leo", 1)
+    val s  = Sample("leo", 10)
     val mc = MapConverter.of[Sample]
     val m  = mc.toMap(s)
     debug(m)

--- a/airframe/src/test/scala/wvlet/airframe/PathDependentTypeTest.scala
+++ b/airframe/src/test/scala/wvlet/airframe/PathDependentTypeTest.scala
@@ -35,7 +35,6 @@ class PathDependentTypeTest extends AirSpec {
 }
 
 object PathDependentType {
-
   object MyBackend extends JdbcBackend
 
   trait JdbcServcie {


### PR DESCRIPTION
This PR will support creating Surface.of[X] for inner classes by providing the context class instance when creating a surface. 

It would be possible to support Scala.js, but I didn't add this as we will not use this in Scala.js.

@takezoe, @smdmts 