### PR TITLE
feat(website): add DocSearch as recommended by docusaurus

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -35,6 +35,10 @@ const users = [
 ];
 
 const siteConfig = {
+    algolia: {
+      apiKey: '71b7e81be03c97dcd37b7a0efc8d6b76',
+      indexName: 'airframe'
+    },
     title: 'Airframe', // Title for your website.
     tagline: 'Essential Building Blocks For Scala',
     url: 'https://wvlet.org', // Your website URL


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Docusaurus](https://docusaurus.io/docs/en/search#enabling-the-search-bar). We thought it is a shame you can not also used this search that you can [find on reactjs for example](https://reactjs.org/).

This PR will add DocSearch to the documentation website. It will allow an user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.