### PR TITLE
Upgrade to sbt-sonatype 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,7 @@ jobs:
       before_script: psql -c 'create database travis_ci_test;' -U postgres
       script: ./sbt ++$SCALA_VERSION ${PROJECT}/test
     - stage: cleanup
-      script: ./sbt sonatypeDropAll
+      script: ./sbt sonatypePrepare
     - stage: publish
       env: PROJECT=publish TARGET=2.12
       jdk: openjdk8
@@ -107,7 +107,7 @@ jobs:
       script:
         - cd $TRAVIS_BUILD_DIR && ./scripts/publish.sh
     - stage: release
-      script: ./sbt sonatypeReleaseAll
+      script: ./sbt sonatypeRelease
 
 env:
   global:

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.xerial.sbt"     % "sbt-sonatype"             % "2.6")
+addSbtPlugin("org.xerial.sbt"     % "sbt-sonatype"             % "3.0")
 addSbtPlugin("com.jsuereth"       % "sbt-pgp"                  % "2.0.0-M2")
 addSbtPlugin("org.scoverage"      % "sbt-scoverage"            % "1.5.1")
 addSbtPlugin("org.scalameta"      % "sbt-scalafmt"             % "2.0.3")

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -13,16 +13,16 @@ if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" -o "$
      # Publish a release version
      case "$TARGET" in
        2.12)
-         RELEASE=true ./sbt ++2.12.8 "; projectJVM2_13/publishSigned; projectJVM2_12/publishSigned"
+         RELEASE=true ./sbt ++2.12.8 "; sonatypeOpen; projectJVM2_13/publishSigned; projectJVM2_12/publishSigned"
          ;;
        2.13)
-         RELEASE=true ./sbt ++2.13.0 "projectJVM2_13/publishSigned"
+         RELEASE=true ./sbt ++2.13.0 "; sonatypeOpen; projectJVM2_13/publishSigned"
          ;;
        2.11)
-         RELEASE=true ./sbt ++2.11.11 "; projectJVM2_13/publishSigned; projectJVM2_12/publishSigned"
+         RELEASE=true ./sbt ++2.11.11 "; sonatypeOpen; projectJVM2_13/publishSigned; projectJVM2_12/publishSigned"
          ;;
        js)
-         RELEASE=true ./sbt "projectJS/publishSigned"
+         RELEASE=true ./sbt "; sonatypeOpen; projectJS/publishSigned"
          ;;
      esac
   fi


### PR DESCRIPTION
Recently uploading artifacts to sonatype is significantly slower than before. To mitigate the issue, I've released sbt-sonatype 3.0 so that we can support parallel artifact upload:
https://github.com/xerial/sbt-sonatype#uploading-artifacts-in-parallel

And also sbt-sonatype 3.0 supports idempotent release by cleaning up previously uploaded artifacts. So if CI builds for tagged revisions fail, we can restart the failed jobs from the scratch. 

cc: @takezoe @Lewuathe @shimamoto