### PR TITLE
airframe-codec: Rename MessageHolder -> MessageContext

### DIFF
--- a/airframe-codec/.jvm/src/main/scala/wvlet/airframe/codec/JDBCCodec.scala
+++ b/airframe-codec/.jvm/src/main/scala/wvlet/airframe/codec/JDBCCodec.scala
@@ -336,7 +336,7 @@ object JDBCCodec extends LogSupport {
       // Store string representation of java.sql.Date
       p.packString(v.toString)
     }
-    override def unpack(u: Unpacker, v: MessageHolder): Unit = {
+    override def unpack(u: Unpacker, v: MessageContext): Unit = {
       u.getNextValueType match {
         case ValueType.STRING =>
           v.setObject(java.sql.Date.valueOf(u.unpackString))
@@ -356,7 +356,7 @@ object JDBCCodec extends LogSupport {
     override def pack(p: Packer, v: Time): Unit = {
       p.packString(v.toString)
     }
-    override def unpack(u: Unpacker, v: MessageHolder): Unit = {
+    override def unpack(u: Unpacker, v: MessageContext): Unit = {
       u.getNextValueType match {
         case ValueType.STRING =>
           v.setObject(java.sql.Time.valueOf(u.unpackString))
@@ -375,7 +375,7 @@ object JDBCCodec extends LogSupport {
     override def pack(p: Packer, v: Timestamp): Unit = {
       p.packString(v.toString)
     }
-    override def unpack(u: Unpacker, v: MessageHolder): Unit = {
+    override def unpack(u: Unpacker, v: MessageContext): Unit = {
       u.getNextValueType match {
         case ValueType.STRING =>
           v.setObject(java.sql.Timestamp.valueOf(u.unpackString))
@@ -394,7 +394,7 @@ object JDBCCodec extends LogSupport {
     override def pack(p: Packer, v: java.math.BigDecimal): Unit = {
       p.packString(v.toString)
     }
-    override def unpack(u: Unpacker, v: MessageHolder): Unit = {
+    override def unpack(u: Unpacker, v: MessageContext): Unit = {
       u.getNextValueType match {
         case ValueType.STRING =>
           val s = u.unpackString
@@ -443,6 +443,6 @@ object JDBCCodec extends LogSupport {
           throw new UnsupportedOperationException(s"Reading array type of ${arr.getClass} is not supported: ${arr}")
       }
     }
-    override def unpack(u: Unpacker, v: MessageHolder): Unit = ???
+    override def unpack(u: Unpacker, v: MessageContext): Unit = ???
   }
 }

--- a/airframe-codec/.jvm/src/main/scala/wvlet/airframe/codec/JavaStandardCodec.scala
+++ b/airframe-codec/.jvm/src/main/scala/wvlet/airframe/codec/JavaStandardCodec.scala
@@ -32,7 +32,7 @@ object JavaStandardCodec {
     override def pack(p: Packer, v: File): Unit = {
       p.packString(v.getPath)
     }
-    override def unpack(u: Unpacker, v: MessageHolder): Unit = {
+    override def unpack(u: Unpacker, v: MessageContext): Unit = {
       val path = u.unpackString
       v.setObject(new File(path))
     }
@@ -54,7 +54,7 @@ object JavaStandardCodec {
       p.packString(v.asInstanceOf[Enum[_]].name())
     }
 
-    override def unpack(u: Unpacker, v: MessageHolder): Unit = {
+    override def unpack(u: Unpacker, v: MessageContext): Unit = {
       val name = u.unpackString
       enumTable.get(CName.toCanonicalName(name)) match {
         case Some(enum) => v.setObject(enum)

--- a/airframe-codec/.jvm/src/main/scala/wvlet/airframe/codec/JavaTimeCodec.scala
+++ b/airframe-codec/.jvm/src/main/scala/wvlet/airframe/codec/JavaTimeCodec.scala
@@ -43,7 +43,7 @@ object JavaTimeCodec {
       p.writePayload(extData, 0, cursor.lastWrittenBytes)
     }
 
-    override def unpack(u: Unpacker, v: MessageHolder): Unit = {
+    override def unpack(u: Unpacker, v: MessageContext): Unit = {
       Try {
         u.getNextFormat.getValueType match {
           case ValueType.STRING =>
@@ -72,7 +72,7 @@ object JavaTimeCodec {
       p.packString(v.toString)
     }
 
-    override def unpack(u: Unpacker, v: MessageHolder): Unit = {
+    override def unpack(u: Unpacker, v: MessageContext): Unit = {
       val zonedDateTimeStr = u.unpackString
       Try(ZonedDateTime.parse(zonedDateTimeStr)) match {
         case Success(zd) =>
@@ -91,7 +91,7 @@ object JavaTimeCodec {
       // Use Instant for encoding
       JavaInstantTimeCodec.pack(p, v.toInstant)
     }
-    override def unpack(u: Unpacker, v: MessageHolder): Unit = {
+    override def unpack(u: Unpacker, v: MessageContext): Unit = {
       JavaInstantTimeCodec.unpack(u, v)
       if (!v.isNull) {
         v.setObject(Date.from(v.getLastValue.asInstanceOf[Instant]))

--- a/airframe-codec/.jvm/src/main/scala/wvlet/airframe/codec/StringUnapplyCodec.scala
+++ b/airframe-codec/.jvm/src/main/scala/wvlet/airframe/codec/StringUnapplyCodec.scala
@@ -24,7 +24,7 @@ class StringUnapplyCodec[A](codec: Surface) extends MessageCodec[A] with LogSupp
   override def pack(p: Packer, v: A): Unit = {
     p.packString(v.toString)
   }
-  override def unpack(u: Unpacker, v: MessageHolder): Unit = {
+  override def unpack(u: Unpacker, v: MessageContext): Unit = {
     val s = u.unpackString
     TypeConverter.convert(s, codec.rawType) match {
       case Some(x) =>

--- a/airframe-codec/README.md
+++ b/airframe-codec/README.md
@@ -43,14 +43,50 @@ codec.fromMsgPack(msgpack) // A(1, "leo")
 
 
 // Convert to JSON
-val json = codec.toJson(a)   //  {"id":1,"name":"leo"}
+val json = codec.toJson(a) // {"id":1,"name":"leo"}
 
 // Exception-free json parser
-codec.unpackJson(json)  // Some(A(1, "leo")) or None
+codec.unpackJson(json) // Some(A(1, "leo")) or None
 
 // JSON -> Object (MessageCodecException will be thrown when parsing is failed)
 codec.fromJson(json) // A(1, "leo")
 ```
 
-
 - To create a custom codec, use MessageCodecFactory.
+
+
+## Populating missing fields with zero values
+
+When mapping data into objects, if some parameter values are missing in the input data, airframe-codec will try to populate these missing parameters with the default values of the target types. This default parameter mapping is defined in `Zero.zeroOf[X]`. For example, if the target type is Int, `zeroOf[Int]` will be 0, and for String `zeroOf[String]` is `""` (empty string).
+
+___Default Values___
+
+| X: type | zeroOf[X] | Notes |
+|------|---------|----|
+| Int  | 0       |
+| Long  | 0L       |
+| String | "" |
+| Boolean | false |
+| Option[X] | None |
+| Float | 0.0f |
+| Double | 0.0 |
+| Array[X] | empty array |
+| Seq[X] | Seq.empty |
+| class A(p1:P1 = v1, ...) | A(p1 = v1, ...) | default parameter value|
+| class A(P1, ...) | A(zeroOf[P1], ...) | zero value of each parameter |
+
+## Strict Mapping
+
+If you need to ensure the presence of some parameter values, add `@requried` annotation to the target object parameters. If some necessary parameter is missing, MessageCodecException will be thrown:
+
+```scals
+import wvlet.airframe.surface.required
+
+case class Person(@required id:String, @requried name:String)
+
+val codec = MessageCodec.of[Person]
+
+// Throws MessageCodecException (MISSING_PARAMETER) exception as id value is not found
+codec.fromJson("""{"name":"Peter"}""")
+
+```

--- a/airframe-codec/README.md
+++ b/airframe-codec/README.md
@@ -1,7 +1,7 @@
 airframe-codec
 ====
 
-airframe-codec is an [MessagePack](https://msgpack.org)-based schema-on-read data transcoder.
+airframe-codec is an [MessagePack](https://msgpack.org)-based schema-on-read data transcoder for Scala and Scala.js.
 
 With airframe-codec you can:
 - Encode Scala objects (e.g., case classes, collection, etc.) into MessagePack format, and decode it. Object serialization/deserialization.
@@ -36,14 +36,20 @@ val codec = MessageCodec.of[A]
 val a = A(1, "leo")
 val msgpack = codec.toMsgPack(a)
 
-// Read msgpack data as object
-codec.unpackMsgPack(msgpack) // Some(A(1, "leo"))
+// Read MsgPack data as object (exception-free)
+codec.unpackMsgPack(msgpack) // Some(A(1, "leo")) or None
+// MsgPack -> Object (MessageCodecException will be thrown when parsing is failed)
+codec.fromMsgPack(msgpack) // A(1, "leo")
 
 
 // Convert to JSON
 val json = codec.toJson(a)   //  {"id":1,"name":"leo"}
 
-codec.unpackJson(json)  // Some(A(1, "leo"))
+// Exception-free json parser
+codec.unpackJson(json)  // Some(A(1, "leo")) or None
+
+// JSON -> Object (MessageCodecException will be thrown when parsing is failed)
+codec.fromJson(json) // A(1, "leo")
 ```
 
 

--- a/airframe-codec/src/main/scala/wvlet/airframe/codec/CollectionCodec.scala
+++ b/airframe-codec/src/main/scala/wvlet/airframe/codec/CollectionCodec.scala
@@ -37,7 +37,7 @@ object CollectionCodec {
 
     def unpack[A](
         u: Unpacker,
-        v: MessageHolder,
+        v: MessageContext,
         surface: Surface,
         elementCodec: MessageCodec[A],
         newBuilder: => mutable.Builder[A, Seq[A]]
@@ -80,7 +80,7 @@ object CollectionCodec {
       BaseSeqCodec.pack(p, v, elementCodec)
     }
 
-    override def unpack(u: Unpacker, v: MessageHolder): Unit = {
+    override def unpack(u: Unpacker, v: MessageContext): Unit = {
       BaseSeqCodec.unpack(u, v, surface, elementCodec, Seq.newBuilder[A])
     }
   }
@@ -90,7 +90,7 @@ object CollectionCodec {
       BaseSeqCodec.pack(p, v, elementCodec)
     }
 
-    override def unpack(u: Unpacker, v: MessageHolder): Unit = {
+    override def unpack(u: Unpacker, v: MessageContext): Unit = {
       BaseSeqCodec.unpack(u, v, surface, elementCodec, IndexedSeq.newBuilder[A])
     }
   }
@@ -109,7 +109,7 @@ object CollectionCodec {
       BaseSeqCodec.pack(p, v, elementCodec)
     }
 
-    override def unpack(u: Unpacker, v: MessageHolder): Unit = {
+    override def unpack(u: Unpacker, v: MessageContext): Unit = {
       BaseSeqCodec.unpack(u, v, surface, elementCodec, List.newBuilder[A])
     }
   }
@@ -124,7 +124,7 @@ object CollectionCodec {
       }
     }
 
-    override def unpack(u: Unpacker, v: MessageHolder): Unit = {
+    override def unpack(u: Unpacker, v: MessageContext): Unit = {
       val len = u.unpackArrayHeader
       val b   = Seq.newBuilder[Any]
       b.sizeHint(len)
@@ -144,7 +144,7 @@ object CollectionCodec {
         valueCodec.pack(p, v)
       }
     }
-    override def unpack(u: Unpacker, v: MessageHolder): Unit = {
+    override def unpack(u: Unpacker, v: MessageContext): Unit = {
       u.getNextFormat.getValueType match {
         case ValueType.MAP =>
           val len = u.unpackMapHeader
@@ -187,7 +187,7 @@ object CollectionCodec {
         valueCodec.pack(p, v)
       }
     }
-    override def unpack(u: Unpacker, v: MessageHolder): Unit = {
+    override def unpack(u: Unpacker, v: MessageContext): Unit = {
       u.getNextValueType match {
         case ValueType.MAP =>
           val len = u.unpackMapHeader

--- a/airframe-codec/src/main/scala/wvlet/airframe/codec/JSONCodec.scala
+++ b/airframe-codec/src/main/scala/wvlet/airframe/codec/JSONCodec.scala
@@ -64,7 +64,7 @@ object JSONCodec extends MessageCodec[String] {
     }
   }
 
-  override def unpack(u: Unpacker, v: MessageHolder): Unit = {
+  override def unpack(u: Unpacker, v: MessageContext): Unit = {
     val json = u.unpackValue.toJson
     v.setString(json)
   }
@@ -80,7 +80,7 @@ object RawJsonCodec extends MessageCodec[Json] {
   override def pack(p: Packer, v: Json): Unit = {
     JSONCodec.pack(p, v)
   }
-  override def unpack(u: Unpacker, v: MessageHolder): Unit = {
+  override def unpack(u: Unpacker, v: MessageContext): Unit = {
     JSONCodec.unpack(u, v)
   }
 }
@@ -128,7 +128,7 @@ object JSONValueCodec extends MessageCodec[JSONValue] {
     }
   }
 
-  override def unpack(u: Unpacker, v: MessageHolder): Unit = {
+  override def unpack(u: Unpacker, v: MessageContext): Unit = {
     val jsonValue = unpackJson(u)
     v.setObject(jsonValue)
   }

--- a/airframe-codec/src/main/scala/wvlet/airframe/codec/MessageCodec.scala
+++ b/airframe-codec/src/main/scala/wvlet/airframe/codec/MessageCodec.scala
@@ -24,6 +24,7 @@ import scala.reflect.runtime.universe._
 import scala.util.{Failure, Success, Try}
 
 trait MessageCodec[A] extends LogSupport {
+
   /**
     * Converting the object into MessagePack (= Array[Byte])
     */
@@ -35,7 +36,7 @@ trait MessageCodec[A] extends LogSupport {
     */
   def unpack(msgpack: MsgPack): A = {
     val unpacker = MessagePack.newUnpacker(msgpack)
-    val v        = new MessageHolder
+    val v        = new MessageContext
     try {
       unpack(unpacker, v)
     } catch {
@@ -54,7 +55,7 @@ trait MessageCodec[A] extends LogSupport {
   }
 
   def pack(p: Packer, v: A): Unit
-  def unpack(u: Unpacker, v: MessageHolder): Unit
+  def unpack(u: Unpacker, v: MessageContext): Unit
 
   // TODO add specialized methods for primitive values
   // def unpackInt(u:MessageUnpacker) : Int
@@ -101,7 +102,7 @@ trait MessageCodec[A] extends LogSupport {
   def unpackMsgPack(msgpack: Array[Byte]): Option[A] = unpackMsgPack(msgpack, 0, msgpack.length)
   def unpackMsgPack(msgpack: Array[Byte], offset: Int, len: Int): Option[A] = {
     val unpacker = MessagePack.newUnpacker(msgpack, offset, len)
-    val v        = new MessageHolder
+    val v        = new MessageContext
     try {
       unpack(unpacker, v)
       if (v.isNull) {
@@ -130,7 +131,7 @@ trait MessageCodec[A] extends LogSupport {
   def fromJson(json: String): A = {
     val msgpack  = MessagePack.fromJSON(json)
     val unpacker = MessagePack.newUnpacker(msgpack)
-    val v        = new MessageHolder
+    val v        = new MessageContext
     unpack(unpacker, v)
     if (v.hasError) {
       throw v.getError.get
@@ -150,7 +151,7 @@ trait MessageValueCodec[A] extends MessageCodec[A] {
     p.packValue(packValue(v))
   }
 
-  override def unpack(u: Unpacker, v: MessageHolder): Unit = {
+  override def unpack(u: Unpacker, v: MessageContext): Unit = {
     val vl = u.unpackValue
     Try(unpackValue(vl)) match {
       case Success(x) =>

--- a/airframe-codec/src/main/scala/wvlet/airframe/codec/MessageCodec.scala
+++ b/airframe-codec/src/main/scala/wvlet/airframe/codec/MessageCodec.scala
@@ -24,7 +24,6 @@ import scala.reflect.runtime.universe._
 import scala.util.{Failure, Success, Try}
 
 trait MessageCodec[A] extends LogSupport {
-
   /**
     * Converting the object into MessagePack (= Array[Byte])
     */

--- a/airframe-codec/src/main/scala/wvlet/airframe/codec/MessageContext.scala
+++ b/airframe-codec/src/main/scala/wvlet/airframe/codec/MessageContext.scala
@@ -18,7 +18,7 @@ import wvlet.airframe.codec.DataType._
 /**
   *
   */
-class MessageHolder {
+class MessageContext {
   private var dataType: DataType     = NIL
   private var value: Option[Any]     = None
   private var err: Option[Throwable] = None

--- a/airframe-codec/src/main/scala/wvlet/airframe/codec/MessageContext.scala
+++ b/airframe-codec/src/main/scala/wvlet/airframe/codec/MessageContext.scala
@@ -16,9 +16,16 @@ package wvlet.airframe.codec
 import wvlet.airframe.codec.DataType._
 
 /**
+  * MessageContext is used for passing the parsing configuration and
+  * the last value read by codec.
+  *
+  * For efficiency, it holds several primitive type values as
+  * local variables to avoid the boxing overhead.
   *
   */
-class MessageContext {
+case class MessageContext(
+    // For now, we have no specific configuration to add
+) {
   private var dataType: DataType     = NIL
   private var value: Option[Any]     = None
   private var err: Option[Throwable] = None

--- a/airframe-codec/src/main/scala/wvlet/airframe/codec/MetricsCodec.scala
+++ b/airframe-codec/src/main/scala/wvlet/airframe/codec/MetricsCodec.scala
@@ -29,7 +29,7 @@ object MetricsCodec {
     override def pack(p: Packer, v: DataSize): Unit = {
       p.packString(v.toString())
     }
-    override def unpack(u: Unpacker, v: MessageHolder): Unit = {
+    override def unpack(u: Unpacker, v: MessageContext): Unit = {
       u.getNextValueType match {
         case ValueType.STRING =>
           v.setObject(DataSize(u.unpackString))
@@ -49,7 +49,7 @@ object MetricsCodec {
       p.packString(v.toString())
     }
 
-    override def unpack(u: Unpacker, v: MessageHolder): Unit = {
+    override def unpack(u: Unpacker, v: MessageContext): Unit = {
       u.getNextValueType match {
         case ValueType.STRING =>
           v.setObject(ElapsedTime(u.unpackString))

--- a/airframe-codec/src/main/scala/wvlet/airframe/codec/ObjectCodec.scala
+++ b/airframe-codec/src/main/scala/wvlet/airframe/codec/ObjectCodec.scala
@@ -117,7 +117,7 @@ class ParamListCodec(
     }
   }
 
-  override def unpack(u: Unpacker, v: MessageHolder): Unit = {
+  override def unpack(u: Unpacker, v: MessageContext): Unit = {
     val numParams = params.length
 
     u.getNextFormat.getValueType match {
@@ -209,7 +209,7 @@ case class ObjectCodec[A](surface: Surface, paramCodec: Seq[MessageCodec[_]])
     paramListCodec.packAsMap(p, v)
   }
 
-  override def unpack(u: Unpacker, v: MessageHolder): Unit = {
+  override def unpack(u: Unpacker, v: MessageContext): Unit = {
     paramListCodec.unpack(u, v)
     if (!v.isNull) {
       val args = v.getLastValue.asInstanceOf[Seq[Any]]
@@ -245,7 +245,7 @@ case class ObjectMapCodec[A](surface: Surface, paramCodec: Seq[MessageCodec[_]])
   }
   override def packAsMap(p: Packer, v: A): Unit = pack(p, v)
 
-  override def unpack(u: Unpacker, v: MessageHolder): Unit = {
+  override def unpack(u: Unpacker, v: MessageContext): Unit = {
     paramListCodec.unpack(u, v)
     if (!v.isNull) {
       val args = v.getLastValue.asInstanceOf[Seq[Any]]

--- a/airframe-codec/src/main/scala/wvlet/airframe/codec/ObjectCodec.scala
+++ b/airframe-codec/src/main/scala/wvlet/airframe/codec/ObjectCodec.scala
@@ -92,7 +92,7 @@ class ParamListCodec(
   private def getParamDefaultValue(p: Parameter): Any = {
     def returnZero: Any = {
       if (p.isRequired) {
-        // If the parameter has @required annotation, we can't
+        // If the parameter has @required annotation, we can't use the Zero value
         throw new MessageCodecException(
           MISSING_PARAMETER,
           this,

--- a/airframe-codec/src/main/scala/wvlet/airframe/codec/PrimitiveCodec.scala
+++ b/airframe-codec/src/main/scala/wvlet/airframe/codec/PrimitiveCodec.scala
@@ -78,7 +78,7 @@ object PrimitiveCodec {
       p.packByte(v)
     }
 
-    override def unpack(u: Unpacker, v: MessageHolder): Unit = {
+    override def unpack(u: Unpacker, v: MessageContext): Unit = {
       def read(body: => Byte): Unit = {
         try {
           v.setByte(body)
@@ -121,7 +121,7 @@ object PrimitiveCodec {
       p.packInt(v)
     }
 
-    override def unpack(u: Unpacker, v: MessageHolder): Unit = {
+    override def unpack(u: Unpacker, v: MessageContext): Unit = {
       def read(body: => Char): Unit = {
         try {
           v.setChar(body)
@@ -167,7 +167,7 @@ object PrimitiveCodec {
       p.packShort(v)
     }
 
-    override def unpack(u: Unpacker, v: MessageHolder): Unit = {
+    override def unpack(u: Unpacker, v: MessageContext): Unit = {
       def read(body: => Short): Unit = {
         try {
           v.setShort(body)
@@ -209,7 +209,7 @@ object PrimitiveCodec {
       p.packInt(v)
     }
 
-    override def unpack(u: Unpacker, v: MessageHolder): Unit = {
+    override def unpack(u: Unpacker, v: MessageContext): Unit = {
       def read(body: => Int): Unit = {
         try {
           v.setInt(body)
@@ -252,7 +252,7 @@ object PrimitiveCodec {
       p.packLong(v)
     }
 
-    override def unpack(u: Unpacker, v: MessageHolder): Unit = {
+    override def unpack(u: Unpacker, v: MessageContext): Unit = {
       def read(body: => Long): Unit = {
         try {
           v.setLong(body)
@@ -298,7 +298,7 @@ object PrimitiveCodec {
       }
     }
 
-    override def unpack(u: Unpacker, v: MessageHolder): Unit = {
+    override def unpack(u: Unpacker, v: MessageContext): Unit = {
       def read(body: => String): Unit = {
         try {
           val s = body
@@ -345,7 +345,7 @@ object PrimitiveCodec {
       p.packBoolean(v)
     }
 
-    override def unpack(u: Unpacker, v: MessageHolder): Unit = {
+    override def unpack(u: Unpacker, v: MessageContext): Unit = {
       def read(body: => Boolean): Unit = {
         try {
           val b = body
@@ -388,7 +388,7 @@ object PrimitiveCodec {
       p.packFloat(v)
     }
 
-    override def unpack(u: Unpacker, v: MessageHolder): Unit = {
+    override def unpack(u: Unpacker, v: MessageContext): Unit = {
       def read(body: => Float): Unit = {
         try {
           v.setFloat(body)
@@ -427,7 +427,7 @@ object PrimitiveCodec {
       p.packDouble(v)
     }
 
-    override def unpack(u: Unpacker, v: MessageHolder): Unit = {
+    override def unpack(u: Unpacker, v: MessageContext): Unit = {
       def read(body: => Double): Unit = {
         try {
           v.setDouble(body)
@@ -467,7 +467,7 @@ object PrimitiveCodec {
       }
     }
 
-    override def unpack(u: Unpacker, v: MessageHolder): Unit = {
+    override def unpack(u: Unpacker, v: MessageContext): Unit = {
       val len = u.unpackArrayHeader
       val b   = Array.newBuilder[Int]
       b.sizeHint(len)
@@ -493,7 +493,7 @@ object PrimitiveCodec {
       }
     }
 
-    override def unpack(u: Unpacker, v: MessageHolder): Unit = {
+    override def unpack(u: Unpacker, v: MessageContext): Unit = {
       val len = u.unpackArrayHeader
       val b   = Array.newBuilder[Short]
       b.sizeHint(len)
@@ -524,7 +524,7 @@ object PrimitiveCodec {
       }
     }
 
-    override def unpack(u: Unpacker, v: MessageHolder): Unit = {
+    override def unpack(u: Unpacker, v: MessageContext): Unit = {
       val len = u.unpackArrayHeader
       val b   = Array.newBuilder[Char]
       b.sizeHint(len)
@@ -555,7 +555,7 @@ object PrimitiveCodec {
       }
     }
 
-    override def unpack(u: Unpacker, v: MessageHolder): Unit = {
+    override def unpack(u: Unpacker, v: MessageContext): Unit = {
       val len = u.unpackArrayHeader
       val b   = Array.newBuilder[Long]
       b.sizeHint(len)
@@ -581,7 +581,7 @@ object PrimitiveCodec {
       }
     }
 
-    override def unpack(u: Unpacker, v: MessageHolder): Unit = {
+    override def unpack(u: Unpacker, v: MessageContext): Unit = {
       val len = u.unpackArrayHeader
       val b   = Array.newBuilder[Float]
       b.sizeHint(len)
@@ -607,7 +607,7 @@ object PrimitiveCodec {
       }
     }
 
-    override def unpack(u: Unpacker, v: MessageHolder): Unit = {
+    override def unpack(u: Unpacker, v: MessageContext): Unit = {
       val len = u.unpackArrayHeader
       val b   = Array.newBuilder[Double]
       b.sizeHint(len)
@@ -632,7 +632,7 @@ object PrimitiveCodec {
       }
     }
 
-    override def unpack(u: Unpacker, v: MessageHolder): Unit = {
+    override def unpack(u: Unpacker, v: MessageContext): Unit = {
       val len = u.unpackArrayHeader
       val b   = Array.newBuilder[Boolean]
       b.sizeHint(len)
@@ -654,7 +654,7 @@ object PrimitiveCodec {
       p.packBinaryHeader(v.length)
       p.addPayload(v)
     }
-    override def unpack(u: Unpacker, v: MessageHolder): Unit = {
+    override def unpack(u: Unpacker, v: MessageContext): Unit = {
       u.getNextValueType match {
         case ValueType.BINARY =>
           val len = u.unpackBinaryHeader
@@ -707,7 +707,7 @@ object PrimitiveCodec {
       }
     }
 
-    override def unpack(u: Unpacker, v: MessageHolder): Unit = {
+    override def unpack(u: Unpacker, v: MessageContext): Unit = {
       val len = u.unpackArrayHeader
       val b   = Array.newBuilder[String]
       b.sizeHint(len)
@@ -731,7 +731,7 @@ object PrimitiveCodec {
       p.packValue(v)
     }
 
-    override def unpack(u: Unpacker, v: MessageHolder): Unit = {
+    override def unpack(u: Unpacker, v: MessageContext): Unit = {
       v.setObject(u.unpackValue)
     }
   }
@@ -802,7 +802,7 @@ object PrimitiveCodec {
       }
     }
 
-    override def unpack(u: Unpacker, v: MessageHolder): Unit = {
+    override def unpack(u: Unpacker, v: MessageContext): Unit = {
       u.getNextValueType match {
         case ValueType.NIL =>
           u.unpackNil

--- a/airframe-codec/src/main/scala/wvlet/airframe/codec/PrimitiveCodec.scala
+++ b/airframe-codec/src/main/scala/wvlet/airframe/codec/PrimitiveCodec.scala
@@ -685,7 +685,7 @@ object PrimitiveCodec {
       p.packBinaryHeader(v.length)
       p.addPayload(v)
     }
-    override def unpack(u: Unpacker, v: MessageHolder): Unit = {
+    override def unpack(u: Unpacker, v: MessageContext): Unit = {
       u.getNextValueType match {
         case ValueType.BINARY =>
           val len = u.unpackBinaryHeader

--- a/airframe-codec/src/main/scala/wvlet/airframe/codec/ScalaStandardCodec.scala
+++ b/airframe-codec/src/main/scala/wvlet/airframe/codec/ScalaStandardCodec.scala
@@ -28,7 +28,7 @@ object ScalaStandardCodec {
       }
     }
 
-    override def unpack(u: Unpacker, v: MessageHolder): Unit = {
+    override def unpack(u: Unpacker, v: MessageContext): Unit = {
       val f = u.getNextFormat
       f.getValueType match {
         case ValueType.NIL =>
@@ -50,7 +50,7 @@ object ScalaStandardCodec {
       }
     }
 
-    override def unpack(u: Unpacker, v: MessageHolder): Unit = {
+    override def unpack(u: Unpacker, v: MessageContext): Unit = {
       val numElems = u.unpackArrayHeader
       if (numElems != elementCodec.size) {
         u.skipValue(numElems)

--- a/airframe-codec/src/main/scala/wvlet/airframe/codec/StandardCodec.scala
+++ b/airframe-codec/src/main/scala/wvlet/airframe/codec/StandardCodec.scala
@@ -28,7 +28,7 @@ object StandardCodec {
   )
 
   val standardCodec
-      : Map[Surface, MessageCodec[_]] = PrimitiveCodec.primitiveCodec ++ PrimitiveCodec.primitiveArrayCodec ++ javaClassCodec
+    : Map[Surface, MessageCodec[_]] = PrimitiveCodec.primitiveCodec ++ PrimitiveCodec.primitiveArrayCodec ++ javaClassCodec
 
   object ThrowableCodec extends MessageCodec[Throwable] {
     override def pack(p: Packer, v: Throwable): Unit = {
@@ -65,6 +65,6 @@ object StandardCodec {
       }
     }
     // We do not support deserialization of generic Throwable classes
-    override def unpack(u: Unpacker, v: MessageHolder): Unit = ???
+    override def unpack(u: Unpacker, v: MessageContext): Unit = ???
   }
 }

--- a/airframe-codec/src/main/scala/wvlet/airframe/codec/StandardCodec.scala
+++ b/airframe-codec/src/main/scala/wvlet/airframe/codec/StandardCodec.scala
@@ -28,7 +28,7 @@ object StandardCodec {
   )
 
   val standardCodec
-    : Map[Surface, MessageCodec[_]] = PrimitiveCodec.primitiveCodec ++ PrimitiveCodec.primitiveArrayCodec ++ javaClassCodec
+      : Map[Surface, MessageCodec[_]] = PrimitiveCodec.primitiveCodec ++ PrimitiveCodec.primitiveArrayCodec ++ javaClassCodec
 
   object ThrowableCodec extends MessageCodec[Throwable] {
     override def pack(p: Packer, v: Throwable): Unit = {

--- a/airframe-codec/src/test/scala/wvlet/airframe/codec/CodecSpec.scala
+++ b/airframe-codec/src/test/scala/wvlet/airframe/codec/CodecSpec.scala
@@ -21,12 +21,12 @@ import wvlet.airspec.AirSpec
   *
   */
 trait CodecSpec extends AirSpec {
-  protected def roundtrip[A](surface: Surface, v: A, expectedType: DataType = DataType.ANY): MessageHolder = {
+  protected def roundtrip[A](surface: Surface, v: A, expectedType: DataType = DataType.ANY): MessageContext = {
     roundtrip[A](MessageCodec.ofSurface(surface).asInstanceOf[MessageCodec[A]], v, expectedType)
   }
 
-  protected def roundtrip[A](codec: MessageCodec[A], v: A, expectedType: DataType): MessageHolder = {
-    val h = new MessageHolder
+  protected def roundtrip[A](codec: MessageCodec[A], v: A, expectedType: DataType): MessageContext = {
+    val h = new MessageContext
     debug(s"Testing roundtrip of ${v} with ${codec}")
     val packer = MessagePack.newBufferPacker
     codec.pack(packer, v)
@@ -43,8 +43,8 @@ trait CodecSpec extends AirSpec {
     h
   }
 
-  protected def roundtripStr[A](codec: MessageCodec[A], v: A, expectedType: DataType): MessageHolder = {
-    val h = new MessageHolder
+  protected def roundtripStr[A](codec: MessageCodec[A], v: A, expectedType: DataType): MessageContext = {
+    val h = new MessageContext
     trace(s"Testing str based roundtrip of ${v} with ${codec}")
     val packer = MessagePack.newBufferPacker
     packer.packString(v.toString)

--- a/airframe-codec/src/test/scala/wvlet/airframe/codec/ObjectCodecTest.scala
+++ b/airframe-codec/src/test/scala/wvlet/airframe/codec/ObjectCodecTest.scala
@@ -32,7 +32,7 @@ class ObjectCodecTest extends CodecSpec {
     codec.packAsMap(packer, v)
     val b = packer.toByteArray
 
-    val h = new MessageHolder
+    val h = new MessageContext
     codec.unpack(MessagePack.newUnpacker(b), h)
 
     h.isNull shouldBe false
@@ -48,7 +48,7 @@ class ObjectCodecTest extends CodecSpec {
     packer.packInt(10)
     val b = packer.toByteArray
 
-    val h = new MessageHolder
+    val h = new MessageContext
     MessageCodec.of[A2].unpack(MessagePack.newUnpacker(b), h)
 
     h.isNull shouldBe false

--- a/airframe-http/src/main/scala/wvlet/airframe/http/router/HttpResponseCodec.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/router/HttpResponseCodec.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.http.router
 
-import wvlet.airframe.codec.{JSONCodec, MessageCodec, MessageHolder}
+import wvlet.airframe.codec.{JSONCodec, MessageCodec, MessageContext}
 import wvlet.airframe.http.{HttpResponse, HttpResponseAdapter}
 import wvlet.airframe.msgpack.spi.{Packer, Unpacker}
 
@@ -40,5 +40,5 @@ class HttpResponseCodec[Resp: HttpResponseAdapter] extends MessageCodec[HttpResp
         }
     }
   }
-  override def unpack(u: Unpacker, v: MessageHolder): Unit = ???
+  override def unpack(u: Unpacker, v: MessageContext): Unit = ???
 }

--- a/airframe-launcher/src/main/scala/wvlet/airframe/launcher/Launcher.scala
+++ b/airframe-launcher/src/main/scala/wvlet/airframe/launcher/Launcher.scala
@@ -37,7 +37,6 @@ import scala.reflect.runtime.{universe => ru}
   * Command launcher
   */
 object Launcher extends LogSupport {
-
   /**
     * Create a new Launcher of the given type
     *
@@ -92,10 +91,11 @@ object Launcher extends LogSupport {
           case None      => false
         }
       }
-      .map { m =>
-        { li: LauncherInstance =>
-          m.call(li.instance)
-        }
+      .map {
+        m =>
+          { li: LauncherInstance =>
+            m.call(li.instance)
+          }
       }
 
     new CommandLauncher(

--- a/airframe-launcher/src/main/scala/wvlet/airframe/launcher/Launcher.scala
+++ b/airframe-launcher/src/main/scala/wvlet/airframe/launcher/Launcher.scala
@@ -23,7 +23,7 @@ package wvlet.airframe.launcher
 
 import java.lang.reflect.InvocationTargetException
 
-import wvlet.airframe.codec.{MessageCodecFactory, MessageHolder, ParamListCodec}
+import wvlet.airframe.codec.{MessageCodecFactory, MessageContext, ParamListCodec}
 import wvlet.airframe.control.CommandLineTokenizer
 import wvlet.airframe.launcher.OptionParser.CLOption
 import wvlet.airframe.msgpack.spi.MessagePack
@@ -37,6 +37,7 @@ import scala.reflect.runtime.{universe => ru}
   * Command launcher
   */
 object Launcher extends LogSupport {
+
   /**
     * Create a new Launcher of the given type
     *
@@ -91,11 +92,10 @@ object Launcher extends LogSupport {
           case None      => false
         }
       }
-      .map {
-        m =>
-          { li: LauncherInstance =>
-            m.call(li.instance)
-          }
+      .map { m =>
+        { li: LauncherInstance =>
+          m.call(li.instance)
+        }
       }
 
     new CommandLauncher(
@@ -309,7 +309,7 @@ class CommandLauncher(
       case c: ClassOptionSchema =>
         val parseTree_mp = result.parseTree.toMsgPack
         val codec        = launcherConfig.codecFactory.withMapOutput.of(c.surface)
-        val h            = new MessageHolder
+        val h            = new MessageContext
         codec.unpack(MessagePack.newUnpacker(parseTree_mp), h)
         h.getError.map { e =>
           throw new IllegalArgumentException(s"Error occurered in launching ${c.surface}: ${e.getMessage}")

--- a/airframe-launcher/src/main/scala/wvlet/airframe/launcher/StringTreeCodec.scala
+++ b/airframe-launcher/src/main/scala/wvlet/airframe/launcher/StringTreeCodec.scala
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 package wvlet.airframe.launcher
-import wvlet.airframe.codec.{MessageCodec, MessageHolder}
+import wvlet.airframe.codec.{MessageCodec, MessageContext}
 import wvlet.airframe.msgpack.spi.{Packer, Unpacker}
 
 /**
@@ -41,5 +41,5 @@ object StringTreeCodec extends MessageCodec[StringTree] {
     }
   }
 
-  override def unpack(u: Unpacker, v: MessageHolder): Unit = ???
+  override def unpack(u: Unpacker, v: MessageContext): Unit = ???
 }


### PR DESCRIPTION
This is a preparation for future extensibility (e.g., configuring codec behavior)