### PR TITLE
airframe-http: Support Future[_], F[_] return types in IDL

### DIFF
--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/codegen/HttpClientGenerator.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/codegen/HttpClientGenerator.scala
@@ -140,7 +140,7 @@ class HttpClientGenerator(
           writeFile(outputFile, code)
           touch(routerHashFile)
         } else {
-          info(s"${path} is up-to-date")
+          info(s"${outputFile} is up-to-date")
         }
         outputFile
       }

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/codegen/HttpClientIR.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/codegen/HttpClientIR.scala
@@ -17,7 +17,7 @@ import java.util.Locale
 import wvlet.airframe.http.Router
 import wvlet.airframe.http.codegen.RouteAnalyzer.RouteAnalysisResult
 import wvlet.airframe.http.router.Route
-import wvlet.airframe.surface.{HigherKindedTypeSurface, MethodParameter, Parameter, Surface}
+import wvlet.airframe.surface.{GenericSurface, HigherKindedTypeSurface, MethodParameter, Parameter, Surface}
 import wvlet.log.LogSupport
 
 /**
@@ -73,11 +73,13 @@ object HttpClientIR extends LogSupport {
       path: String
   ) extends ClientCodeIR {
 
-    def resolveLeafReturnTypeName: String = {
-      logger.info(returnType)
+    def unwrapFutureFromReturnType: String = {
       returnType match {
-        case f if f.name.startsWith("Future[") || f.name.startsWith("Object[") || f.name.startsWith("F[") =>
-          returnType.typeArgs.mkString(", ")
+        case h: HigherKindedTypeSurface =>
+          h.typeArgs.mkString(",")
+        case g: GenericSurface
+            if g.rawType == classOf[scala.concurrent.Future[_]] || g.rawType.getName == "com.twitter.util.Future" =>
+          g.typeArgs.mkString(",")
         case _ =>
           returnType.name
       }

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/codegen/HttpClientIR.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/codegen/HttpClientIR.scala
@@ -151,9 +151,9 @@ object HttpClientIR extends LogSupport {
       case h: HigherKindedTypeSurface
           if h.typeArgs.size == 1 && h.name == "F" => // Only support 'F' for tagless-final pattern
         h.typeArgs.head
-      case g: GenericSurface
-          if g.rawType == classOf[scala.concurrent.Future[_]] || g.rawType.getName == "com.twitter.util.Future" =>
-        g.typeArgs.head
+      case s: Surface
+          if s.rawType == classOf[scala.concurrent.Future[_]] || s.rawType.getName == "com.twitter.util.Future" =>
+        s.typeArgs.head
       case _ =>
         s
     }

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/codegen/HttpClientIR.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/codegen/HttpClientIR.scala
@@ -17,7 +17,7 @@ import java.util.Locale
 import wvlet.airframe.http.Router
 import wvlet.airframe.http.codegen.RouteAnalyzer.RouteAnalysisResult
 import wvlet.airframe.http.router.Route
-import wvlet.airframe.surface.{MethodParameter, Parameter, Surface}
+import wvlet.airframe.surface.{HigherKindedTypeSurface, MethodParameter, Parameter, Surface}
 import wvlet.log.LogSupport
 
 /**
@@ -71,7 +71,18 @@ object HttpClientIR extends LogSupport {
       clientCallParameters: Seq[MethodParameter],
       returnType: Surface,
       path: String
-  ) extends ClientCodeIR
+  ) extends ClientCodeIR {
+
+    def resolveLeafReturnTypeName: String = {
+      logger.info(returnType)
+      returnType match {
+        case f if f.name.startsWith("Future[") || f.name.startsWith("Object[") || f.name.startsWith("F[") =>
+          returnType.typeArgs.mkString(", ")
+        case _ =>
+          returnType.name
+      }
+    }
+  }
 
   private case class PathVariableParam(name: String, param: MethodParameter)
 

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/codegen/HttpClientIR.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/codegen/HttpClientIR.scala
@@ -49,7 +49,7 @@ object HttpClientIR extends LogSupport {
 
       def requireImports(surface: Surface): Boolean = {
         val fullName          = surface.fullName
-        val importPackageName = resolveObjectName(fullName).split("\\.").dropRight(1).mkString(".")
+        val importPackageName = resolveObjectName(fullName).split(".").dropRight(1).mkString(".")
         // Primitive Scala collections can be found in scala.Predef. No need to include them
         !(importPackageName == "scala.collection" ||
           importPackageName == "wvlet.airframe.http" ||

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/codegen/HttpClientIR.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/codegen/HttpClientIR.scala
@@ -30,7 +30,7 @@ object HttpClientIR extends LogSupport {
   // Intermediate representation (IR) of HTTP client code
   sealed trait ClientCodeIR
   case class ClientSourceDef(packageName: String, classDef: ClientClassDef) extends ClientCodeIR {
-    def imports: Seq[Surface] = {
+    private def imports: Seq[Surface] = {
       // Collect all Surfaces used in the generated code
       def loop(s: Any): Seq[Surface] = {
         s match {
@@ -41,24 +41,34 @@ object HttpClientIR extends LogSupport {
           case c: ClientClassDef   => c.services.flatMap(loop)
           case x: ClientServiceDef => x.methods.flatMap(loop)
           case m: ClientMethodDef =>
-            loop(m.returnType) ++ m.inputParameters.flatMap(loop)
+            loop(m.returnType) ++ m.typeArgs.flatMap(loop) ++ m.inputParameters.flatMap(loop)
           case _ =>
             Seq.empty
         }
       }
 
       def requireImports(surface: Surface): Boolean = {
-        val fullName = surface.fullName
+        val fullName          = surface.fullName
+        val importPackageName = resolveObjectName(fullName).split("\\.").dropRight(1).mkString(".")
         // Primitive Scala collections can be found in scala.Predef. No need to include them
-        !(surface.rawType.getPackageName == "scala.collection" ||
-          fullName.startsWith("wvlet.airframe.http.") ||
+        !(importPackageName == "scala.collection" ||
+          importPackageName == "wvlet.airframe.http" ||
           surface.isPrimitive ||
           // Within the same package
-          surface.rawType.getPackageName == packageName)
+          importPackageName == packageName)
       }
 
       loop(classDef).filter(requireImports).distinct.sortBy(_.name)
     }
+
+    private def resolveObjectName(fullName: String): String = {
+      fullName.replaceAll("\\$", ".")
+    }
+
+    def importStatements: String = {
+      imports.map(x => s"import ${resolveObjectName(x.rawType.getName)}").mkString("\n")
+    }
+
   }
   case class ClientClassDef(clsName: String, services: Seq[ClientServiceDef])     extends ClientCodeIR
   case class ClientServiceDef(serviceName: String, methods: Seq[ClientMethodDef]) extends ClientCodeIR
@@ -72,18 +82,8 @@ object HttpClientIR extends LogSupport {
       returnType: Surface,
       path: String
   ) extends ClientCodeIR {
+    def typeArgString = typeArgs.map(_.name).mkString(", ")
 
-    def unwrapFutureFromReturnType: String = {
-      returnType match {
-        case h: HigherKindedTypeSurface =>
-          h.typeArgs.mkString(",")
-        case g: GenericSurface
-            if g.rawType == classOf[scala.concurrent.Future[_]] || g.rawType.getName == "com.twitter.util.Future" =>
-          g.typeArgs.mkString(",")
-        case _ =>
-          returnType.name
-      }
-    }
   }
 
   private case class PathVariableParam(name: String, param: MethodParameter)
@@ -126,7 +126,7 @@ object HttpClientIR extends LogSupport {
         throw new IllegalStateException(s"HttpClient doesn't support multiple object inputs: ${route}")
       }
       httpClientCallInputs.headOption.map { x => typeArgBuilder += x.surface }
-      typeArgBuilder += route.returnTypeSurface
+      typeArgBuilder += unwrapFuture(route.returnTypeSurface)
 
       ClientMethodDef(
         httpMethod = route.method,
@@ -136,7 +136,7 @@ object HttpClientIR extends LogSupport {
         inputParameters = analysis.userInputParameters,
         clientCallParameters = httpClientCallInputs,
         path = analysis.pathString,
-        returnType = route.returnTypeSurface
+        returnType = unwrapFuture(route.returnTypeSurface)
       )
     }
 
@@ -144,6 +144,19 @@ object HttpClientIR extends LogSupport {
       packageName = config.targetPackageName,
       classDef = buildClassDef
     )
+  }
+
+  private def unwrapFuture(s: Surface): Surface = {
+    s match {
+      case h: HigherKindedTypeSurface
+          if h.typeArgs.size == 1 && h.name == "F" => // Only support 'F' for tagless-final pattern
+        h.typeArgs.head
+      case g: GenericSurface
+          if g.rawType == classOf[scala.concurrent.Future[_]] || g.rawType.getName == "com.twitter.util.Future" =>
+        g.typeArgs.head
+      case _ =>
+        s
+    }
   }
 
 }

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/codegen/client/ScalaHttpClient.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/codegen/client/ScalaHttpClient.scala
@@ -80,8 +80,8 @@ object AsyncClient extends HttpClientType {
           sendRequestArgs ++= m.clientCallParameters.map(x => s"${x.name}")
           sendRequestArgs += "requestFilter = requestFilter"
 
-          s"""def ${m.name}(${inputArgs.mkString(", ")}): F[${m.resolveLeafReturnTypeName}] = {
-             |  client.${httpClientMethodName}[${m.typeArgs.map(_.name).mkString(", ")}](${sendRequestArgs.result
+          s"""def ${m.name}(${inputArgs.mkString(", ")}): F[${m.unwrapFutureFromReturnType}] = {
+             |  client.${httpClientMethodName}[${m.unwrapFutureFromReturnType}](${sendRequestArgs.result
                .mkString(", ")})
              |}""".stripMargin
         }.mkString("\n")

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/codegen/client/ScalaHttpClient.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/codegen/client/ScalaHttpClient.scala
@@ -80,7 +80,7 @@ object AsyncClient extends HttpClientType {
           sendRequestArgs ++= m.clientCallParameters.map(x => s"${x.name}")
           sendRequestArgs += "requestFilter = requestFilter"
 
-          s"""def ${m.name}(${inputArgs.mkString(", ")}): F[${m.returnType.name}] = {
+          s"""def ${m.name}(${inputArgs.mkString(", ")}): F[${m.resolveLeafReturnTypeName}] = {
              |  client.${httpClientMethodName}[${m.typeArgs.map(_.name).mkString(", ")}](${sendRequestArgs.result
                .mkString(", ")})
              |}""".stripMargin

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/codegen/client/ScalaHttpClient.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/codegen/client/ScalaHttpClient.scala
@@ -42,12 +42,14 @@ object AsyncClient extends HttpClientType {
   override def defaultFileName: String  = "ServiceClient.scala"
   override def defaultClassName: String = "ServiceClient"
   override def generate(src: ClientSourceDef): String = {
-    def code = s"""${header(src.packageName)}
+    def code =
+      s"""${header(src.packageName)}
          |
          |import wvlet.airframe.http._
-         |${src.imports.map(x => s"import ${x.rawType.getName}").mkString("\n")}
+         |${src.importStatements}
          |
-         |${cls}""".stripMargin
+         |${cls}"""
+      /**EndMarker*/ .stripMargin.stripMargin
 
     def cls: String =
       s"""class ${src.classDef.clsName}[F[_], Req, Resp](private val client: HttpClient[F, Req, Resp]) extends AutoCloseable {
@@ -80,8 +82,8 @@ object AsyncClient extends HttpClientType {
           sendRequestArgs ++= m.clientCallParameters.map(x => s"${x.name}")
           sendRequestArgs += "requestFilter = requestFilter"
 
-          s"""def ${m.name}(${inputArgs.mkString(", ")}): F[${m.unwrapFutureFromReturnType}] = {
-             |  client.${httpClientMethodName}[${m.unwrapFutureFromReturnType}](${sendRequestArgs.result
+          s"""def ${m.name}(${inputArgs.mkString(", ")}): F[${m.returnType}] = {
+             |  client.${httpClientMethodName}[${m.typeArgString}](${sendRequestArgs.result
                .mkString(", ")})
              |}""".stripMargin
         }.mkString("\n")
@@ -100,7 +102,7 @@ object SyncClient extends HttpClientType {
       s"""${header(src.packageName)}
          |
          |import wvlet.airframe.http._
-         |${src.imports.map(x => s"import ${x.rawType.getName}").mkString("\n")}
+         |${src.importStatements}
          |
          |${cls}""".stripMargin
 
@@ -136,7 +138,7 @@ object SyncClient extends HttpClientType {
           sendRequestArgs += "requestFilter = requestFilter"
 
           s"""def ${m.name}(${inputArgs.mkString(", ")}): ${m.returnType.name} = {
-             |  client.${httpClientMethodName}[${m.typeArgs.map(_.name).mkString(", ")}](${sendRequestArgs.result
+             |  client.${httpClientMethodName}[${m.typeArgString}](${sendRequestArgs.result
                .mkString(", ")})
              |}""".stripMargin
         }.mkString("\n")
@@ -162,7 +164,7 @@ object ScalaJSClient extends HttpClientType {
          |import wvlet.airframe.surface.Surface
          |import wvlet.airframe.http.js.JSHttpClient
          |import wvlet.airframe.http.HttpMessage.Request
-         |${src.imports.map(x => s"import ${x.rawType.getName}").mkString("\n")}
+         |${src.importStatements}
          |
          |${cls}""".stripMargin
 
@@ -200,8 +202,8 @@ object ScalaJSClient extends HttpClientType {
           sendRequestArgs ++= m.typeArgs.map(s => s"Surface.of[${s.name}]")
           sendRequestArgs += "requestFilter = requestFilter"
 
-          s"""def ${m.name}(${inputArgs.mkString(", ")}): Future[${m.returnType.name}] = {
-             |  client.${httpClientMethodName}[${m.typeArgs.map(_.name).mkString(", ")}](${sendRequestArgs.result
+          s"""def ${m.name}(${inputArgs.mkString(", ")}): Future[${m.returnType}] = {
+             |  client.${httpClientMethodName}[${m.typeArgString}](${sendRequestArgs.result
                .mkString(", ")})
              |}""".stripMargin
         }.mkString("\n")

--- a/airframe-http/.jvm/src/test/scala/example/api/MyService.scala
+++ b/airframe-http/.jvm/src/test/scala/example/api/MyService.scala
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package example
+package example.api
 
 /**
   *

--- a/airframe-http/.jvm/src/test/scala/example/generic/GenericService.scala
+++ b/airframe-http/.jvm/src/test/scala/example/generic/GenericService.scala
@@ -13,6 +13,7 @@
  */
 package example.generic
 import wvlet.airframe.http.Endpoint
+import wvlet.airframe.http.HttpMessage.Response
 
 import scala.concurrent.Future
 import scala.language.higherKinds
@@ -26,4 +27,11 @@ trait GenericService[F[_]] {
 
   @Endpoint(path = "/v1/hello_f")
   def concreteFuture: Future[Int]
+
+  @Endpoint(path = "/v1/hello_ops")
+  def ops(in: String): Future[Response]
+
+  @Endpoint(path = "/v1/hello_ops2")
+  def ops2(in: String): F[Response]
+
 }

--- a/airframe-http/.jvm/src/test/scala/example/generic/GenericService.scala
+++ b/airframe-http/.jvm/src/test/scala/example/generic/GenericService.scala
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.generic
+import wvlet.airframe.http.Endpoint
+
+import scala.concurrent.Future
+import scala.language.higherKinds
+
+/**
+  *
+  */
+trait GenericService[F[_]] {
+  @Endpoint(path = "/v1/hello")
+  def hello: F[String]
+
+  @Endpoint(path = "/v1/hello_f")
+  def concreteFuture: Future[Int]
+}

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/codegen/GenericServiceTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/codegen/GenericServiceTest.scala
@@ -24,12 +24,33 @@ class GenericServiceTest extends AirSpec {
 
   private val router = RouteScanner.buildRouter(Seq(classOf[GenericService[Future]]))
 
-  test("support F and Future return values") {
+  test("support F and Future return values in async clients") {
     debug(router)
 
     val code = HttpClientGenerator.generate(router, HttpClientGeneratorConfig("example.generic:async"))
     code.contains(": F[String]") shouldBe true
     code.contains(": F[Int]") shouldBe true
+    code.contains("import wvlet.airframe.http.HttpMessage.Response")
   }
 
+  test("support F and Future return values in sync clients") {
+    debug(router)
+
+    val code = HttpClientGenerator.generate(router, HttpClientGeneratorConfig("example.generic:sync"))
+    code.contains(": String = {") shouldBe true
+    code.contains(": Int = {") shouldBe true
+    code.contains("import wvlet.airframe.http.HttpMessage.Response")
+  }
+
+  test("support F and Future return values in Scala.js clients") {
+    debug(router)
+
+    val code = HttpClientGenerator.generate(router, HttpClientGeneratorConfig("example.generic:scalajs"))
+    code.contains(": Future[String] = {") shouldBe true
+    code.contains("Surface.of[String]") shouldBe true
+    code.contains(": Future[Int] = {") shouldBe true
+    code.contains("Surface.of[Int]") shouldBe true
+    code.contains("import wvlet.airframe.http.HttpMessage.Response")
+    code.contains("import wvlet.airframe.http.HttpMessage.Request")
+  }
 }

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/codegen/GenericServiceTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/codegen/GenericServiceTest.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.http.codegen
+import example.generic.GenericService
+import wvlet.airspec.AirSpec
+
+import scala.concurrent.Future
+
+/**
+  *
+  */
+class GenericServiceTest extends AirSpec {
+
+  private val router = RouteScanner.buildRouter(Seq(classOf[GenericService[Future]]))
+
+  test("support F and Future return values") {
+    debug(router)
+
+    val code = HttpClientGenerator.generate(router, HttpClientGeneratorConfig("example.generic:async"))
+    code.contains(": F[String]") shouldBe true
+    code.contains(": F[Int]") shouldBe true
+  }
+
+}

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/codegen/HttpClientGeneratorTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/codegen/HttpClientGeneratorTest.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.http.codegen
 import wvlet.airspec.AirSpec
-import example._
+import example.api._
 import wvlet.airframe.http._
 import java.net.URLClassLoader
 
@@ -42,7 +42,7 @@ class HttpClientGeneratorTest extends AirSpec {
       HttpClientGeneratorConfig("example.api:async:example.api.client")
     )
     code.contains("package example.api.client") shouldBe true
-    code.contains("import example.Query") shouldBe true
+    code.contains("import example.api.Query") shouldBe true
     code.contains("class ServiceClient[F[_], Req, Resp]")
   }
 

--- a/airframe-surface/jvm/src/main/scala/wvlet/airframe/surface/reflect/ReflectSurfaceFactory.scala
+++ b/airframe-surface/jvm/src/main/scala/wvlet/airframe/surface/reflect/ReflectSurfaceFactory.scala
@@ -360,7 +360,7 @@ object ReflectSurfaceFactory extends LogSupport {
         HigherKindedTypeSurface(name, fullName, inner, inner.typeArgs)
       case t @ TypeRef(NoPrefix, tpe, List()) if tpe.name.decodedName.toString.contains("$") =>
         wvlet.airframe.surface.ExistentialType
-      case t @ TypeRef(NoPrefix, tpe, args) =>
+      case t @ TypeRef(NoPrefix, tpe, args) if !t.typeSymbol.isClass =>
         val name = tpe.name.decodedName.toString
         HigherKindedTypeSurface(name, name, surfaceOf(t.erasure), args.map(ta => surfaceOf(ta)))
     }

--- a/airframe-surface/jvm/src/main/scala/wvlet/airframe/surface/reflect/ReflectSurfaceFactory.scala
+++ b/airframe-surface/jvm/src/main/scala/wvlet/airframe/surface/reflect/ReflectSurfaceFactory.scala
@@ -301,6 +301,7 @@ object ReflectSurfaceFactory extends LogSupport {
           // Cache if not yet cached
           surfaceCache.getOrElseUpdate(fullName, surface)
           typeMap.getOrElseUpdate(surface, tpe)
+          //info(s"${tpe}, ${surface}, ${showRaw(tpe)}")
           surface
         }
       } catch {
@@ -356,7 +357,12 @@ object ReflectSurfaceFactory extends LogSupport {
         val inner    = surfaceOf(t.erasure)
         val name     = symbol.asType.name.decodedName.toString
         val fullName = s"${prefix.typeSymbol.fullName}.${name}"
-        HigherKindedTypeSurface(name, fullName, inner)
+        HigherKindedTypeSurface(name, fullName, inner, inner.typeArgs)
+      case t @ TypeRef(NoPrefix, tpe, List()) if tpe.name.decodedName.toString.contains("$") =>
+        wvlet.airframe.surface.ExistentialType
+      case t @ TypeRef(NoPrefix, tpe, args) =>
+        val name = tpe.name.decodedName.toString
+        HigherKindedTypeSurface(name, name, surfaceOf(t.erasure), args.map(ta => surfaceOf(ta)))
     }
 
     private def taggedTypeFactory: SurfaceMatcher = {

--- a/airframe-surface/jvm/src/test/scala/wvlet/airframe/surface/reflect/NamedParameterTest.scala
+++ b/airframe-surface/jvm/src/test/scala/wvlet/airframe/surface/reflect/NamedParameterTest.scala
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.surface.reflect
+import wvlet.airspec.AirSpec
+
+import scala.concurrent.Future
+import scala.language.higherKinds
+
+/**
+  *
+  */
+object NamedParameterTest extends AirSpec {
+
+  trait MyService[F[_]] {
+    def hello: F[String]
+  }
+
+  test("read F[_]") {
+    val cl = classOf[MyService[Future]]
+    val s  = ReflectSurfaceFactory.ofClass(cl)
+    s.toString shouldBe "MyService[F]"
+
+    val m = ReflectSurfaceFactory.methodsOfClass(cl)
+    m.headOption shouldBe defined
+
+    val m1 = m.head
+    m1.returnType.toString shouldBe "F[String]"
+  }
+}

--- a/airframe-surface/shared/src/main/scala/wvlet/airframe/surface/SurfaceMacros.scala
+++ b/airframe-surface/shared/src/main/scala/wvlet/airframe/surface/SurfaceMacros.scala
@@ -17,7 +17,9 @@ import scala.language.experimental.macros
 import scala.reflect.macros.{blackbox => sm}
 
 /**
+  * Surface genration Macros for Scala.js.
   *
+  * This code needs to be almost the same with ReflectSurfaceFactory
   */
 private[surface] object SurfaceMacros {
   def surfaceOf[A: c.WeakTypeTag](c: sm.Context): c.Tree = {
@@ -229,6 +231,13 @@ private[surface] object SurfaceMacros {
         val fullName = s"${prefix.typeSymbol.fullName}.${name}"
         val inner    = surfaceOf(t.erasure)
         q"wvlet.airframe.surface.HigherKindedTypeSurface(${name}, ${fullName}, ${inner})"
+      case t @ TypeRef(NoPrefix, tpe, List()) if tpe.name.decodedName.toString.contains("$") =>
+        q"wvlet.airframe.surface.ExistentialType"
+      case t @ TypeRef(NoPrefix, tpe, args) =>
+        val name     = tpe.name.decodedName.toString
+        val inner    = surfaceOf(t.erasure)
+        val typeArgs = args.map(ta => surfaceOf(ta))
+        q"wvlet.airframe.surface.HigherKindedTypeSurface(${name}, ${name}, ${inner}, Seq(..${typeArgs}))"
     }
 
     private val primitiveFactory: SurfaceFactory = {

--- a/airframe-surface/shared/src/main/scala/wvlet/airframe/surface/SurfaceMacros.scala
+++ b/airframe-surface/shared/src/main/scala/wvlet/airframe/surface/SurfaceMacros.scala
@@ -233,11 +233,12 @@ private[surface] object SurfaceMacros {
         q"wvlet.airframe.surface.HigherKindedTypeSurface(${name}, ${fullName}, ${inner}, Seq.empty)"
       case t @ TypeRef(NoPrefix, tpe, List()) if tpe.name.decodedName.toString.contains("$") =>
         q"wvlet.airframe.surface.ExistentialType"
-      case t @ TypeRef(NoPrefix, tpe, args) =>
+      case t @ TypeRef(NoPrefix, tpe, args) if !t.typeSymbol.isClass =>
+        val fullName = tpe.fullName
         val name     = tpe.name.decodedName.toString
         val inner    = surfaceOf(t.erasure)
         val typeArgs = args.map(ta => surfaceOf(ta))
-        q"wvlet.airframe.surface.HigherKindedTypeSurface(${name}, ${name}, ${inner}, Seq(..${typeArgs}))"
+        q"wvlet.airframe.surface.HigherKindedTypeSurface(${name}, ${fullName}, ${inner}, Seq(..${typeArgs}))"
     }
 
     private val primitiveFactory: SurfaceFactory = {

--- a/airframe-surface/shared/src/main/scala/wvlet/airframe/surface/SurfaceMacros.scala
+++ b/airframe-surface/shared/src/main/scala/wvlet/airframe/surface/SurfaceMacros.scala
@@ -230,7 +230,7 @@ private[surface] object SurfaceMacros {
         val name     = symbol.asType.name.decodedName.toString
         val fullName = s"${prefix.typeSymbol.fullName}.${name}"
         val inner    = surfaceOf(t.erasure)
-        q"wvlet.airframe.surface.HigherKindedTypeSurface(${name}, ${fullName}, ${inner})"
+        q"wvlet.airframe.surface.HigherKindedTypeSurface(${name}, ${fullName}, ${inner}, Seq.empty)"
       case t @ TypeRef(NoPrefix, tpe, List()) if tpe.name.decodedName.toString.contains("$") =>
         q"wvlet.airframe.surface.ExistentialType"
       case t @ TypeRef(NoPrefix, tpe, args) =>

--- a/airframe-surface/shared/src/main/scala/wvlet/airframe/surface/Surfaces.scala
+++ b/airframe-surface/shared/src/main/scala/wvlet/airframe/surface/Surfaces.scala
@@ -120,6 +120,13 @@ case class HigherKindedTypeSurface(
     ref: Surface,
     override val typeArgs: Seq[Surface]
 ) extends GenericSurface(ref.rawType, typeArgs, ref.params, ref.objectFactory) {
+  override def toString: String = {
+    if (typeArgs.isEmpty) {
+      name
+    } else {
+      s"${name}[${typeArgs.mkString(",")}]"
+    }
+  }
   override def isAlias: Boolean     = false
   override def isPrimitive: Boolean = ref.isPrimitive
   override def isOption: Boolean    = ref.isOption

--- a/airframe-surface/shared/src/main/scala/wvlet/airframe/surface/Surfaces.scala
+++ b/airframe-surface/shared/src/main/scala/wvlet/airframe/surface/Surfaces.scala
@@ -114,8 +114,12 @@ case class Alias(override val name: String, override val fullName: String, ref: 
   override def dealias: Surface     = ref.dealias
 }
 
-case class HigherKindedTypeSurface(override val name: String, override val fullName: String, ref: Surface)
-    extends GenericSurface(ref.rawType, ref.typeArgs, ref.params, ref.objectFactory) {
+case class HigherKindedTypeSurface(
+    override val name: String,
+    override val fullName: String,
+    ref: Surface,
+    override val typeArgs: Seq[Surface]
+) extends GenericSurface(ref.rawType, typeArgs, ref.params, ref.objectFactory) {
   override def isAlias: Boolean     = false
   override def isPrimitive: Boolean = ref.isPrimitive
   override def isOption: Boolean    = ref.isOption

--- a/airframe-surface/shared/src/test/scala/wvlet/airframe/surface/RecursiveHigherKindTypeTest.scala
+++ b/airframe-surface/shared/src/test/scala/wvlet/airframe/surface/RecursiveHigherKindTypeTest.scala
@@ -41,6 +41,6 @@ class RecursiveHigherKindTypeTest extends SurfaceSpec {
   def `support recursive higher kind types`: Unit = {
     val s = Surface.of[Holder[BySkinny]]
     s.name shouldBe "Holder[BySkinny]"
-    s.typeArgs(0).dealias.name shouldBe "MyTask[_]"
+    s.typeArgs(0).dealias.name shouldBe "MyTask[A]"
   }
 }

--- a/airframe-surface/shared/src/test/scala/wvlet/airframe/surface/SurfaceSpec.scala
+++ b/airframe-surface/shared/src/test/scala/wvlet/airframe/surface/SurfaceSpec.scala
@@ -23,7 +23,7 @@ trait SurfaceSpec extends AirSpec with LogSupport {
   protected def check(body: => Surface, expectedName: String): Surface = {
     val surface = body
     debug(s"[${surface.getClass.getSimpleName}] $surface, ${surface.fullName}")
-    assert(surface.toString == expectedName)
+    surface.toString shouldBe expectedName
     surface
   }
 

--- a/airframe-surface/shared/src/test/scala/wvlet/airframe/surface/SurfaceTest.scala
+++ b/airframe-surface/shared/src/test/scala/wvlet/airframe/surface/SurfaceTest.scala
@@ -174,7 +174,7 @@ class SurfaceTest extends SurfaceSpec {
   def `resolve generic type`: Unit = {
     val d1 = check(Surface.of[D[String]], "D[String]")
     val d2 = check(Surface.of[D[A]], "D[A]")
-    assert(d1 ne d2)
+    d1 shouldNotBeTheSameInstanceAs d2
   }
 
   def `resolve recursive type`: Unit = {

--- a/airframe/src/test/scala/wvlet/airframe/BindLocalTest.scala
+++ b/airframe/src/test/scala/wvlet/airframe/BindLocalTest.scala
@@ -53,6 +53,7 @@ class BindLocalTest extends AirSpec {
     }
 
     val d = newSilentDesign.bind[Y].toSingleton
+    // test 2
     d.build[App2] { a => a.y0 shouldNotBeTheSameInstanceAs a.yLocal }
   }
 

--- a/sbt-airframe/src/test/scala/example/MyService.scala
+++ b/sbt-airframe/src/test/scala/example/MyService.scala
@@ -28,16 +28,16 @@ case class DeleteResourceRequest(id: String)
   */
 trait ResourceApi {
   @Endpoint(method = HttpMethod.GET, path = "/v1/resources/:id")
-  def getResource(getRequest: GetResourceRequest): ResourceResponse
+  def getResource(getRequest: GetResourceRequest): api.ResourceResponse
 
   @Endpoint(method = HttpMethod.POST, path = "/v1/resources")
-  def addResource(createResourceRequest: CreateResourceRequest): ResourceResponse
+  def addResource(createResourceRequest: CreateResourceRequest): api.ResourceResponse
 
   @Endpoint(method = HttpMethod.DELETE, path = "/v1/resources/:id")
   def deleteResource(deleteResourceRequest: DeleteResourceRequest, request: SimpleHttpRequest): Unit
 
   @Endpoint(method = HttpMethod.GET, path = "/v1/resources")
-  def listResources(context: HttpContext[SimpleHttpRequest, SimpleHttpResponse, Future]): Seq[ResourceResponse] = {
+  def listResources(context: HttpContext[SimpleHttpRequest, SimpleHttpResponse, Future]): Seq[api.ResourceResponse] = {
     // Non abstract method example
     Seq.empty
   }
@@ -52,11 +52,11 @@ trait QueryApi {
   def listQueries: Seq[Query]
 
   @Endpoint(method = HttpMethod.GET, path = "/v1/query/:id")
-  def getQueryById(id: Int): QueryResultResponse
+  def getQueryById(id: Int): api.QueryResultResponse
 
   @Endpoint(method = HttpMethod.GET, path = "/v1/query/:id/page/:page")
-  def getQueryPage(id: Int, page: Int): QueryResultResponse
+  def getQueryPage(id: Int, page: Int): api.QueryResultResponse
 
   @Endpoint(method = HttpMethod.POST, path = "/v1/query")
-  def newQuery(createQueryRequest: CreateQueryRequest): QueryResultResponse
+  def newQuery(createQueryRequest: CreateQueryRequest): api.QueryResultResponse
 }

--- a/sbt-airframe/src/test/scala/example/MyService.scala
+++ b/sbt-airframe/src/test/scala/example/MyService.scala
@@ -28,16 +28,16 @@ case class DeleteResourceRequest(id: String)
   */
 trait ResourceApi {
   @Endpoint(method = HttpMethod.GET, path = "/v1/resources/:id")
-  def getResource(getRequest: GetResourceRequest): api.ResourceResponse
+  def getResource(getRequest: GetResourceRequest): ResourceResponse
 
   @Endpoint(method = HttpMethod.POST, path = "/v1/resources")
-  def addResource(createResourceRequest: CreateResourceRequest): api.ResourceResponse
+  def addResource(createResourceRequest: CreateResourceRequest): ResourceResponse
 
   @Endpoint(method = HttpMethod.DELETE, path = "/v1/resources/:id")
   def deleteResource(deleteResourceRequest: DeleteResourceRequest, request: SimpleHttpRequest): Unit
 
   @Endpoint(method = HttpMethod.GET, path = "/v1/resources")
-  def listResources(context: HttpContext[SimpleHttpRequest, SimpleHttpResponse, Future]): Seq[api.ResourceResponse] = {
+  def listResources(context: HttpContext[SimpleHttpRequest, SimpleHttpResponse, Future]): Seq[ResourceResponse] = {
     // Non abstract method example
     Seq.empty
   }
@@ -52,11 +52,11 @@ trait QueryApi {
   def listQueries: Seq[Query]
 
   @Endpoint(method = HttpMethod.GET, path = "/v1/query/:id")
-  def getQueryById(id: Int): api.QueryResultResponse
+  def getQueryById(id: Int): QueryResultResponse
 
   @Endpoint(method = HttpMethod.GET, path = "/v1/query/:id/page/:page")
-  def getQueryPage(id: Int, page: Int): api.QueryResultResponse
+  def getQueryPage(id: Int, page: Int): QueryResultResponse
 
   @Endpoint(method = HttpMethod.POST, path = "/v1/query")
-  def newQuery(createQueryRequest: CreateQueryRequest): api.QueryResultResponse
+  def newQuery(createQueryRequest: CreateQueryRequest): QueryResultResponse
 }


### PR DESCRIPTION
This resolves #999 

- airframe-surface: support named parameters like F[_] named