### PR TITLE
Add javacOptions to generate Java8 compatible binary

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,6 +50,7 @@ val buildSettings = Seq[Setting[_]](
   crossScalaVersions := targetScalaVersions,
   crossPaths := true,
   publishMavenStyle := true,
+  javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
   scalacOptions ++= Seq("-feature", "-deprecation"), // ,"-Ytyper-debug"),
   testFrameworks += airSpecFramework,
   libraryDependencies ++= Seq(


### PR DESCRIPTION
I got the following error when I tried to upgrade Airframe in my application.
```
java.lang.UnsupportedClassVersionError: wvlet/airframe/launcher/option has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0
```
Java code in the latest version of Airframe seems to have been compiled for Java11, but it would be better to keep Java8 compatibility.