### PR TITLE
Fix port in jdbcUrl

### DIFF
--- a/airframe-jdbc/src/main/scala/wvlet/airframe/jdbc/DbConfig.scala
+++ b/airframe-jdbc/src/main/scala/wvlet/airframe/jdbc/DbConfig.scala
@@ -43,7 +43,7 @@ case class DbConfig(
       case "sqlite" =>
         s"jdbc:sqlite:${database}"
       case _ =>
-        s"jdbc:${`type`}://${host.getOrElse("localhost")}${port.map(p => s":${port}").getOrElse("")}/${database}"
+        s"jdbc:${`type`}://${host.getOrElse("localhost")}${port.map(p => s":${p}").getOrElse("")}/${database}"
     }
   }
 

--- a/airframe-jdbc/src/test/scala/wvlet/airframe/jdbc/DbConfigTest.scala
+++ b/airframe-jdbc/src/test/scala/wvlet/airframe/jdbc/DbConfigTest.scala
@@ -74,7 +74,7 @@ class DbConfigTest extends AirSpec {
 
     presto.jdbcPort shouldBe 8080
     presto.jdbcDriverName shouldBe "io.prestosql.jdbc.Driver"
-    presto.jdbcUrl
+    presto.jdbcUrl shouldBe "jdbc:presto://localhost:8080/public"
 
     val mysql = c
       .withType("mysql")


### PR DESCRIPTION
The current `DBConfig` generates invalid jdbcUrl if the port number is specified, like `jdbc:presto://localhost:Some(8080)/public`.