### PR TITLE
airframe-http-finagle: Fix FinagleServer lifecycle

### DIFF
--- a/airframe-control/src/main/scala/wvlet/airframe/control/MultipleExceptions.scala
+++ b/airframe-control/src/main/scala/wvlet/airframe/control/MultipleExceptions.scala
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.control
+
+/**
+  *
+  */
+case class MultipleExceptions(causes: Seq[Throwable]) extends Exception {
+  causes.foreach { ex =>
+    this.addSuppressed(ex)
+  }
+  override def getMessage: String = {
+    s"Multiple failures occurred:\n${causes.map(x => s"  - ${x.getMessage}").mkString("\n")}"
+  }
+}

--- a/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/FinagleServerFactoryTest.scala
+++ b/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/FinagleServerFactoryTest.scala
@@ -12,26 +12,28 @@
  * limitations under the License.
  */
 package wvlet.airframe.http.finagle
-import com.twitter.finagle.{Http, Service}
 import com.twitter.finagle.http.{Request, Response, Status}
 import com.twitter.finagle.tracing.ConsoleTracer
+import com.twitter.finagle.{Http, Service}
 import com.twitter.util.{Await, Future}
 import wvlet.airframe.http.Router
 import wvlet.airframe.http.finagle.FinagleServer.FinagleService
 import wvlet.airspec.AirSpec
