### PR TITLE
airframe-http-rx: Fix EntityRef rendering

### DIFF
--- a/airframe-http-rx/.js/src/main/scala/wvlet/airframe/http/rx/html/DOMRenderer.scala
+++ b/airframe-http-rx/.js/src/main/scala/wvlet/airframe/http/rx/html/DOMRenderer.scala
@@ -106,8 +106,20 @@ object DOMRenderer extends LogSupport {
           node.mountHere(textNode, anchor)
           Cancelable.empty
         case EntityRef(entityName) =>
-          val domNode = dom.document.createTextNode("").asInstanceOf[dom.Element]
-          domNode.innerHTML = s"&${entityName};"
+          // Wrap entity ref with a span tag.
+          // This is a workaround if the text is inserted in the middle of text element.
+          val domNode = dom.document.createElement("span");
+          val entity = {
+            var x = entityName.trim
+            if (!x.startsWith("&")) {
+              x = s"&${x}"
+            }
+            if (!x.endsWith(";")) {
+              x = s"${x};"
+            }
+            x
+          }
+          domNode.innerHTML = entity
           node.mountHere(domNode, anchor)
           Cancelable.empty
         case v: Int =>

--- a/airframe-http-rx/.js/src/test/scala/wvlet/airframe/http/rx/html/HtmlRenderingTest.scala
+++ b/airframe-http-rx/.js/src/test/scala/wvlet/airframe/http/rx/html/HtmlRenderingTest.scala
@@ -120,4 +120,9 @@ class HtmlRenderingTest extends AirSpec {
     val d4 = d3(style.noValue)
     render(d4) shouldBe """<div style=""></div>"""
   }
+
+  test("entity ref") {
+    val d = div("1.23", EntityRef("amp"), "0.5")
+    render(d).contains("&amp;") shouldBe true
+  }
 }

--- a/airframe-http-rx/.js/src/test/scala/wvlet/airframe/http/rx/html/HtmlRenderingTest.scala
+++ b/airframe-http-rx/.js/src/test/scala/wvlet/airframe/http/rx/html/HtmlRenderingTest.scala
@@ -15,7 +15,6 @@ package wvlet.airframe.http.rx.html
 
 import org.scalajs.dom
 import wvlet.airframe.http.rx.Rx
-import wvlet.airframe.http.rx.Rx
 import wvlet.airframe.http.rx.html.all._
 import wvlet.airspec._
 


### PR DESCRIPTION
This fixes an issue that entity refs (e.g., "&amp;", "&pm;") become invisible if they are inserted in the middle of text contents.

For example, with this fix, `&plusmn;` EntityRef("plusmn") can be shown properly:
![image](https://user-images.githubusercontent.com/57538/81851310-1acdd800-950e-11ea-84b1-a0be11010174.png)
