### PR TITLE
airframe-http: Evaluate request/response body lazily

### DIFF
--- a/airframe-http-finagle/src/main/scala/wvlet/airframe/http/finagle/package.scala
+++ b/airframe-http-finagle/src/main/scala/wvlet/airframe/http/finagle/package.scala
@@ -110,11 +110,13 @@ package object finagle {
   private def toMessage(buf: Buf): HttpMessage.Message = {
     buf match {
       case b: ByteArray =>
-        HttpMessage.ByteArrayMessage(ByteArray.Owned.extract(b))
+        new HttpMessage.LazyByteArrayMessage(ByteArray.Owned.extract(b))
       case c =>
-        val buf = new Array[Byte](c.length)
-        c.write(buf, 0)
-        HttpMessage.ByteArrayMessage(buf)
+        new HttpMessage.LazyByteArrayMessage({
+          val buf = new Array[Byte](c.length)
+          c.write(buf, 0)
+          buf
+        })
     }
   }
 


### PR DESCRIPTION
Add LazyByteArrayMessage so that we don't need to actually materialize HTTP request/response objects unless necessary. For example, okhttp, finagle response body is unnecessary to materialize to classify its request success or failure. 