### PR TITLE
airframe-http: Use no record expiration

### DIFF
--- a/airframe-http-finagle/src/main/scala/wvlet/airframe/http/finagle/Finagle.scala
+++ b/airframe-http-finagle/src/main/scala/wvlet/airframe/http/finagle/Finagle.scala
@@ -17,7 +17,7 @@ package wvlet.airframe.http.finagle
   * An entry point for building customized Finagle services
   */
 object Finagle {
-  def client: FinagleClient.FinagleClientBuilder            = FinagleClient.FinagleClientBuilder()
+  def client: FinagleClientConfig                           = FinagleClientConfig()
   def newClient(hostAndPort: String): FinagleClient         = client.newClient(hostAndPort)
   def newSyncClient(hostAndPort: String): FinagleSyncClient = client.newSyncClient(hostAndPort)
 }

--- a/airframe-http-recorder/src/main/scala/wvlet/airframe/http/recorder/HttpRecorderServer.scala
+++ b/airframe-http-recorder/src/main/scala/wvlet/airframe/http/recorder/HttpRecorderServer.scala
@@ -19,13 +19,17 @@ import com.twitter.util.Future
 import wvlet.airframe.http.finagle.FinagleServer.FinagleService
 import wvlet.airframe.http.finagle.{FinagleServer, FinagleServerConfig}
 import wvlet.log.LogSupport
+import wvlet.log.io.IOUtil
 
 /**
   * A FinagleServer wrapper to close HttpRecordStore when the server terminates
   */
 class HttpRecorderServer(recordStore: HttpRecordStore, finagleService: FinagleService)
     extends FinagleServer(
-      FinagleServerConfig(s"[http-recorder] ${recordStore.recorderConfig.name}", recordStore.recorderConfig.serverPort),
+      FinagleServerConfig(
+        s"[http-recorder] ${recordStore.recorderConfig.recorderName}",
+        recordStore.recorderConfig.port.getOrElse(IOUtil.unusedPort)
+      ),
       finagleService
     ) {
 

--- a/airframe-http-recorder/src/test/scala/wvlet/airframe/http/recorder/HttpRecorderTest.scala
+++ b/airframe-http-recorder/src/test/scala/wvlet/airframe/http/recorder/HttpRecorderTest.scala
@@ -49,7 +49,7 @@ class HttpRecorderTest extends AirSpec {
 
   def `start HTTP recorder`: Unit = {
     val recorderConfig =
-      HttpRecorderConfig(name = "wvlet.org", destUri = "https://wvlet.org", sessionName = "airframe")
+      HttpRecorderConfig(recorderName = "wvlet.org", destUri = "https://wvlet.org", sessionName = "airframe")
     val path = "/airframe/"
     val response: Response =
       withResource(HttpRecorder.createRecordOnlyServer(recorderConfig, dropExistingSession = true)) { server =>
@@ -148,13 +148,10 @@ class HttpRecorderTest extends AirSpec {
   }
 
   def `delete expired records`: Unit = {
-    val recorderConfig =
-      HttpRecorderConfig(
-        destUri = "https://wvlet.org",
-        sessionName = "airframe",
-        // Expire immediately
-        expirationTime = "1s"
-      )
+    val recorderConfig = HttpRecorder.config
+      .withDestUri("https://wvlet.org")
+      .withSessionName("airframe")
+      .withExpirationTime("1s")
 
     val path = "/airframe/"
     withResource(new HttpRecordStore(recorderConfig, dropSession = true)) { store =>


### PR DESCRIPTION
Resolves #772 
This PR also includes refactoring of builder patterns

After this PR, we should add a trigger to force expire http records (e.g., presto version string change) automatically or embed such version string to sessionName (as a best practice for creating a new session for each Presto version, etc.)