### PR TITLE
Move the internal routing code to wvlet.airframe.http.router package

### DIFF
--- a/airframe-http-finagle/src/main/scala/wvlet/airframe/http/finagle/FinagleClient.scala
+++ b/airframe-http-finagle/src/main/scala/wvlet/airframe/http/finagle/FinagleClient.scala
@@ -22,6 +22,7 @@ import wvlet.airframe.codec.{MessageCodec, MessageCodecFactory}
 import wvlet.airframe.control.Retry.RetryContext
 import wvlet.airframe.http.HttpClient.urlEncode
 import wvlet.airframe.http._
+import wvlet.airframe.http.router.HttpResponseCodec
 import wvlet.airframe.json.JSON.{JSONArray, JSONObject}
 import wvlet.log.LogSupport
 

--- a/airframe-http-finagle/src/main/scala/wvlet/airframe/http/finagle/FinagleFilter.scala
+++ b/airframe-http-finagle/src/main/scala/wvlet/airframe/http/finagle/FinagleFilter.scala
@@ -17,7 +17,8 @@ import com.twitter.finagle.http.{Request, Response}
 import com.twitter.finagle.{Service, SimpleFilter}
 import com.twitter.util.Future
 import wvlet.airframe.Session
-import wvlet.airframe.http.{ControllerProvider, HttpContext, HttpRequestDispatcher, ResponseHandler}
+import wvlet.airframe.http.router.HttpRequestDispatcher
+import wvlet.airframe.http.HttpContext
 
 /**
   * An wrapper of HttpFilter for Finagle backend implementation

--- a/airframe-http-finagle/src/main/scala/wvlet/airframe/http/finagle/FinagleResponseHandler.scala
+++ b/airframe-http-finagle/src/main/scala/wvlet/airframe/http/finagle/FinagleResponseHandler.scala
@@ -20,7 +20,8 @@ import com.twitter.finagle.http._
 import com.twitter.io.Buf.ByteArray
 import com.twitter.io.{Buf, Reader}
 import wvlet.airframe.codec.{JSONCodec, MessageCodec, MessageCodecFactory}
-import wvlet.airframe.http.{HttpStatus, ResponseHandler, SimpleHttpResponse}
+import wvlet.airframe.http.router.ResponseHandler
+import wvlet.airframe.http.{HttpStatus, SimpleHttpResponse}
 import wvlet.airframe.surface.{Primitive, Surface}
 import wvlet.log.LogSupport
 

--- a/airframe-http-finagle/src/main/scala/wvlet/airframe/http/finagle/FinagleServer.scala
+++ b/airframe-http-finagle/src/main/scala/wvlet/airframe/http/finagle/FinagleServer.scala
@@ -24,7 +24,8 @@ import wvlet.airframe._
 import wvlet.airframe.codec.MessageCodec
 import wvlet.airframe.control.MultipleExceptions
 import wvlet.airframe.http.finagle.FinagleServer.FinagleService
-import wvlet.airframe.http.{ControllerProvider, HttpServerException, ResponseHandler, Router}
+import wvlet.airframe.http.router.{ControllerProvider, ResponseHandler}
+import wvlet.airframe.http.{HttpServerException, Router}
 import wvlet.airframe.surface.Surface
 import wvlet.log.LogSupport
 import wvlet.log.io.IOUtil

--- a/airframe-http/src/main/scala/wvlet/airframe/http/Router.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/Router.scala
@@ -13,6 +13,7 @@
  */
 package wvlet.airframe.http
 
+import wvlet.airframe.http.router.{ControllerRoute, Route, RouteMatch, RouteMatcher, RouterMacros}
 import wvlet.airframe.surface.{MethodSurface, Surface}
 import wvlet.log.LogSupport
 

--- a/airframe-http/src/main/scala/wvlet/airframe/http/router/Automaton.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/router/Automaton.scala
@@ -11,8 +11,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.airframe.http
+package wvlet.airframe.http.router
 
