### PR TITLE
airframe-surface, codec: #1092 Support Enum-like classes in Scala.js

### DIFF
--- a/airframe-codec/.jvm/src/main/scala/wvlet/airframe/codec/Compat.scala
+++ b/airframe-codec/.jvm/src/main/scala/wvlet/airframe/codec/Compat.scala
@@ -15,10 +15,10 @@ package wvlet.airframe.codec
 import java.time.Instant
 import java.util.UUID
 
-import wvlet.airframe.codec.JavaStandardCodec.EnumCodec
+import wvlet.airframe.codec.JavaStandardCodec.JavaEnumCodec
 import wvlet.airframe.metrics.TimeParser
 import wvlet.airframe.surface.reflect.ReflectTypeUtil
-import wvlet.airframe.surface.{EnumSurface, Surface}
+import wvlet.airframe.surface.{JavaEnumSurface, EnumSurface, Surface}
 
 import scala.reflect.runtime.{universe => ru}
 import scala.util.Try
@@ -37,8 +37,8 @@ object Compat {
         factory: MessageCodecFactory,
         seenSet: Set[Surface]
     ): PartialFunction[Surface, MessageCodec[_]] = {
-      case EnumSurface(cl) =>
-        EnumCodec(cl)
+      case JavaEnumSurface(cl) =>
+        JavaEnumCodec(cl)
       case s if ReflectTypeUtil.hasStringUnapplyConstructor(s) =>
         new StringUnapplyCodec(s)
     }

--- a/airframe-codec/.jvm/src/main/scala/wvlet/airframe/codec/JavaStandardCodec.scala
+++ b/airframe-codec/.jvm/src/main/scala/wvlet/airframe/codec/JavaStandardCodec.scala
@@ -38,7 +38,7 @@ object JavaStandardCodec {
     }
   }
 
