### PR TITLE
airframe-di: Automatically register shutdown hooks for Closeable resources

### DIFF
--- a/airframe/.jvm/src/main/scala/wvlet/airframe/JSR250LifeCycleExecutor.scala
+++ b/airframe/.jvm/src/main/scala/wvlet/airframe/JSR250LifeCycleExecutor.scala
@@ -23,7 +23,7 @@ import scala.reflect.ClassTag
 
 class MethodCallHook(val injectee: Injectee, method: jl.reflect.Method) extends LifeCycleHook {
   override def toString: String = s"MethodCallHook for [${surface}]"
-  def execute: Unit = {
+  override def execute: Unit = {
     method.invoke(injectee.injectee)
   }
 }

--- a/airframe/.jvm/src/test/scala/wvlet/airframe/CloseableHookPrecedenceTest.scala
+++ b/airframe/.jvm/src/test/scala/wvlet/airframe/CloseableHookPrecedenceTest.scala
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+import javax.annotation.PreDestroy
+import wvlet.airspec.AirSpec
+
+/**
+  *
+  */
+class CloseableHookPrecedenceTest extends AirSpec {
+  class A extends AutoCloseable {
+    val closeIsCalled    = new AtomicBoolean(false)
+    val shutdownIsCalled = new AtomicBoolean(false)
+
+    override def close(): Unit = {
+      closeIsCalled.set(true)
+    }
+
+    @PreDestroy
+    def shutdown: Unit = {
+      shutdownIsCalled.set(true)
+    }
+  }
+
+  def `support closeable`: Unit = {
+    val a = new A
+    val d = newSilentDesign.bind[A].toInstance(a)
+    d.build[A] { a =>
+      }
+
+    a.closeIsCalled.get shouldBe false
+    a.shutdownIsCalled.get() shouldBe true
+  }
+}

--- a/airframe/.jvm/src/test/scala/wvlet/airframe/CloseableHookPrecedenceTest.scala
+++ b/airframe/.jvm/src/test/scala/wvlet/airframe/CloseableHookPrecedenceTest.scala
@@ -40,7 +40,7 @@ class CloseableHookPrecedenceTest extends AirSpec {
     val a = new A
     val d = newSilentDesign.bind[A].toInstance(a)
     d.build[A] { a =>
-      }
+    }
 
     a.closeIsCalled.get shouldBe false
     a.shutdownIsCalled.get() shouldBe true

--- a/airframe/README.md
+++ b/airframe/README.md
@@ -297,9 +297,13 @@ This pattern is useful since you usually need a single entry point for starting 
 
 ## Life Cycle
 
+__Update since version 19.9.0__: If objects injected by DI implements `def close(): Unit` function of java.lang.AutoCloseable interface, airframe will call the close method upon the session shutdown. To override this behavior, define your own `onShutdown` hook or use `@PreDestory` annotation.
+
 Server side application often requires resource management (e.g., network connection, threads, etc.). Airframe has a built-in object life cycle manager to implement these hooks:
 
 ```scala
+import wvlet.airframe._
+
 trait MyServerService {
   val service = bind[Server]
     .onInit( _.init )   // Called when the object is initialized
@@ -320,6 +324,7 @@ trait Server {
 }
 ```
 These life cycle hooks except `onInject` will be called only once when the binding type is singleton.
+
 
 ### Eager Initialization of Singletons for Production
 

--- a/airframe/src/main/scala/wvlet/airframe/AirframeSession.scala
+++ b/airframe/src/main/scala/wvlet/airframe/AirframeSession.scala
@@ -112,7 +112,7 @@ private[airframe] class AirframeSession(
     trace(s"[${name}] Creating a new shared child session with ${d}")
     val childSession = new AirframeSession(
       parent = Some(this),
-      sessionName,                                 // Should we add suffixes for child sessions?
+      sessionName, // Should we add suffixes for child sessions?
       new Design(design.designOptions, d.binding), // Inherit parent options
       stage,
       lifeCycleManager,
@@ -132,7 +132,7 @@ private[airframe] class AirframeSession(
         design = childDesign,
         parent = Some(this),
         name = None,
-        addShutdownHook = false,                                  // Disable registration of shutdown hooks
+        addShutdownHook = false, // Disable registration of shutdown hooks
         lifeCycleEventHandler = lifeCycleManager.coreEventHandler // Use only core lifecycle event handlers
       )
 
@@ -196,7 +196,7 @@ private[airframe] class AirframeSession(
     observedTypes.getOrElseUpdate(t, System.currentTimeMillis())
     Try(lifeCycleManager.onInit(t, injectee.asInstanceOf[AnyRef])).recover {
       case e: Throwable =>
-        error(s"Error occurred while executing onInject(${t}, ${injectee})", e)
+        error(s"Error occurred while executing onInit(${t}, ${injectee})", e)
         throw e
     }
     tracer.onInitInstanceEnd(this, t, injectee)

--- a/airframe/src/main/scala/wvlet/airframe/AirframeSession.scala
+++ b/airframe/src/main/scala/wvlet/airframe/AirframeSession.scala
@@ -112,7 +112,7 @@ private[airframe] class AirframeSession(
     trace(s"[${name}] Creating a new shared child session with ${d}")
     val childSession = new AirframeSession(
       parent = Some(this),
-      sessionName, // Should we add suffixes for child sessions?
+      sessionName,                                 // Should we add suffixes for child sessions?
       new Design(design.designOptions, d.binding), // Inherit parent options
       stage,
       lifeCycleManager,
@@ -132,7 +132,7 @@ private[airframe] class AirframeSession(
         design = childDesign,
         parent = Some(this),
         name = None,
-        addShutdownHook = false, // Disable registration of shutdown hooks
+        addShutdownHook = false,                                  // Disable registration of shutdown hooks
         lifeCycleEventHandler = lifeCycleManager.coreEventHandler // Use only core lifecycle event handlers
       )
 

--- a/airframe/src/test/scala/wvlet/airframe/CloseableShutdownHookTest.scala
+++ b/airframe/src/test/scala/wvlet/airframe/CloseableShutdownHookTest.scala
@@ -35,7 +35,7 @@ class CloseableShutdownHookTest extends AirSpec {
     val a = new A
     val d = newSilentDesign.bind[A].toInstance(a)
     d.build[A] { a =>
-      }
+    }
 
     a.closeIsCalled.get() shouldBe true
   }

--- a/airframe/src/test/scala/wvlet/airframe/CloseableShutdownHookTest.scala
+++ b/airframe/src/test/scala/wvlet/airframe/CloseableShutdownHookTest.scala
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+import wvlet.airspec.AirSpec
+
+/**
+  *
+  */
+class CloseableShutdownHookTest extends AirSpec {
+  scalaJsSupport
+
+  class A extends AutoCloseable {
+    val closeIsCalled = new AtomicBoolean(false)
+
+    override def close(): Unit = {
+      closeIsCalled.set(true)
+    }
+  }
+
+  def `support closeable`: Unit = {
+    val a = new A
+    val d = newSilentDesign.bind[A].toInstance(a)
+    d.build[A] { a =>
+      }
+
+    a.closeIsCalled.get() shouldBe true
+  }
+
+  trait A1 {
+    val onShutdownIsCalled = new AtomicBoolean(false)
+    val a = bind[A].onShutdown { x =>
+      onShutdownIsCalled.set(true)
+    }
+  }
+
+  def `favor onShutdownHook`: Unit = {
+    val x = newSilentDesign
+      .build[A1] { a1 =>
+        a1
+      }.asInstanceOf[A1]
+
+    x.onShutdownIsCalled.get shouldBe true
+    x.a.closeIsCalled.get shouldBe false
+  }
+}

--- a/airspec/README.md
+++ b/airspec/README.md
@@ -343,7 +343,7 @@ class Service(config:ServerConfig) extends LogSupport {
   }
 
   @PreDestroy
-  def end {
+  def stop {
     info(s"Stopping the server at ${config.port}")
   }
 }


### PR DESCRIPTION
#644 

@takezoe @Lewuathe 
What I'm expecting for this review is getting questions around how Airframe DI's lifecycle hooks work in general, rather than checking the details of this PR. 

Related code:
- default life cycle handler chain: https://github.com/wvlet/airframe/blob/b20fd4e98ea51817477b2d49319d4922472b26e1/airframe/src/main/scala/wvlet/airframe/LifeCycleManager.scala#L181

- init life cycle hook is called when a new instance is injected:  https://github.com/wvlet/airframe/blob/b20fd4e98ea51817477b2d49319d4922472b26e1/airframe/src/main/scala/wvlet/airframe/AirframeSession.scala#L197