### PR TITLE
MetricLogger shouldn't throw exception

### DIFF
--- a/airframe-fluentd/src/main/scala/wvlet/airframe/fluentd/MetricLogger.scala
+++ b/airframe-fluentd/src/main/scala/wvlet/airframe/fluentd/MetricLogger.scala
@@ -18,6 +18,7 @@ import javax.annotation.{PostConstruct, PreDestroy}
 import wvlet.airframe.codec.{MessageCodec, MessageCodecFactory}
 import wvlet.airframe.surface.Surface
 import wvlet.log.LogSupport
+import scala.util.Try
 
 abstract class MetricLogger extends AutoCloseable {
   protected def tagPrefix: Option[String]
@@ -51,7 +52,9 @@ abstract class MetricLogger extends AutoCloseable {
 
 class TypedMetricLogger[T <: TaggedMetric](fluentdClient: MetricLogger, codec: MessageCodec[T]) {
   def emit(event: T): Unit = {
-    fluentdClient.emitMsgPack(event.metricTag, codec.toMsgPack(event))
+    Try {
+      fluentdClient.emitMsgPack(event.metricTag, codec.toMsgPack(event))
+    }
   }
 }
 


### PR DESCRIPTION
Fluency throws an exception when the buffer is full and fail to flush, but it shouldn't break the host logic even if such unknown errors occur inside of it.