### PR TITLE
Add option to disable implicit instance creation

### DIFF
--- a/airframe/src/main/scala/wvlet/airframe/AirframeSession.scala
+++ b/airframe/src/main/scala/wvlet/airframe/AirframeSession.scala
@@ -353,6 +353,11 @@ private[airframe] class AirframeSession(
 
     val result =
       obj.getOrElse {
+        // strict mode
+        if (design.designOptions.disableImplicitInstanceGeneration.contains(true)) {
+          throw new MISSING_DEPENDENCY(seen, sourceCode)
+        }
+
         trace(s"[${name}] No binding is found for ${tpe}. Building the instance. create = ${create}")
         if (create) {
           // Create a new instance for bindFactory[X] or building X using its default value

--- a/airframe/src/main/scala/wvlet/airframe/AirframeSession.scala
+++ b/airframe/src/main/scala/wvlet/airframe/AirframeSession.scala
@@ -355,7 +355,7 @@ private[airframe] class AirframeSession(
       obj.getOrElse {
         // strict mode
         if (design.designOptions.defaultInstanceInjection.contains(false)) {
-          throw new MISSING_DEPENDENCY(seen, sourceCode)
+          throw new MISSING_DEPENDENCY(tpe :: seen, sourceCode)
         }
 
         trace(s"[${name}] No binding is found for ${tpe}. Building the instance. create = ${create}")

--- a/airframe/src/main/scala/wvlet/airframe/AirframeSession.scala
+++ b/airframe/src/main/scala/wvlet/airframe/AirframeSession.scala
@@ -354,7 +354,7 @@ private[airframe] class AirframeSession(
     val result =
       obj.getOrElse {
         // strict mode
-        if (design.designOptions.disableImplicitInstanceGeneration.contains(true)) {
+        if (design.designOptions.defaultInstanceInjection.contains(false)) {
           throw new MISSING_DEPENDENCY(seen, sourceCode)
         }
 

--- a/airframe/src/main/scala/wvlet/airframe/Design.scala
+++ b/airframe/src/main/scala/wvlet/airframe/Design.scala
@@ -29,6 +29,7 @@ import wvlet.airframe.lifecycle.LifeCycleHookType
 case class DesignOptions(
     enabledLifeCycleLogging: Option[Boolean] = None,
     stage: Option[Stage] = None,
+    disableImplicitInstanceGeneration: Option[Boolean] = None,
     options: Map[String, Any] = Map.empty
 ) extends Serializable {
   def +(other: DesignOptions): DesignOptions = {
@@ -36,6 +37,7 @@ case class DesignOptions(
     new DesignOptions(
       other.enabledLifeCycleLogging.orElse(this.enabledLifeCycleLogging),
       other.stage.orElse(this.stage),
+      other.disableImplicitInstanceGeneration.orElse(this.disableImplicitInstanceGeneration),
       defaultOptionMerger(options, other.options)
     )
   }
@@ -66,6 +68,10 @@ case class DesignOptions(
 
   def withLazyMode: DesignOptions = {
     this.copy(stage = Some(Stage.DEVELOPMENT))
+  }
+
+  def disableImplicitInstanceCreation: DesignOptions = {
+    this.copy(disableImplicitInstanceGeneration = Some(true))
   }
 
   private[airframe] def withOption[A](key: String, value: A): DesignOptions = {
@@ -187,6 +193,10 @@ class Design private[airframe] (
 
   def noLifeCycleLogging: Design = {
     new Design(designOptions.noLifecycleLogging, binding, hooks)
+  }
+
+  def disableImplicitInstanceCreation: Design = {
+    new Design(designOptions.disableImplicitInstanceCreation, binding, hooks)
   }
 
   /**

--- a/airframe/src/main/scala/wvlet/airframe/Design.scala
+++ b/airframe/src/main/scala/wvlet/airframe/Design.scala
@@ -29,7 +29,7 @@ import wvlet.airframe.lifecycle.LifeCycleHookType
 case class DesignOptions(
     enabledLifeCycleLogging: Option[Boolean] = None,
     stage: Option[Stage] = None,
-    disableImplicitInstanceGeneration: Option[Boolean] = None,
+    defaultInstanceInjection: Option[Boolean] = None,
     options: Map[String, Any] = Map.empty
 ) extends Serializable {
   def +(other: DesignOptions): DesignOptions = {
@@ -37,7 +37,7 @@ case class DesignOptions(
     new DesignOptions(
       other.enabledLifeCycleLogging.orElse(this.enabledLifeCycleLogging),
       other.stage.orElse(this.stage),
-      other.disableImplicitInstanceGeneration.orElse(this.disableImplicitInstanceGeneration),
+      other.defaultInstanceInjection.orElse(this.defaultInstanceInjection),
       defaultOptionMerger(options, other.options)
     )
   }
@@ -70,8 +70,8 @@ case class DesignOptions(
     this.copy(stage = Some(Stage.DEVELOPMENT))
   }
 
-  def disableImplicitInstanceCreation: DesignOptions = {
-    this.copy(disableImplicitInstanceGeneration = Some(true))
+  def noDefaultInstanceInjection: DesignOptions = {
+    this.copy(defaultInstanceInjection = Some(false))
   }
 
   private[airframe] def withOption[A](key: String, value: A): DesignOptions = {
@@ -195,8 +195,8 @@ class Design private[airframe] (
     new Design(designOptions.noLifecycleLogging, binding, hooks)
   }
 
-  def disableImplicitInstanceCreation: Design = {
-    new Design(designOptions.disableImplicitInstanceCreation, binding, hooks)
+  def noDefaultInstanceInjection: Design = {
+    new Design(designOptions.noDefaultInstanceInjection, binding, hooks)
   }
 
   /**

--- a/airframe/src/test/scala/wvlet/airframe/DisableImplicitInstanceCreationTest.scala
+++ b/airframe/src/test/scala/wvlet/airframe/DisableImplicitInstanceCreationTest.scala
@@ -19,6 +19,9 @@ import wvlet.airspec.AirSpec
 object DisableImplicitInstanceCreationTest {
   case class Component(config: Config)
   case class Config(value: String = "test")
+
+  case class Component2(config: Config2)
+  case class Config2(value: String)
 }
 
 class DisableImplicitInstanceCreationTest extends AirSpec {
@@ -45,6 +48,17 @@ class DisableImplicitInstanceCreationTest extends AirSpec {
     val d = Design.newDesign.bind[Component].toSingleton
     d.build[Component] { c =>
       assert(c.config.value == "test")
+    }
+  }
+
+  // Even if Airframe provide automatic singleton binding as safe-default behavior,
+  // a runtime exception can occur at unexpected timing in this case.
+  def `missing dependency`: Unit = {
+    val d = Design.newDesign.withProductionMode
+    d.withSession { session =>
+      intercept[MISSING_DEPENDENCY] {
+        session.build[Component2]
+      }
     }
   }
 }

--- a/airframe/src/test/scala/wvlet/airframe/DisableImplicitInstanceCreationTest.scala
+++ b/airframe/src/test/scala/wvlet/airframe/DisableImplicitInstanceCreationTest.scala
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe
+
+import wvlet.airframe.AirframeException.MISSING_DEPENDENCY
+import wvlet.airspec.AirSpec
+
+object DisableImplicitInstanceCreationTest {
+  case class Component(config: Config)
+  case class Config(value: String = "test")
+}
+
+class DisableImplicitInstanceCreationTest extends AirSpec {
+  import DisableImplicitInstanceCreationTest._
+  scalaJsSupport
+
+  def `disable implicit instance creation`: Unit = {
+    val d = Design.newDesign.bind[Component].toSingleton.disableImplicitInstanceCreation
+    intercept[MISSING_DEPENDENCY] {
+      d.build[Component] { _ =>
+      }
+    }
+  }
+
+  def `enable implicit instance creation`: Unit = {
+    val d = Design.newDesign.bind[Component].toSingleton
+    d.build[Component] { c =>
+      assert(c.config.value == "test")
+    }
+  }
+}

--- a/airframe/src/test/scala/wvlet/airframe/DisableImplicitInstanceCreationTest.scala
+++ b/airframe/src/test/scala/wvlet/airframe/DisableImplicitInstanceCreationTest.scala
@@ -33,6 +33,14 @@ class DisableImplicitInstanceCreationTest extends AirSpec {
     }
   }
 
+  def `disable implicit instance creation with production mode`: Unit = {
+    val d = Design.newDesign.bind[Component].toSingleton.disableImplicitInstanceCreation.withProductionMode
+    intercept[MISSING_DEPENDENCY] {
+      d.withSession { _ =>
+      }
+    }
+  }
+
   def `enable implicit instance creation`: Unit = {
     val d = Design.newDesign.bind[Component].toSingleton
     d.build[Component] { c =>

--- a/airframe/src/test/scala/wvlet/airframe/DisableNoDefaultInstanceCreationTest.scala
+++ b/airframe/src/test/scala/wvlet/airframe/DisableNoDefaultInstanceCreationTest.scala
@@ -16,20 +16,17 @@ package wvlet.airframe
 import wvlet.airframe.AirframeException.MISSING_DEPENDENCY
 import wvlet.airspec.AirSpec
 
-object DisableImplicitInstanceCreationTest {
+object DisableNoDefaultInstanceCreationTest {
   case class Component(config: Config)
   case class Config(value: String = "test")
-
-  case class Component2(config: Config2)
-  case class Config2(value: String)
 }
 
-class DisableImplicitInstanceCreationTest extends AirSpec {
-  import DisableImplicitInstanceCreationTest._
+class DisableNoDefaultInstanceCreationTest extends AirSpec {
+  import DisableNoDefaultInstanceCreationTest._
   scalaJsSupport
 
   def `disable implicit instance creation`: Unit = {
-    val d = Design.newDesign.bind[Component].toSingleton.disableImplicitInstanceCreation
+    val d = Design.newDesign.bind[Component].toSingleton.noDefaultInstanceInjection
     intercept[MISSING_DEPENDENCY] {
       d.build[Component] { _ =>
       }
@@ -37,7 +34,7 @@ class DisableImplicitInstanceCreationTest extends AirSpec {
   }
 
   def `disable implicit instance creation with production mode`: Unit = {
-    val d = Design.newDesign.bind[Component].toSingleton.disableImplicitInstanceCreation.withProductionMode
+    val d = Design.newDesign.bind[Component].toSingleton.noDefaultInstanceInjection.withProductionMode
     intercept[MISSING_DEPENDENCY] {
       d.withSession { _ =>
       }
@@ -48,17 +45,6 @@ class DisableImplicitInstanceCreationTest extends AirSpec {
     val d = Design.newDesign.bind[Component].toSingleton
     d.build[Component] { c =>
       assert(c.config.value == "test")
-    }
-  }
-
-  // Even if Airframe provide automatic singleton binding as safe-default behavior,
-  // a runtime exception can occur at unexpected timing in this case.
-  def `missing dependency`: Unit = {
-    val d = Design.newDesign.withProductionMode
-    d.withSession { session =>
-      intercept[MISSING_DEPENDENCY] {
-        session.build[Component2]
-      }
     }
   }
 }


### PR DESCRIPTION
Add a new option that disables implicit instance creation.

```scala
val d = Design.newDesign
  .bind[Component].toSingleton
  .noDefaultInstanceInjection
```

This allows us to prevent unexpected side effect caused by unintentional instance creation. Also, it helps us to remove unused components with confidence.