### PR TITLE
airframe-okhttp: Fix for Scala 2.11 and release process in build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -152,6 +152,7 @@ lazy val jvmProjects: Seq[ProjectReference] = communityBuildProjects ++ Seq[Proj
   fluentd,
   airspecLight,
   finagle,
+  okhttp,
   httpRecorder
 )
 


### PR DESCRIPTION
I tried to upgrade Airframe version in td-scala-util and found airframe-http-okhttp was not available in Maven. So I tried to publish this module individually, and found this Scala 2.11 incompatibility issue. 