### PR TITLE
sbt-airframe: Fixes #1034

### DIFF
--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/codegen/HttpClientGenerator.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/codegen/HttpClientGenerator.scala
@@ -98,7 +98,7 @@ class HttpClientGenerator(
 ) extends LogSupport {
   Logger.init
 
-  logLevel.foreach { x => Logger.setDefaultLogLevel(x) }
+  logLevel.foreach { x => Logger("wvlet.airframe.http").setLogLevel(x) }
 
   @command(isDefault = true)
   def default = {

--- a/airframe-http/.jvm/src/test/scala/example/rpc/RPCTestService.scala
+++ b/airframe-http/.jvm/src/test/scala/example/rpc/RPCTestService.scala
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.rpc
+import wvlet.airframe.http.RPC
+
+/**
+  *
+  */
+@RPC
+trait RPCTestService {
+  import RPCTestService._
+  def addUser(request: CreateUserRequest): User
+}
+
+object RPCTestService {
+  case class CreateUserRequest(id: String, name: String)
+  case class User(id: String, name: String)
+}

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/codegen/RPCClientGeneratorTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/codegen/RPCClientGeneratorTest.scala
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.http.codegen
+import example.rpc.RPCTestService
+import wvlet.airspec.AirSpec
+
+/**
+  *
+  */
+class RPCClientGeneratorTest extends AirSpec {
+  test("avoid duplicate route entries") {
+    val router = RouteScanner.buildRouter(Array(classOf[RPCTestService]))
+    val r      = router.toString
+    r.contains("/example.rpc.RPCTestService/addUser") shouldBe true
+    r.contains("addUser(request:CreateUserRequest): User") shouldBe true
+  }
+}

--- a/airframe-surface/jvm/src/main/scala/wvlet/airframe/surface/reflect/ReflectSurfaceFactory.scala
+++ b/airframe-surface/jvm/src/main/scala/wvlet/airframe/surface/reflect/ReflectSurfaceFactory.scala
@@ -143,7 +143,6 @@ object ReflectSurfaceFactory extends LogSupport {
 
   def methodsOfType(tpe: ru.Type, cls: Option[Class[_]] = None): Seq[MethodSurface] = {
     val name = fullTypeNameOf(tpe)
-    info(s"name: ${name}, ${tpe}")
     methodSurfaceCache.getOrElseUpdate(name, {
       new SurfaceFinder().createMethodSurfaceOf(tpe, cls)
     })

--- a/airframe-surface/jvm/src/main/scala/wvlet/airframe/surface/reflect/ReflectSurfaceFactory.scala
+++ b/airframe-surface/jvm/src/main/scala/wvlet/airframe/surface/reflect/ReflectSurfaceFactory.scala
@@ -110,7 +110,7 @@ object ReflectSurfaceFactory extends LogSupport {
     typeNameOf(t).startsWith("wvlet.airframe.surface.tag.")
   }
 
-  private def fullTypeNameOf(tpe: ru.Type): TypeName = {
+  private[reflect] def fullTypeNameOf(tpe: ru.Type): TypeName = {
     tpe match {
       case t if t.typeArgs.length == 2 && isTaggedType(t) =>
         s"${fullTypeNameOf(t.typeArgs(0))}@@${fullTypeNameOf(t.typeArgs(1))}"
@@ -142,7 +142,9 @@ object ReflectSurfaceFactory extends LogSupport {
   def methodsOf[A: ru.WeakTypeTag]: Seq[MethodSurface] = methodsOfType(implicitly[ru.WeakTypeTag[A]].tpe)
 
   def methodsOfType(tpe: ru.Type, cls: Option[Class[_]] = None): Seq[MethodSurface] = {
-    methodSurfaceCache.getOrElseUpdate(fullTypeNameOf(tpe), {
+    val name = fullTypeNameOf(tpe)
+    info(s"name: ${name}, ${tpe}")
+    methodSurfaceCache.getOrElseUpdate(name, {
       new SurfaceFinder().createMethodSurfaceOf(tpe, cls)
     })
   }

--- a/airframe-surface/jvm/src/main/scala/wvlet/airframe/surface/reflect/package.scala
+++ b/airframe-surface/jvm/src/main/scala/wvlet/airframe/surface/reflect/package.scala
@@ -56,17 +56,20 @@ package object reflect {
     }
 
     def findAnnotationOf[T <: jl.annotation.Annotation: ClassTag]: Option[T] = {
-      def loop(cl: Class[_]): Seq[Annotation] = {
-        cl match {
-          case null => Seq.empty
-          case other =>
-            cl.getDeclaredAnnotations ++ cl.getInterfaces.flatMap(loop)
-        }
-      }
-
-      val annot = loop(s.rawType)
-      findAnnotation[T](annot)
+      findAnnotationFromClass[T](s.rawType)
     }
+  }
+
+  def findAnnotationFromClass[T <: jl.annotation.Annotation: ClassTag](cls: Class[_]): Option[T] = {
+    def loop(cl: Class[_]): Seq[Annotation] = {
+      cl match {
+        case null => Seq.empty
+        case _ =>
+          cl.getDeclaredAnnotations ++ cl.getInterfaces.flatMap(loop)
+      }
+    }
+    val annot = loop(cls)
+    findAnnotation[T](annot)
   }
 
   implicit class ToRuntimeSurfaceParameter(p: Parameter) {

--- a/sbt-airframe/src/sbt-test/sbt-airframe/generate-client/build.sbt
+++ b/sbt-airframe/src/sbt-test/sbt-airframe/generate-client/build.sbt
@@ -15,7 +15,7 @@ lazy val server =
     .in(file("server"))
     .enablePlugins(AirframeHttpPlugin)
     .settings(
-      airframeHttpGeneratorOption := "-l debug",
+      airframeHttpGeneratorOption := "-l trace",
       airframeHttpClients := Seq(
         "myapp.spi",
         "myapp.spi:sync"

--- a/sbt-airframe/src/sbt-test/sbt-airframe/generate-client/server/src/main/scala/myapp/server/MyServer.scala
+++ b/sbt-airframe/src/sbt-test/sbt-airframe/generate-client/server/src/main/scala/myapp/server/MyServer.scala
@@ -12,7 +12,7 @@ class MyServiceImpl extends myapp.spi.MyService {
 }
 
 class MyRPCImpl extends myapp.spi.MyRPC {
-  override def world: String = "world"
+  override def world() = myapp.spi.MyRPC.World("world")
 }
 
 object MyServer extends LogSupport {
@@ -46,7 +46,7 @@ object MyServer extends LogSupport {
 
       val ret2 = syncClient.myRPC.world()
       info(ret2)
-      assert(ret2 == "world")
+      assert(ret2 == myapp.spi.MyRPC.World("world"))
     }
   }
 }

--- a/sbt-airframe/src/sbt-test/sbt-airframe/generate-client/spi/src/main/scala/myapp/spi/MyRPC.scala
+++ b/sbt-airframe/src/sbt-test/sbt-airframe/generate-client/spi/src/main/scala/myapp/spi/MyRPC.scala
@@ -4,5 +4,11 @@ import wvlet.airframe.http._
 
 @RPC
 trait MyRPC {
-  def world: String
+  import MyRPC._
+
+  def world(): World
+}
+
+object MyRPC {
+  case class World(name: String)
 }


### PR DESCRIPTION
Do not scan classes and their companion objects when building Router