### PR TITLE
Add test case for showConfig()

### DIFF
--- a/airframe-config/src/test/scala/wvlet/airframe/config/AirframeBootstrapTest.scala
+++ b/airframe-config/src/test/scala/wvlet/airframe/config/AirframeBootstrapTest.scala
@@ -20,12 +20,14 @@ import wvlet.airspec.AirSpec
 object AirframeBootstrapTest {
   case class AppConfig(name: String)
   case class App2Config(name: String)
+  case class DBConfig(host: String, private val port: Option[Int] = None)
 
   import wvlet.airframe._
 
   val module1 =
     newDesign
       .bindConfig(AppConfig("hello"))
+      .bindConfig(DBConfig("localhost"))
       .bind[String].toInstance("world")
 
   val module2 =


### PR DESCRIPTION
This test case reproduces https://github.com/wvlet/airframe/issues/901

Possible options are:
- Config must not have `private val` in the constructor
- Exclude `private val` fields from the target of `showConfig()`