+/**
+  *
+  */
 object Automaton {
   def empty[Node, Token]: Automaton[Node, Token] = new Automaton(Set.empty, Set.empty)
 

--- a/airframe-http/src/main/scala/wvlet/airframe/http/router/ControllerProvider.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/router/ControllerProvider.scala
@@ -11,13 +11,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.airframe.http
+package wvlet.airframe.http.router
 
-import wvlet.log.LogSupport
+import wvlet.airframe._
 import wvlet.airframe.surface.Surface
+import wvlet.log.LogSupport
 
 import scala.util.{Failure, Success, Try}
-import wvlet.airframe._
 
 /**
   *

--- a/airframe-http/src/main/scala/wvlet/airframe/http/router/HttpRequestDispatcher.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/router/HttpRequestDispatcher.scala
@@ -11,17 +11,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.airframe.http
+package wvlet.airframe.http.router
 
 import java.lang.reflect.InvocationTargetException
 
 import wvlet.airframe.Session
 import wvlet.airframe.http.Router.RouteFilter
+import wvlet.airframe.http._
 import wvlet.log.LogSupport
 
 import scala.concurrent.ExecutionContext
 import scala.language.higherKinds
 
+/**
+  *
+  */
 object HttpRequestDispatcher {
   def newDispatcher[Req: HttpRequestAdapter, Resp, F[_]](
       session: Session,
@@ -38,6 +42,7 @@ object HttpRequestDispatcher {
     backend.newFilter { (request: Req, context: HttpContext[Req, Resp, F]) =>
       router.findRoute(request) match {
         case Some(routeMatch) =>
+          // Find a filter for the matched route
           val routeFilter = filterTable(routeMatch.route)
           val context =
             new HttpEndpointExecutionContext(backend, routeMatch, routeFilter.controller, responseHandler)

--- a/airframe-http/src/main/scala/wvlet/airframe/http/router/HttpRequestMapper.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/router/HttpRequestMapper.scala
@@ -11,10 +11,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.airframe.http
+package wvlet.airframe.http.router
 
 import wvlet.airframe.codec.PrimitiveCodec.StringCodec
 import wvlet.airframe.codec.{JSONCodec, MessageCodec, MessageCodecFactory}
+import wvlet.airframe.http.{HttpMethod, HttpRequest, HttpRequestAdapter}
 import wvlet.airframe.json.JSON
 import wvlet.airframe.msgpack.spi.MessagePack
 import wvlet.airframe.surface.reflect.ReflectMethodSurface

--- a/airframe-http/src/main/scala/wvlet/airframe/http/router/HttpResponseCodec.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/router/HttpResponseCodec.scala
@@ -11,9 +11,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.airframe.http
+package wvlet.airframe.http.router
 
 import wvlet.airframe.codec.{JSONCodec, MessageCodec, MessageHolder}
+import wvlet.airframe.http.{HttpResponse, HttpResponseAdapter}
 import wvlet.airframe.msgpack.spi.{Packer, Unpacker}
 
 /**

--- a/airframe-http/src/main/scala/wvlet/airframe/http/router/ResponseHandler.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/router/ResponseHandler.scala
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.airframe.http
+package wvlet.airframe.http.router
 
 import wvlet.airframe.surface.Surface
 

--- a/airframe-http/src/main/scala/wvlet/airframe/http/router/Route.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/router/Route.scala
@@ -11,10 +11,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.airframe.http
+package wvlet.airframe.http.router
 
 import wvlet.airframe.Session
 import wvlet.airframe.codec.{MISSING_PARAMETER, MessageCodecException}
+import wvlet.airframe.http._
 import wvlet.airframe.surface.Surface
 import wvlet.airframe.surface.reflect.ReflectMethodSurface
 import wvlet.log.LogSupport

--- a/airframe-http/src/main/scala/wvlet/airframe/http/router/RouteMatcher.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/router/RouteMatcher.scala
@@ -11,9 +11,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.airframe.http
+package wvlet.airframe.http.router
+
 import wvlet.airframe.Session
-import wvlet.airframe.http.Automaton.{DFA, NextNode}
+import Automaton.{DFA, NextNode}
+import wvlet.airframe.http._
 import wvlet.log.LogSupport
 
 case class RouteMatch(route: Route, params: Map[String, String]) {
@@ -69,7 +71,7 @@ object RouteMatcher extends LogSupport {
             throw new IllegalArgumentException(
               s"Found multiple matching routes: ${state.map(_.route).flatten.map(p => s"${p.path}").mkString(", ")} "
             )
-          }
+        }
       )
 
     def findRoute[Req](request: Req)(implicit tp: HttpRequestAdapter[Req]): Option[RouteMatch] = {
@@ -111,7 +113,7 @@ object RouteMatcher extends LogSupport {
 
       foundRoute.map { r =>
         trace(s"Found a matching route: ${r.path} <= {${params.mkString(", ")}}")
-        RouteMatch(r, params.toMap)
+        router.RouteMatch(r, params.toMap)
       }
     }
   }

--- a/airframe-http/src/main/scala/wvlet/airframe/http/router/RouteMatcher.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/router/RouteMatcher.scala
@@ -71,7 +71,7 @@ object RouteMatcher extends LogSupport {
             throw new IllegalArgumentException(
               s"Found multiple matching routes: ${state.map(_.route).flatten.map(p => s"${p.path}").mkString(", ")} "
             )
-        }
+          }
       )
 
     def findRoute[Req](request: Req)(implicit tp: HttpRequestAdapter[Req]): Option[RouteMatch] = {

--- a/airframe-http/src/main/scala/wvlet/airframe/http/router/RouterMacros.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/router/RouterMacros.scala
@@ -11,9 +11,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.airframe.http
+package wvlet.airframe.http.router
 
-import scala.language.experimental.macros
+import wvlet.airframe.http.HttpFilterType
 import scala.reflect.macros.{blackbox => sm}
 
 /**

--- a/airframe-http/src/test/scala/wvlet/airframe/http/RouterTest.scala
+++ b/airframe-http/src/test/scala/wvlet/airframe/http/RouterTest.scala
@@ -16,6 +16,7 @@ package wvlet.airframe.http
 import wvlet.airframe.Session
 import wvlet.airframe.http.example.ControllerExample.User
 import wvlet.airframe.http.example._
+import wvlet.airframe.http.router.{ControllerProvider, RouteMatcher}
 import wvlet.airframe.surface.Surface
 import wvlet.airspec.AirSpec
 


### PR DESCRIPTION
This PR is just for moving internal code to router package. Router object, which is used for defining HTTP endpoints will remain in http package, so it should have no user-facing change. 