### PR TITLE
Fix airframe-config README

### DIFF
--- a/airframe-config/README.md
+++ b/airframe-config/README.md
@@ -46,7 +46,7 @@ default:
 
 **config/server.yml**
 ```
-default:
+default: &default
   host: localhost
   port: 8080
 


### PR DESCRIPTION
I think that `*default` should need an anchor in the example(`server.yaml)`.