-  case class EnumCodec[A](enumType: Class[A]) extends MessageCodec[A] with LogSupport {
+  case class JavaEnumCodec[A](enumType: Class[A]) extends MessageCodec[A] with LogSupport {
     private lazy val enumTable: Map[String, A] = {
       // Canonical Enum names -> Enum[A]
       Try {

--- a/airframe-codec/src/main/scala/wvlet/airframe/codec/EnumCodec.scala
+++ b/airframe-codec/src/main/scala/wvlet/airframe/codec/EnumCodec.scala
@@ -13,24 +13,20 @@
  */
 package wvlet.airframe.codec
 import wvlet.airframe.msgpack.spi.{Packer, Unpacker}
-import wvlet.airframe.surface.Surface
-import wvlet.airframe.surface.reflect.TypeConverter
-import wvlet.log.LogSupport
+import wvlet.airframe.surface.EnumSurface
 
 /**
   * A codec for Enum-like case objects that can be instantiated with unapply(String)
   */
-class StringUnapplyCodec[A](codec: Surface) extends MessageCodec[A] with LogSupport {
+class EnumCodec[A](enumSurface: EnumSurface) extends MessageCodec[A] {
   override def pack(p: Packer, v: A): Unit = {
     p.packString(v.toString)
   }
   override def unpack(u: Unpacker, v: MessageContext): Unit = {
     val s = u.unpackString
-    TypeConverter.convert(s, codec.rawType) match {
-      case Some(x) =>
-        v.setObject(x)
-      case None =>
-        v.setNull
+    enumSurface.stringExtractor(enumSurface.rawType, s) match {
+      case Some(x) => v.setObject(x)
+      case None    => v.setNull
     }
   }
 }

--- a/airframe-codec/src/main/scala/wvlet/airframe/codec/MessageCodecFinder.scala
+++ b/airframe-codec/src/main/scala/wvlet/airframe/codec/MessageCodecFinder.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.codec
 import wvlet.airframe.codec.ScalaStandardCodec.{OptionCodec, TupleCodec}
-import wvlet.airframe.surface.{Alias, GenericSurface, Surface}
+import wvlet.airframe.surface.{Alias, EnumSurface, GenericSurface, Surface}
 
 /**
   *
@@ -109,6 +109,8 @@ object MessageCodecFinder {
           factory.ofSurface(g.typeArgs(0), seenSet),
           factory.ofSurface(g.typeArgs(1), seenSet)
         )
+      case es @ EnumSurface(cl, stringExtractor) =>
+        new EnumCodec(es)
     }
   }
 }

--- a/airframe-codec/src/test/scala/wvlet/airframe/codec/EnumCodecTest.scala
+++ b/airframe-codec/src/test/scala/wvlet/airframe/codec/EnumCodecTest.scala
@@ -11,14 +11,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.airframe.surface
+package wvlet.airframe.codec
+import wvlet.airframe.codec.PrimitiveCodec.StringCodec
 import wvlet.airspec.AirSpec
-import wvlet.log.Logger
 
 /**
   *
  */
-object EnumTest extends AirSpec {
+object EnumCodecTest extends AirSpec {
 
   sealed trait Color
   case object Blue extends Color
@@ -31,15 +31,10 @@ object EnumTest extends AirSpec {
     }
   }
 
-  test("Find Surface.stringExtractor") {
-    Surface.of[Color] match {
-      case s: EnumSurface =>
-        val f = s.stringExtractor
-        f(classOf[Color], "Blue") shouldBe Some(Blue)
-        f(classOf[Color], "Red") shouldBe Some(Red)
-        f(classOf[Color], "White") shouldBe empty
-      case _ =>
-        fail("EnumSurface is not found...")
-    }
+  test("read Enum-like classes") {
+    val codec = MessageCodec.of[Color]
+    codec.unpackMsgPack(codec.toMsgPack(Blue)) shouldBe Some(Blue)
+    codec.unpackMsgPack(codec.toMsgPack(Red)) shouldBe Some(Red)
+    codec.unpackMsgPack(StringCodec.toMsgPack("Green")) shouldBe empty
   }
 }

--- a/airframe-codec/src/test/scala/wvlet/airframe/codec/EnumCodecTest.scala
+++ b/airframe-codec/src/test/scala/wvlet/airframe/codec/EnumCodecTest.scala
@@ -37,4 +37,32 @@ object EnumCodecTest extends AirSpec {
     codec.unpackMsgPack(codec.toMsgPack(Red)) shouldBe Some(Red)
     codec.unpackMsgPack(StringCodec.toMsgPack("Green")) shouldBe empty
   }
+
+  test("find unapply(String) from package object methods") {
+    pending("We need to find how to find package object in Scala Macros")
+    import enumtest._
+
+    val codec = MessageCodec.of[Status]
+    info(codec)
+    codec.unpackMsgPack(codec.toMsgPack(Status.SUCCESS)) shouldBe Some(Status.SUCCESS)
+    codec.unpackMsgPack(codec.toMsgPack(Status.FAILURE)) shouldBe Some(Status.FAILURE)
+    codec.unpackMsgPack(StringCodec.toMsgPack("unknown")) shouldBe empty
+  }
+}
+
+package enumtest {
+
+  sealed trait Status
+
+  object Status {
+    def values = Seq(SUCCESS, FAILURE)
+    case object SUCCESS extends Status
+    case object FAILURE extends Status
+  }
+
+  package object enumtest {
+    def unapply(s: String): Option[Status] = {
+      Status.values.find(_.toString == s)
+    }
+  }
 }

--- a/airframe-surface/jvm/src/main/scala/wvlet/airframe/surface/reflect/ReflectSurfaceFactory.scala
+++ b/airframe-surface/jvm/src/main/scala/wvlet/airframe/surface/reflect/ReflectSurfaceFactory.scala
@@ -687,6 +687,4 @@ object ReflectSurfaceFactory extends LogSupport {
       }
     }
   }
-
-  class ReflectEnumSurface(override val rawType: Class[_]) extends GenericSurface(rawType) {}
 }

--- a/airframe-surface/jvm/src/main/scala/wvlet/airframe/surface/reflect/ReflectSurfaceFactory.scala
+++ b/airframe-surface/jvm/src/main/scala/wvlet/airframe/surface/reflect/ReflectSurfaceFactory.scala
@@ -19,7 +19,6 @@ import java.util.concurrent.ConcurrentHashMap
 import wvlet.airframe.surface._
 import wvlet.log.LogSupport
 
-import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 import scala.reflect.runtime.{universe => ru}
 
@@ -555,40 +554,6 @@ object ReflectSurfaceFactory extends LogSupport {
           s
         }
       }
-
-    private def genericSurfaceWithStringUnapplyConstructor: SurfaceMatcher = {
-      new SurfaceMatcher {
-        override def isDefinedAt(x: ru.Type): Boolean = {
-          x.companion match {
-            case companion: Type =>
-              companion.member(TermName("unapply")) match {
-                case s: Symbol if s.isMethod && s.asMethod.paramLists.size == 1 =>
-                  val m    = s.asMethod
-                  val args = m.paramLists.head
-                  args.size == 1 &&
-                  args.head.typeSignature =:= typeOf[String] &&
-                  m.returnType <:< weakTypeOf[Option[_]] &&
-                  m.returnType.typeArgs.size == 1 &&
-                  m.returnType.typeArgs.head =:= x
-                case _ => false
-              }
-            case _ => false
-          }
-        }
-
-        override def apply(t: ru.Type): Surface = {
-          val primaryConstructor = findPrimaryConstructorOf(t).get
-          val typeArgs           = typeArgsOf(t).map(surfaceOf(_)).toIndexedSeq
-          val methodParams       = methodParametersOf(t, primaryConstructor)
-          val s = new RuntimeGenericSurface(
-            resolveClass(t),
-            typeArgs,
-            params = methodParams
-          )
-          s
-        }
-      }
-    }
 
     private def hasStringUnapply(t: ru.Type): Boolean = {
       t.companion match {

--- a/airframe-surface/jvm/src/main/scala/wvlet/airframe/surface/reflect/TypeConverter.scala
+++ b/airframe-surface/jvm/src/main/scala/wvlet/airframe/surface/reflect/TypeConverter.scala
@@ -97,7 +97,7 @@ object TypeConverter extends LogSupport {
         v match {
           case Some(c) => v
           case None =>
-            warn(s"cannot create an instance of $targetType from $value")
+            debug(s"cannot create an instance of $targetType from $value")
             None
         }
       }

--- a/airframe-surface/shared/src/main/scala/wvlet/airframe/surface/Surfaces.scala
+++ b/airframe-surface/shared/src/main/scala/wvlet/airframe/surface/Surfaces.scala
@@ -149,7 +149,11 @@ case class OptionSurface(override val rawType: Class[_], elementSurface: Surface
     extends GenericSurface(rawType, Seq(elementSurface)) {
   override def isOption: Boolean = true
 }
-case class EnumSurface(override val rawType: Class[_]) extends GenericSurface(rawType) {}
+case class JavaEnumSurface(override val rawType: Class[_]) extends GenericSurface(rawType)
+
+case class EnumSurface(override val rawType: Class[_], stringExtractor: (Class[_], String) => Option[Any])
+    extends GenericSurface(rawType)
+
 case class TupleSurface(override val rawType: Class[_], override val typeArgs: Seq[Surface])
     extends GenericSurface(rawType, typeArgs) {}
 

--- a/airframe-surface/shared/src/test/scala/wvlet/airframe/surface/EnumTest.scala
+++ b/airframe-surface/shared/src/test/scala/wvlet/airframe/surface/EnumTest.scala
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.surface
+import wvlet.airspec.AirSpec
+import wvlet.log.Logger
+
+/**
+  *
+ */
+object EnumTest extends AirSpec {
+
+  sealed trait Color
+  case object Blue extends Color
+  case object Red  extends Color
+
+  object Color {
+    def values: Seq[Color] = Seq(Blue, Red)
+    def unapply(s: String): Option[Color] = {
+      values.find(_.toString == s)
+    }
+  }
+
+  test("Find Surface.stringExtractor") {
+    Surface.of[Color] match {
+      case s: EnumSurface =>
+        val f = s.stringExtractor
+        f(classOf[Color], "Blue") shouldBe Some(Blue)
+        f(classOf[Color], "Red") shouldBe Some(Red)
+        f(classOf[Color], "White") shouldBe empty
+      case _ =>
+        fail("EnumSurface is not used")
+    }
+  }
+}


### PR DESCRIPTION
Support enum like classes with Surface and codec. This PR closes #1092

This support will be useful for defining RPC/Endpoint model classes with Enum-like case objects that can be shared between Scala JVM and Scala.js. 

cc: @takezoe @shimamoto 