+import wvlet.log.Logger
 import wvlet.log.io.IOUtil
 
 /**
   *
   */
 class FinagleServerFactoryTest extends AirSpec {
-  val p1 = IOUtil.unusedPort
-  val p2 = IOUtil.unusedPort
-
-  val router1 = Router.add[MyApi]
-  val router2 = Router.add[MyApi]
 
   def `start multiple FinagleServers`: Unit = {
+    val p1 = IOUtil.unusedPort
+    val p2 = IOUtil.unusedPort
+
+    val router1 = Router.add[MyApi]
+    val router2 = Router.add[MyApi]
+
     val serverConfig1 = FinagleServerConfig(name = "server1", port = p1, router = router1)
     val serverConfig2 = FinagleServerConfig(name = "server2", port = p2, router = router2)
 

--- a/airframe-log/jvm/src/main/scala/wvlet/log/LogEnv.scala
+++ b/airframe-log/jvm/src/main/scala/wvlet/log/LogEnv.scala
@@ -12,7 +12,7 @@ private[log] object LogEnv extends LogEnvBase {
   override def isScalaJS: Boolean        = false
   override def defaultLogLevel: LogLevel = LogLevel.INFO
 
-  override def defaultConsoleOutput: PrintStream         = Console.err
+  override def defaultConsoleOutput: PrintStream         = System.err
   override def defaultHandler: java.util.logging.Handler = new ConsoleLogHandler(SourceCodeLogFormatter)
 
   /**

--- a/airframe-log/shared/src/main/scala/wvlet/log/Handler.scala
+++ b/airframe-log/shared/src/main/scala/wvlet/log/Handler.scala
@@ -8,9 +8,7 @@ import java.util.{logging => jl}
   *
   * @param formatter
   */
-class ConsoleLogHandler(formatter: LogFormatter) extends jl.Handler {
-  private lazy val out: PrintStream = LogEnv.defaultConsoleOutput
-
+class ConsoleLogHandler(formatter: LogFormatter, out: PrintStream = LogEnv.defaultConsoleOutput) extends jl.Handler {
   override def publish(record: jl.LogRecord): Unit = {
     out.println(formatter.format(record))
   }

--- a/airframe/src/main/scala/wvlet/airframe/AirframeSession.scala
+++ b/airframe/src/main/scala/wvlet/airframe/AirframeSession.scala
@@ -113,7 +113,7 @@ private[airframe] class AirframeSession(
     trace(s"[${name}] Creating a new shared child session with ${d}")
     val childSession = new AirframeSession(
       parent = Some(this),
-      sessionName, // Should we add suffixes for child sessions?
+      sessionName,                                          // Should we add suffixes for child sessions?
       new Design(design.designOptions, d.binding, d.hooks), // Inherit parent options
       stage,
       lifeCycleManager,
@@ -133,7 +133,7 @@ private[airframe] class AirframeSession(
         design = childDesign,
         parent = Some(this),
         name = None,
-        addShutdownHook = false, // Disable registration of shutdown hooks
+        addShutdownHook = false,                                  // Disable registration of shutdown hooks
         lifeCycleEventHandler = lifeCycleManager.coreEventHandler // Use only core lifecycle event handlers
       )
 

--- a/airframe/src/main/scala/wvlet/airframe/AirframeSession.scala
+++ b/airframe/src/main/scala/wvlet/airframe/AirframeSession.scala
@@ -113,7 +113,7 @@ private[airframe] class AirframeSession(
     trace(s"[${name}] Creating a new shared child session with ${d}")
     val childSession = new AirframeSession(
       parent = Some(this),
-      sessionName,                                          // Should we add suffixes for child sessions?
+      sessionName, // Should we add suffixes for child sessions?
       new Design(design.designOptions, d.binding, d.hooks), // Inherit parent options
       stage,
       lifeCycleManager,
@@ -133,7 +133,7 @@ private[airframe] class AirframeSession(
         design = childDesign,
         parent = Some(this),
         name = None,
-        addShutdownHook = false,                                  // Disable registration of shutdown hooks
+        addShutdownHook = false, // Disable registration of shutdown hooks
         lifeCycleEventHandler = lifeCycleManager.coreEventHandler // Use only core lifecycle event handlers
       )
 
@@ -181,7 +181,8 @@ private[airframe] class AirframeSession(
 
   def register[A: ru.TypeTag](instance: A): Unit = {
     val surface = Surface.of[A]
-    registerInjectee(surface, instance)
+    val owner   = findOwnerSessionOf(surface).getOrElse(this)
+    owner.registerInjectee(surface, instance)
   }
 
   /**

--- a/airspec/src/main/scala/wvlet/airspec/runner/AirSpecLogger.scala
+++ b/airspec/src/main/scala/wvlet/airspec/runner/AirSpecLogger.scala
@@ -19,7 +19,8 @@ import sbt.testing._
 import wvlet.airframe.log.AnsiColorPalette
 import wvlet.airframe.metrics.ElapsedTime
 import wvlet.airspec.spi.AirSpecFailureBase
-import wvlet.log.{LogFormatter, LogLevel, Logger}
+import wvlet.log.LogFormatter.BareFormatter
+import wvlet.log.{ConsoleLogHandler, LogFormatter, LogLevel, Logger}
 
 private[airspec] case class AirSpecEvent(
     taskDef: TaskDef,
@@ -42,13 +43,8 @@ private[airspec] class AirSpecLogger() extends AnsiColorPalette {
 
   private val airSpecLogger = {
     val l = Logger("wvlet.airspec.runner.AirSpecLogger")
-    l.clearAllHandlers
-    l.setFormatter(LogFormatter.BareFormatter)
+    l.setFormatter(BareFormatter)
     l
-  }
-
-  private[runner] def clearHandler = {
-    airSpecLogger.clearHandlers
   }
 
   def withColor(colorEsc: String, s: String) = {

--- a/build.sbt
+++ b/build.sbt
@@ -616,8 +616,6 @@ lazy val finagle =
     .settings(
       name := "airframe-http-finagle",
       description := "REST API binding for Finagle",
-      // A workaround for the dealy of slf4j-jdk14 log flush after sbt class loader is detached
-      fork in Test := true,
       // Finagle doesn't support Scala 2.13 yet
       crossScalaVersions := untilScala2_12,
       libraryDependencies ++= Seq(


### PR DESCRIPTION
Change to automatically start FinagleServer when FinagleServerFactory is used.
And also, stopped using Session.register[FinagleServer] because if FinagleServer has an alias type, it will not be registered properly to the Session.