### PR TITLE
Fetch all git tags for sbt-dynver

### DIFF
--- a/.github/workflows/release-js.yml
+++ b/.github/workflows/release-js.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      # Fetch all tags so that sbt-dynver can find the previous release version
+      - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - uses: olafurpg/setup-scala@v5
         with:
           java-version: adopt@1.11

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      # Fetch all tags so that sbt-dynver can find the previous release version
+      - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       # Install OpenJDK 11
       - uses: olafurpg/setup-scala@v5
         with:

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      # Fetch all tags so that sbt-dynver can find the previous release version
+      - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - uses: olafurpg/setup-scala@v5
         with:
           java-version: adopt@1.11


### PR DESCRIPTION
actions/checkout@v2 does not pull tags, so sbt-dynver creates weird version numbers like `airframe-control_2.12-0.0.0-1-119ada28-SNAPSHOT.pom` https://github.com/wvlet/airframe/runs/674989481

Ref: https://github.com/actions/checkout#Fetch-all-tags