### PR TITLE
Building components in Future causes strange errors

### DIFF
--- a/airframe/.jvm/src/test/scala/wvlet/airframe/BuildInFutureTest.scala
+++ b/airframe/.jvm/src/test/scala/wvlet/airframe/BuildInFutureTest.scala
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe
+
+import wvlet.airspec.AirSpec
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Future}
+
+case class Config1(port: Int = 8080)
+case class Config2()
+
+class BuildInFutureTest extends AirSpec {
+
+  def `Building in Future causes MISSING_DEPENDENCY` = {
+    val f = Future {
+      newDesign.build[Config1] { config =>
+        println(config)
+      }
+    }
+    Await.result(f, Duration.Inf)
+  }
+
+  def `Building in Future causes java.lang.ClassCastException` = {
+    val f = Future {
+      newDesign
+        .bind[Config2].toInstance(Config2())
+        .build[Config1] { config =>
+          println(config)
+        }
+    }
+    Await.result(f, Duration.Inf)
+  }
+}


### PR DESCRIPTION
This test fails as follows. I believe that it had been working at some points of the previous versions of Airframe.

```
BuildInFutureTest:
2020-02-01 14:18:55.355+0900  info [LifeCycleManager] [session:43ed165b] Starting a new lifecycle ...  - (LifeCycleManager.scala:260)
2020-02-01 14:18:55.361+0900  info [LifeCycleManager] [session:43ed165b] ======== STARTED ========  - (LifeCycleManager.scala:264)
2020-02-01 14:18:55.402+0900  info [LifeCycleManager] [session:43ed165b] Stopping the lifecycle ...  - (LifeCycleManager.scala:268)
2020-02-01 14:18:55.406+0900  info [LifeCycleManager] [session:43ed165b] The lifecycle has stopped.  - (LifeCycleManager.scala:272)
 - Building in Future causes MISSING_DEPENDENCY 61.89ms << error: [MISSING_DEPENDENCY] Binding for Int at BuildInFutureTest.scala:29 is not found: Int <- Object

[MISSING_DEPENDENCY] Binding for Int at BuildInFutureTest.scala:29 is not found: Int <- Object
  | => wat wvlet.airframe.AirframeSession.buildInstance(AirframeSession.scala:425)
        at wvlet.airframe.AirframeSession.$anonfun$buildInstance$4(AirframeSession.scala:409)
        at scala.Option.getOrElse(Option.scala:189)
        at wvlet.airframe.AirframeSession.buildInstance(AirframeSession.scala:407)
        at wvlet.airframe.AirframeSession.$anonfun$getInstance$7(AirframeSession.scala:367)
        at scala.Option.getOrElse(Option.scala:189)
        at wvlet.airframe.AirframeSession.getInstance(AirframeSession.scala:355)
        at wvlet.airframe.AirframeSession.$anonfun$buildInstance$5(AirframeSession.scala:440)
        at scala.collection.TraversableLike.$anonfun$map$1(TraversableLike.scala:238)
        at scala.collection.Iterator.foreach(Iterator.scala:941)
        at scala.collection.Iterator.foreach$(Iterator.scala:941)
        at scala.collection.AbstractIterator.foreach(Iterator.scala:1429)
        at scala.collection.IterableLike.foreach(IterableLike.scala:74)
        at scala.collection.IterableLike.foreach$(IterableLike.scala:73)
        at scala.collection.AbstractIterable.foreach(Iterable.scala:56)
        at scala.collection.TraversableLike.map(TraversableLike.scala:238)
        at scala.collection.TraversableLike.map$(TraversableLike.scala:231)
        at scala.collection.AbstractTraversable.map(Traversable.scala:108)
        at wvlet.airframe.AirframeSession.buildInstance(AirframeSession.scala:430)
        at wvlet.airframe.AirframeSession.$anonfun$buildInstance$4(AirframeSession.scala:409)
        at scala.Option.getOrElse(Option.scala:189)
        at wvlet.airframe.AirframeSession.buildInstance(AirframeSession.scala:407)
        at wvlet.airframe.AirframeSession.$anonfun$getInstance$8(AirframeSession.scala:376)
        at scala.collection.concurrent.Map.getOrElseUpdate(Map.scala:97)
        at scala.collection.concurrent.Map.getOrElseUpdate$(Map.scala:94)
        at scala.collection.convert.Wrappers$JConcurrentMapWrapper.getOrElseUpdate(Wrappers.scala:333)
        at wvlet.airframe.AirframeSession.$anonfun$getInstance$7(AirframeSession.scala:373)
        at scala.Option.getOrElse(Option.scala:189)
        at wvlet.airframe.AirframeSession.getInstance(AirframeSession.scala:355)
        at wvlet.airframe.AirframeSession.get(AirframeSession.scala:169)
        at wvlet.airframe.BuildInFutureTest.$anonfun$Building$u0020in$u0020Future$u0020causes$u0020MISSING_DEPENDENCY$4(BuildInFutureTest.scala:29)
        at wvlet.airframe.BuildInFutureTest.$anonfun$Building$u0020in$u0020Future$u0020causes$u0020MISSING_DEPENDENCY$3(BuildInFutureTest.scala:29)
        at wvlet.airframe.BuildInFutureTest.$anonfun$Building$u0020in$u0020Future$u0020causes$u0020MISSING_DEPENDENCY$3$adapted(BuildInFutureTest.scala:29)
        at wvlet.airframe.Design.runWithSession(Design.scala:289)
        at wvlet.airframe.Design.withSession(Design.scala:302)
        at wvlet.airframe.BuildInFutureTest.$anonfun$Building$u0020in$u0020Future$u0020causes$u0020MISSING_DEPENDENCY$1(BuildInFutureTest.scala:29)
        at scala.concurrent.Future$.$anonfun$apply$1(Future.scala:659)
        at scala.util.Success.$anonfun$map$1(Try.scala:255)
        at scala.util.Success.map(Try.scala:213)
        at scala.concurrent.Future.$anonfun$map$1(Future.scala:292)
        at scala.concurrent.impl.Promise.liftedTree1$1(Promise.scala:33)
        at scala.concurrent.impl.Promise.$anonfun$transform$1(Promise.scala:33)
        at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:64)
        at java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1402)
        at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
        at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
        at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
2020-02-01 14:18:55.444+0900  info [LifeCycleManager] [session:7b81a73b] Starting a new lifecycle ...  - (LifeCycleManager.scala:260)
2020-02-01 14:18:55.444+0900  info [LifeCycleManager] [session:7b81a73b] ======== STARTED ========  - (LifeCycleManager.scala:264)
2020-02-01 14:18:55.445+0900  info [LifeCycleManager] [session:7b81a73b] Stopping the lifecycle ...  - (LifeCycleManager.scala:268)
2020-02-01 14:18:55.445+0900  info [LifeCycleManager] [session:7b81a73b] The lifecycle has stopped.  - (LifeCycleManager.scala:272)
 - Building in Future causes java.lang.ClassCastException 26.69ms << error: wvlet.airframe.Config2 cannot be cast to wvlet.airframe.Config1

java.lang.ClassCastException: wvlet.airframe.Config2 cannot be cast to wvlet.airframe.Config1
        at wvlet.airframe.BuildInFutureTest.$anonfun$Building$u0020in$u0020Future$u0020causes$u0020java$u002Elang$u002EClassCastException$6(BuildInFutureTest.scala:39)
        at wvlet.airframe.BuildInFutureTest.$anonfun$Building$u0020in$u0020Future$u0020causes$u0020java$u002Elang$u002EClassCastException$5(BuildInFutureTest.scala:39)
  | => wat wvlet.airframe.BuildInFutureTest.$anonfun$Building$u0020in$u0020Future$u0020causes$u0020java$u002Elang$u002EClassCastException$5$adapted(BuildInFutureTest.scala:39)
        at wvlet.airframe.Design.runWithSession(Design.scala:289)
        at wvlet.airframe.Design.withSession(Design.scala:302)
        at wvlet.airframe.BuildInFutureTest.$anonfun$Building$u0020in$u0020Future$u0020causes$u0020java$u002Elang$u002EClassCastException$1(BuildInFutureTest.scala:39)
        at scala.concurrent.Future$.$anonfun$apply$1(Future.scala:659)
        at scala.util.Success.$anonfun$map$1(Try.scala:255)
        at scala.util.Success.map(Try.scala:213)
        at scala.concurrent.Future.$anonfun$map$1(Future.scala:292)
        at scala.concurrent.impl.Promise.liftedTree1$1(Promise.scala:33)
        at scala.concurrent.impl.Promise.$anonfun$transform$1(Promise.scala:33)
        at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:64)
        at java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1402)
        at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
        at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
        at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
[error] Error: Total 2, Failed 0, Errors 2, Passed 0
[error] Error during tests:
[error]         wvlet.airframe.BuildInFutureTest
```