### PR TITLE
airframe-http: Retry on Finagle's ChannelClosedException

### DIFF
--- a/airframe-http/src/main/scala/wvlet/airframe/http/HttpClientException.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/HttpClientException.scala
@@ -182,7 +182,7 @@ object HttpClientException extends LogSupport {
         case other =>
           nonRetryableFailure(e)
       }
-    // ChannelClosedException of Finagle. Using the string class name so as not to include finagle dependency.
+    // Exceptions from Finagle. Using the string class names so as not to include Finagle dependencies.
     case e: Throwable if finagleRetryableExceptionClasses.contains(e.getClass().getName) =>
       retryableFailure(e)
   }


### PR DESCRIPTION
When a server is not yet ready, FinagleClient will throw ChannelClosedException. This happens, for example, when launching Nginx inside a test suite, and trying to connect it using FinagleClient before Nginx is not yet started inside the container. We can wait until a docker container starts, but waiting the service startup inside the container needs extra wait. 

By adding this retry pattern, we can retry http requests to a docker container until the application inside the container actually starts.

