### PR TITLE
Drop Scala.js 0.6.x support

### DIFF
--- a/.github/workflows/release-js.yml
+++ b/.github/workflows/release-js.yml
@@ -24,10 +24,6 @@ jobs:
           path: ~/.cache
           key: ${{ runner.os }}-release-js-${{ hashFiles('**/*.sbt') }}
           restore-keys: ${{ runner.os }}-release-js-
-      - name: Build for Scala.js 0.6.x
-        env:
-          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-        run: SCALAJS_VERSION=0.6.32 ./sbt "; + projectJS/publishSigned"
       - name: Build for Scala.js 1.0.x
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Scala 2.11 test
         run: ./sbt ++2.11.12 projectJVM/test
   test_js:
-    name: Scala.js
+    name: Scala.js / Scala 2.12
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
@@ -89,7 +89,7 @@ jobs:
         # A workaround for Scala.js linker error
         run: ./sbt "; projectJS/test"
   test_js_2_13:
-    name: Scala.js with Scala 2.13
+    name: Scala.js / Scala 2.13
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -8,14 +8,9 @@ addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"            % "0.9.0")
 // For Scala.js
 val SCALAJS_VERSION = sys.env.getOrElse("SCALAJS_VERSION", "1.0.1")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % SCALAJS_VERSION)
-//addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.16.0")
 
 libraryDependencies ++= (
-  if (SCALAJS_VERSION.startsWith("1.0.1")) {
-    Seq("org.scala-js" %% "scalajs-env-jsdom-nodejs" % "1.0.0")
-  } else {
-    Seq.empty
-  }
+  Seq("org.scala-js" %% "scalajs-env-jsdom-nodejs" % "1.0.0")
 )
 
 // For setting explicit versions for each commit


### PR DESCRIPTION
Now that Scala.js 1.0.x is widely available, and we already have migrated our internal projects to Scala.js 1.0.x, we no longer need to support Scala.js 0.6.x for future versions. 

