### PR TITLE
No need to shutdown ConnectionPoolFactory explicitly

### DIFF
--- a/airframe-jdbc/src/main/scala/wvlet/airframe/jdbc/ConnectionPool.scala
+++ b/airframe-jdbc/src/main/scala/wvlet/airframe/jdbc/ConnectionPool.scala
@@ -72,8 +72,6 @@ trait ConnectionPool extends LogSupport {
 
 trait ConnectionPoolFactoryService {
   val connectionPoolFactory = bind[ConnectionPoolFactory]
-    .onShutdown(_.close)
-
 }
 
 trait ConnectionPoolFactory extends Guard with AutoCloseable with LogSupport {


### PR DESCRIPTION
Because `ConnectionPoolFactory` is `AutoCloseable`.