### PR TITLE
airframe-codec: Support Base64 encoded binary

### DIFF
--- a/airframe-codec/src/main/scala/wvlet/airframe/codec/PrimitiveCodec.scala
+++ b/airframe-codec/src/main/scala/wvlet/airframe/codec/PrimitiveCodec.scala
@@ -14,8 +14,8 @@
 package wvlet.airframe.codec
 
 import java.time.Instant
+import java.util.Base64
 
-import wvlet.airframe.codec.ScalaStandardCodec.OptionCodec
 import wvlet.airframe.codec.StandardCodec.ThrowableCodec
 import wvlet.airframe.json.JSON.JSONValue
 import wvlet.airframe.json.Json
@@ -330,6 +330,8 @@ object PrimitiveCodec {
         case ValueType.BINARY =>
           read {
             val len = u.unpackBinaryHeader
+            val b = u.readPayload(len)
+            Base64.getDecoder.
             new String(u.readPayload(len))
           }
         case _ =>
@@ -660,6 +662,9 @@ object PrimitiveCodec {
           val len = u.unpackBinaryHeader
           val b   = u.readPayload(len)
           v.setObject(b)
+        case ValueType.STRING =>
+          val arr: Array[Byte] = Base64.getDecoder.decode(u.unpackString)
+          v.setObject(arr)
         case _ =>
           // Set MessagePack binary
           val value = u.unpackValue

--- a/airframe-codec/src/test/scala/wvlet/airframe/codec/PrimitiveCodecTest.scala
+++ b/airframe-codec/src/test/scala/wvlet/airframe/codec/PrimitiveCodecTest.scala
@@ -23,6 +23,8 @@ import wvlet.airframe.msgpack.spi.Value.StringValue
 import wvlet.airframe.surface.{ArraySurface, GenericSurface, Surface}
 import wvlet.airspec.spi.PropertyCheck
 
+import scala.util.Random
+
 /**
   *
   */
@@ -428,5 +430,16 @@ class PrimitiveCodecTest extends CodecSpec with PropertyCheck {
     val codec = MessageCodec.of[Seq[Any]]
     val seq   = codec.fromJson("[null, 1]")
     seq shouldBe Seq(null, 1)
+  }
+
+  case class BinaryData(data: Array[Byte])
+
+  def `encode binary with BASE64`: Unit = {
+    val data = new Array[Byte](40)
+    Random.nextBytes(data)
+    val codec = MessageCodec.of[BinaryData]
+    val json  = codec.toJson(BinaryData(data))
+    val x     = codec.fromJson(json)
+    x.data shouldBe data
   }
 }

--- a/airframe-msgpack/src/main/scala/wvlet/airframe/msgpack/spi/Value.scala
+++ b/airframe-msgpack/src/main/scala/wvlet/airframe/msgpack/spi/Value.scala
@@ -162,6 +162,7 @@ object Value {
       packer.writePayload(v)
     }
 
+    // Produces Base64 encoded strings
     override protected def toRawString: String = {
       synchronized {
         if (decodedStringCache == null) {
@@ -183,13 +184,10 @@ object Value {
   }
 
   case class ExtensionValue(extType: Byte, v: Array[Byte]) extends Value {
+    // [extType(int),extBinary(base64)]
     override def toJson = {
-      val sb = Seq.newBuilder[String]
-      for (e <- v) {
-        // Binary to HEX
-        sb += Integer.toString(e.toInt, 16)
-      }
-      s"""[${extType.toInt.toString},"${sb.result.mkString(" ")}"]"""
+      val base64 = Base64.getEncoder.encodeToString(v)
+      s"""[${extType.toInt},"${base64}"]"""
     }
     override def valueType: ValueType = ValueType.EXTENSION
     override def writeTo(packer: Packer): Unit = {

--- a/airframe-msgpack/src/main/scala/wvlet/airframe/msgpack/spi/Value.scala
+++ b/airframe-msgpack/src/main/scala/wvlet/airframe/msgpack/spi/Value.scala
@@ -14,7 +14,6 @@
 package wvlet.airframe.msgpack.spi
 
 import java.math.BigInteger
-import java.nio.charset.StandardCharsets
 import java.time.Instant
 import java.util
 import java.util.Base64

--- a/airframe-msgpack/src/main/scala/wvlet/airframe/msgpack/spi/Value.scala
+++ b/airframe-msgpack/src/main/scala/wvlet/airframe/msgpack/spi/Value.scala
@@ -17,6 +17,7 @@ import java.math.BigInteger
 import java.nio.charset.StandardCharsets
 import java.time.Instant
 import java.util
+import java.util.Base64
 
 import wvlet.airframe.msgpack.spi.MessageException._
 
@@ -164,7 +165,7 @@ object Value {
     override protected def toRawString: String = {
       synchronized {
         if (decodedStringCache == null) {
-          decodedStringCache = new String(v, StandardCharsets.UTF_8)
+          decodedStringCache = Base64.getEncoder.encodeToString(v)
         }
       }
       decodedStringCache

--- a/airframe-msgpack/src/test/scala/wvlet/airframe/msgpack/spi/ValueTest.scala
+++ b/airframe-msgpack/src/test/scala/wvlet/airframe/msgpack/spi/ValueTest.scala
@@ -14,6 +14,7 @@
 package wvlet.airframe.msgpack.spi
 
 import java.math.BigInteger
+import java.util.Base64
 
 import org.scalacheck.Gen
 import wvlet.airframe.msgpack.io.ByteArrayBuffer
@@ -127,7 +128,7 @@ class ValueTest extends AirSpec with PropertyCheck {
   def `have Binary`: Unit = {
     val b = newBinary(Array[Byte]('a', 'b', 'c', '\n', '\b', '\r', '\t', '\f', '\\', '"', 'd', 0x01))
     b.valueType shouldBe ValueType.BINARY
-    val json = """"abc\n\b\r\t\f\\\"d""" + "\\" + "u0001" + "\""
+    val json = "\"" + Base64.getEncoder.encodeToString(b.v) + "\""
     b.toJson shouldBe json
     b.toString shouldBe json
   }
@@ -135,7 +136,9 @@ class ValueTest extends AirSpec with PropertyCheck {
   def `have ext`: Unit = {
     val e = newExt(-1, Array[Byte]('a', 'b', 'c'))
     e.valueType shouldBe ValueType.EXTENSION
-    e.toString shouldBe """[-1,"61 62 63"]"""
+    val json = s"""[-1,"${Base64.getEncoder.encodeToString(e.v)}"]"""
+    e.toJson shouldBe json
+    e.toString shouldBe json
   }
 
   def `have map`: Unit = {


### PR DESCRIPTION
This will close #634 

Previously airframe-codec encodes binary values as UTF-8 strings, but it may have caused data loss. This PR will use Base64 for representing binary values when generating JSON data. 

Similarly, when reading string values to Array[Byte], try decoding the strings as Base64 binaries. If it fails, it will fall back to using the raw string byte arrays of the string.   

This encoding is also used in Open API https://swagger.io/docs/specification/data-models/data-types/#string

cc: @takezoe @shimamoto 