### PR TITLE
airframe-di: Fix duplicated Closeable hook registration

### DIFF
--- a/airframe/src/main/scala/wvlet/airframe/AirframeSession.scala
+++ b/airframe/src/main/scala/wvlet/airframe/AirframeSession.scala
@@ -113,8 +113,10 @@ private[airframe] class AirframeSession(
     trace(s"[${name}] Creating a new shared child session with ${d}")
     val childSession = new AirframeSession(
       parent = Some(this),
-      sessionName, // Should we add suffixes for child sessions?
-      new Design(design.designOptions, d.binding, d.hooks), // Inherit parent options
+      // Should we add suffixes for child sessions?
+      sessionName,
+      // Inherit parent options
+      new Design(design.designOptions, d.binding, d.hooks),
       stage,
       lifeCycleManager,
       singletonHolder
@@ -133,8 +135,10 @@ private[airframe] class AirframeSession(
         design = childDesign,
         parent = Some(this),
         name = None,
-        addShutdownHook = false, // Disable registration of shutdown hooks
-        lifeCycleEventHandler = lifeCycleManager.coreEventHandler // Use only core lifecycle event handlers
+        // Disable registration of shutdown hooks
+        addShutdownHook = false,
+        // Use only core lifecycle event handlers
+        lifeCycleEventHandler = lifeCycleManager.coreEventHandler
       )
 
     val childSession = sb.create

--- a/airframe/src/main/scala/wvlet/airframe/lifecycle/LifeCycleManager.scala
+++ b/airframe/src/main/scala/wvlet/airframe/lifecycle/LifeCycleManager.scala
@@ -330,7 +330,7 @@ object FILOLifeCycleHookExecutor extends LifeCycleEventHandler with LogSupport {
     // onShutdown
     val shutdownOrder = lifeCycleManager.shutdownHooks.reverse
     if (shutdownOrder.nonEmpty) {
-      debug(s"[${lifeCycleManager.sessionName}] Shutdown order:\n${shutdownOrder.mkString("\n-> ")}")
+      debug(s"[${lifeCycleManager.sessionName}] Shutdown order:\n${shutdownOrder.map(x => s"-> ${x}").mkString("\n")}")
     }
     shutdownOrder.map { h =>
       trace(s"Calling shutdown hook: $h")

--- a/airframe/src/main/scala/wvlet/airframe/lifecycle/LifeCycleManager.scala
+++ b/airframe/src/main/scala/wvlet/airframe/lifecycle/LifeCycleManager.scala
@@ -16,7 +16,6 @@ package wvlet.airframe.lifecycle
 import java.util.concurrent.atomic.AtomicReference
 
 import wvlet.airframe.AirframeException.{MULTIPLE_SHUTDOWN_FAILURES, SHUTDOWN_FAILURE}
-import wvlet.airframe.lifecycle.CloseableLifeCycleHookFinder.CloseHook
 import wvlet.airframe.surface.Surface
 import wvlet.airframe.tracing.Tracer
 import wvlet.airframe.{AirframeSession, Session}
@@ -253,8 +252,7 @@ object LifeCycleManager {
 
   def defaultLifeCycleEventHandler: LifeCycleEventHandler =
     FILOLifeCycleHookExecutor andThen
-      JSR250LifeCycleExecutor andThen
-      CloseableLifeCycleHookFinder // This lifecycle must be the last one to check any preceding shutdown hooks
+      JSR250LifeCycleExecutor
 }
 
 object ShowLifeCycleLog extends LifeCycleEventHandler {
@@ -354,33 +352,13 @@ object FILOLifeCycleHookExecutor extends LifeCycleEventHandler with LogSupport {
   }
 }
 
-/**
-  * If an injected class implements close() (in AutoCloseable interface), add a shutdown hook to call
-  * close() if there is no other shutdown hooks
-  */
-object CloseableLifeCycleHookFinder extends LifeCycleEventHandler with LogSupport {
-
-  class CloseHook(val injectee: Injectee) extends LifeCycleHook {
-    override def toString: String = s"CloseHook for [${surface}]"
-    override def execute: Unit = {
-      injectee.injectee match {
-        case c: AutoCloseable =>
-          c.close()
-        case _ =>
-      }
-    }
-  }
-
-  override def onInit(lifeCycleManager: LifeCycleManager, t: Surface, injectee: AnyRef): Unit = {
-    if (classOf[AutoCloseable].isAssignableFrom(t.rawType)) {
-      // Do not register CloseHook if @PreDestory is already registered
-      injectee match {
-        case s: Session => // ignore Airframe session
-        case _ =>
-          if (!lifeCycleManager.hasShutdownHooksFor(t)) {
-            lifeCycleManager.addShutdownHook(new CloseHook(new Injectee(t, injectee)))
-          }
-      }
+class CloseHook(val injectee: Injectee) extends LifeCycleHook {
+  override def toString: String = s"CloseHook for [${surface}]"
+  override def execute: Unit = {
+    injectee.injectee match {
+      case c: AutoCloseable =>
+        c.close()
+      case _ =>
     }
   }
 }

--- a/airframe/src/test/scala/wvlet/airframe/lifecycle/ExtendedCloseableTest.scala
+++ b/airframe/src/test/scala/wvlet/airframe/lifecycle/ExtendedCloseableTest.scala
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.lifecycle
+
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
+
+import wvlet.airframe.Design
+import wvlet.airspec.AirSpec
+
+/**
+  *
+  */
+class ExtendedCloseableTest extends AirSpec {
+  scalaJsSupport
+
+  val closeCount = new AtomicInteger(0)
+  trait A extends AutoCloseable {
+    override def close(): Unit = {
+      closeCount.incrementAndGet()
+    }
+  }
+
+  trait B extends A
+
+  import wvlet.airframe._
+
+  def `close only once`: Unit = {
+    val d = newSilentDesign
+      .bind[A].to[B]
+
+    d.build[A] { a =>
+      //
+    }
+    closeCount.get() shouldBe 1
+  }
+
+}

--- a/airframe/src/test/scala/wvlet/airframe/lifecycle/ExtendedCloseableTest.scala
+++ b/airframe/src/test/scala/wvlet/airframe/lifecycle/ExtendedCloseableTest.scala
@@ -24,7 +24,8 @@ import wvlet.airspec.AirSpec
 class ExtendedCloseableTest extends AirSpec {
   scalaJsSupport
 
-  val closeCount = new AtomicInteger(0)
+  private val closeCount = new AtomicInteger(0)
+
   trait A extends AutoCloseable {
     override def close(): Unit = {
       closeCount.incrementAndGet()
@@ -39,6 +40,7 @@ class ExtendedCloseableTest extends AirSpec {
     val d = newSilentDesign
       .bind[A].to[B]
 
+    closeCount.get() shouldBe 0
     d.build[A] { a =>
       //
     }


### PR DESCRIPTION
```scala
trait A extends Closeable
trait B 

bind[A].to[B]  // This registers two CoseHooks for A and B, but we need to register it only once for A (to call B.close())
```
