### PR TITLE
airframe-http: Find Endpoint annotations in parent interfaces

### DIFF
--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/ApiRouterTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/ApiRouterTest.scala
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.http
+import wvlet.airspec.AirSpec
+
+/**
+  *
+  */
+object ApiRouterTest extends AirSpec {
+
+  @Endpoint(path = "/v1")
+  trait MyApi {
+    @Endpoint(path = "/hello")
+    def hello: String
+  }
+
+  class MyApiImpl extends MyApi {
+    override def hello: String = "hello"
+  }
+
+  test("Create a router using API implementations") {
+    val r = Router.add[MyApiImpl]
+
+    r.routes shouldNotBe empty
+    val x = r.routes.head
+    x.method shouldBe HttpMethod.GET
+    x.path shouldBe "/v1/hello"
+  }
+}

--- a/airframe-http/src/main/scala/wvlet/airframe/http/Endpoint.java
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/Endpoint.java
@@ -14,6 +14,7 @@
 
 package wvlet.airframe.http;
 
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 

--- a/sbt-airframe/src/main/scala/wvlet/airframe/sbt/http/AirframeHttpPlugin.scala
+++ b/sbt-airframe/src/main/scala/wvlet/airframe/sbt/http/AirframeHttpPlugin.scala
@@ -81,6 +81,8 @@ object AirframeHttpPlugin extends AutoPlugin with LogSupport {
             val code = HttpClientGenerator.generate(router, config)
             IO.write(file, code)
             IO.touch(routerHashFile)
+          } else {
+            info(s"${relativeFileLoc} is up-to-date")
           }
           file
         }

--- a/sbt-airframe/src/sbt-test/sbt-airframe/generate-client/server/src/main/scala/myapp/server/MyServer.scala
+++ b/sbt-airframe/src/sbt-test/sbt-airframe/generate-client/server/src/main/scala/myapp/server/MyServer.scala
@@ -6,19 +6,18 @@ import wvlet.log.LogSupport
 import myapp.spi.MyService
 import com.twitter.util.Await
 
-class MyServer extends myapp.spi.MyService {
+class MyServiceImpl extends myapp.spi.MyService {
   override def hello(id: Int): String = s"hello ${id}"
 }
 
 object MyServer extends LogSupport {
 
   def main(args: Array[String]): Unit = {
-    val router = Router.of[MyService]
+    val router = Router.of[MyServiceImpl]
 
     val d =
       newFinagleServerDesign(router = router)
         .add(finagleClientDesign)
-        .bind[MyService].to[MyServer]
 
     d.build[FinagleClient] { finagleClient =>
       val client = new myapp.spi.ServiceClient(finagleClient)


### PR DESCRIPTION
Follow-up of #878 to fill the case when the leaf class is a concrete class.