### PR TITLE
airframe-http: #1100 Support unary and n-ary functions in RPC 

### DIFF
--- a/airframe-codec/src/main/scala/wvlet/airframe/codec/ScalaStandardCodec.scala
+++ b/airframe-codec/src/main/scala/wvlet/airframe/codec/ScalaStandardCodec.scala
@@ -36,7 +36,12 @@ object ScalaStandardCodec {
           v.setObject(None)
         case _ =>
           elementCodec.unpack(u, v)
-          v.setObject(Some(v.getLastValue))
+          Option(v.getLastValue) match {
+            case Some(x) =>
+              v.setObject(Some(x))
+            case None =>
+              v.setNull
+          }
       }
     }
   }

--- a/airframe-codec/src/test/scala/wvlet/airframe/codec/CollectionCodecTest.scala
+++ b/airframe-codec/src/test/scala/wvlet/airframe/codec/CollectionCodecTest.scala
@@ -48,6 +48,12 @@ class CollectionCodecTest extends CodecSpec {
     codec.unpackMsgPack(msgpack) shouldBe Some(Seq(1, 2, 3))
   }
 
+  def `support mapping a single string for Seq[X]` : Unit = {
+    val codec   = MessageCodec.of[Seq[Int]]
+    val msgpack = StringCodec.toMsgPack("1")
+    codec.fromMsgPack(msgpack) shouldBe Seq(1)
+  }
+
   def `support JSON Map`: Unit = {
     val codec   = MessageCodec.of[Map[String, Int]]
     val msgpack = MessagePack.newBufferPacker.packString("""{"leo":1, "yui":2}""").toByteArray

--- a/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/FinagleRouterTest.scala
+++ b/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/FinagleRouterTest.scala
@@ -16,7 +16,7 @@ package wvlet.airframe.http.finagle
 import java.lang.reflect.InvocationTargetException
 
 import com.twitter.concurrent.AsyncStream
-import com.twitter.finagle.http.{Method, Request, Response}
+import com.twitter.finagle.http.{MediaType, Method, Request, Response}
 import com.twitter.io.Buf.ByteArray
 import com.twitter.io.{Buf, Reader}
 import com.twitter.util.{Await, Future}
@@ -341,9 +341,18 @@ class FinagleRouterTest extends AirSpec {
       result.contentString shouldBe "1:xyz"
     }
 
-    def `support missing query parameter mapping for POST`: Unit = {
+    def `support option parameter mapping for POST`: Unit = {
       val r = Request(Method.Post, "/v1/user/1/profile")
       r.contentString = "hello"
+      val result = Await.result(client.send(r))
+      result.statusCode shouldBe HttpStatus.Ok_200.code
+      result.contentString shouldBe "1:hello"
+    }
+
+    def `skip content body mapping for application/octet-stream requests`: Unit = {
+      val r = Request(Method.Post, "/v1/user/1/profile")
+      r.contentString = "hello" // This content should not be used for RPC binding
+      r.contentType = MediaType.OctetStream
       val result = Await.result(client.send(r))
       result.statusCode shouldBe HttpStatus.Ok_200.code
       result.contentString shouldBe "1:unknown"

--- a/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/FinagleRouterTest.scala
+++ b/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/FinagleRouterTest.scala
@@ -126,8 +126,9 @@ trait MyApi extends LogSupport {
   */
 class FinagleRouterTest extends AirSpec {
   protected override def design: Design = {
-    newFinagleServerDesign(router = Router.add[MyApi]).noLifeCycleLogging
-      .bind[FinagleServer].toEagerSingleton
+    Finagle.server
+      .withRouter(Router.add[MyApi])
+      .design
       .bind[FinagleClient].toProvider { server: FinagleServer => Finagle.client.noRetry.newClient(server.localAddress) }
   }
 

--- a/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/HttpAccessLogTest.scala
+++ b/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/HttpAccessLogTest.scala
@@ -19,16 +19,7 @@ import wvlet.airframe.Design
 import wvlet.airframe.codec.MessageCodec
 import wvlet.airframe.http.finagle.filter.HttpAccessLogWriter.JSONHttpAccessLogWriter
 import wvlet.airframe.http.finagle.filter.{HttpAccessLogConfig, HttpAccessLogFilter, HttpAccessLogWriter}
-import wvlet.airframe.http.{
-  Endpoint,
-  Http,
-  HttpContext,
-  HttpMessage,
-  HttpMethod,
-  HttpServerException,
-  HttpStatus,
-  Router
-}
+import wvlet.airframe.http._
 import wvlet.airspec.AirSpec
 import wvlet.log.Logger
 import wvlet.log.io.IOUtil

--- a/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/HttpParamTest.scala
+++ b/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/HttpParamTest.scala
@@ -21,7 +21,7 @@ import wvlet.log.LogSupport
 class HttpParamExample extends LogSupport {
   @Endpoint(path = "/api/get")
   def get(p1: Option[Int]): Option[Int] = {
-    info(p1)
+    debug(p1)
     p1
   }
 }
@@ -32,11 +32,7 @@ class HttpParamExample extends LogSupport {
 class HttpParamTest extends AirSpec {
   protected override def design: Design = {
     val r = Router.add[HttpParamExample]
-    newFinagleServerDesign(router = r)
-      .bind[FinagleSyncClient].toProvider { server: FinagleServer =>
-        Finagle.client.noRetry
-          .newSyncClient(server.localAddress)
-      }
+    Finagle.server.withRouter(r).designWithSyncClient
   }
 
   def `support Option[Int]`(client: FinagleSyncClient): Unit = {

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/codegen/HttpClientIR.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/codegen/HttpClientIR.scala
@@ -21,7 +21,7 @@ import wvlet.airframe.surface.{GenericSurface, HigherKindedTypeSurface, MethodPa
 import wvlet.log.LogSupport
 
 /**
-  * Generate an intermediate represenatation (IR) of Scala HTTP client code from a given airframe-http interface definition (Router).
+  * Generate an intermediate representation (IR) of Scala HTTP client code from a given airframe-http interface definition (Router).
   *
   * This IR abstracts away the differences between Scala (Sync/Async clients) and Scala.js (Async + AJAX).
   */

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/codegen/HttpClientIR.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/codegen/HttpClientIR.scala
@@ -82,7 +82,9 @@ object HttpClientIR extends LogSupport {
       inputParameters: Seq[MethodParameter],
       clientCallParameters: Seq[String],
       returnType: Surface,
-      path: String
+      path: String,
+      // A case class definition for wrapping HTTP request parameters
+      requestModelClassDef: Option[String] = None
   ) extends ClientCodeIR {
     def typeArgString = typeArgs.map(_.name).mkString(", ")
     def clientMethodName = {
@@ -130,35 +132,73 @@ object HttpClientIR extends LogSupport {
 
       def isPrimitive(s: Surface): Boolean = s.isPrimitive || (s.isOption && s.typeArgs.forall(_.isPrimitive))
 
-      val hasPrimitiveInputs =
-        if (httpClientCallInputs.nonEmpty && httpClientCallInputs.forall(x => isPrimitive(x.surface))) {
-          true
-        } else if (httpClientCallInputs.size >= 2) {
-          throw new IllegalStateException(s"HttpClient doesn't support multiple non-primitive object inputs: ${route}")
-        } else {
-          false
-        }
+      val primitiveOnlyInputs =
+        httpClientCallInputs.nonEmpty && httpClientCallInputs.forall(x => isPrimitive(x.surface))
 
-      val clientCallParams = Seq.newBuilder[String]
+      val clientCallParams                     = Seq.newBuilder[String]
+      var requestModelClassDef: Option[String] = None
 
-      if (hasPrimitiveInputs) {
-        // Primitive values (or its Option) cannot be represented in JSON, so we need to wrap them with a map
-        val params = Seq.newBuilder[String]
-        httpClientCallInputs.foreach { x => params += s""""${x.name}" -> ${x.name}""" }
-        clientCallParams += s"Map(${params.result.mkString(", ")})"
-        typeArgBuilder += Surface.of[Map[String, Any]]
-      } else {
-        if (httpClientCallInputs.isEmpty && route.method == HttpMethod.POST) {
+      if (httpClientCallInputs.isEmpty) {
+        if (route.method == HttpMethod.POST) {
           // For RPC calls without any input, embed an empty json
           clientCallParams += "Map.empty"
           typeArgBuilder += Surface.of[Map[String, Any]]
         } else {
-          httpClientCallInputs.headOption.map { x =>
-            clientCallParams += x.name
-            typeArgBuilder += x.surface
+          // Do not add any parameters for empty requests
+        }
+      } else if (httpClientCallInputs.size == 1 && !primitiveOnlyInputs) {
+        // Unary RPC call
+        httpClientCallInputs.headOption.map { x =>
+          clientCallParams += x.name
+          typeArgBuilder += x.surface
+        }
+      } else if (primitiveOnlyInputs) {
+        // Primitive values (or its Option) cannot be represented in JSON, so we need to wrap them with a map
+        val params = Seq.newBuilder[String]
+        httpClientCallInputs.foreach { x =>
+          params += s""""${x.name}" -> ${x.name}"""
+        }
+        clientCallParams += s"Map(${params.result.mkString(", ")})"
+        typeArgBuilder += Surface.of[Map[String, Any]]
+      } else {
+        // For complex request arguments, create a model class to wrap the request parameters
+        val requestModelClassName = s"__${name}_request"
+        // Create Parameter objects for the model class surface
+        val requestModelClassParamSurfaces: Seq[Parameter] = for ((p, i) <- httpClientCallInputs.zipWithIndex) yield {
+          new Parameter {
+            override def index: Int                   = p.index
+            override def name: String                 = p.name
+            override def surface: Surface             = p.surface
+            override def isRequired: Boolean          = p.isRequired
+            override def isSecret: Boolean            = p.isSecret
+            override def get(x: Any): Any             = p.get(x)
+            override def getDefaultValue: Option[Any] = p.getDefaultValue
           }
         }
+        requestModelClassDef = Some(s"private case class ${requestModelClassName}(${requestModelClassParamSurfaces
+          .map { p =>
+            s"${p.name}: ${p.surface.name}"
+          }.mkString(", ")})")
+        clientCallParams += s"${requestModelClassName}(${requestModelClassParamSurfaces
+          .map { p =>
+            s"${p.name} = ${p.name}"
+          }.mkString(", ")})"
+
+        // Create a model class surface for defining http request object parameter
+        val requestModelClassSurface =
+          new Surface {
+            override def rawType: Class[_]      = classOf[Any]
+            override def typeArgs: Seq[Surface] = Seq.empty
+            override def params: Seq[Parameter] = requestModelClassParamSurfaces
+            override def name: String           = requestModelClassName
+            override def fullName: String       = ???
+            override def isOption: Boolean      = false
+            override def isAlias: Boolean       = false
+            override def isPrimitive: Boolean   = false
+          }
+        typeArgBuilder += requestModelClassSurface
       }
+
       typeArgBuilder += unwrapFuture(route.returnTypeSurface)
       val typeArgs = typeArgBuilder.result()
 
@@ -170,7 +210,8 @@ object HttpClientIR extends LogSupport {
         inputParameters = analysis.userInputParameters,
         clientCallParameters = clientCallParams.result(),
         path = analysis.pathString,
-        returnType = unwrapFuture(route.returnTypeSurface)
+        returnType = unwrapFuture(route.returnTypeSurface),
+        requestModelClassDef = requestModelClassDef
       )
     }
 

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/codegen/client/ScalaHttpClient.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/codegen/client/ScalaHttpClient.scala
@@ -79,11 +79,14 @@ object AsyncClient extends HttpClientType {
           sendRequestArgs ++= m.clientCallParameters
           sendRequestArgs += "requestFilter = requestFilter"
 
-          s"""${m.requestModelClassDef.map(x => s"${x}").getOrElse("")}
-             |def ${m.name}(${inputArgs.mkString(", ")}): F[${m.returnType}] = {
-             |  client.${m.clientMethodName}[${m.typeArgString}](${sendRequestArgs.result.mkString(", ")})
-             |}
-             |""".stripMargin
+          val lines = Seq.newBuilder[String]
+          m.requestModelClassDef.foreach { x =>
+            lines += x
+          }
+          lines += s"def ${m.name}(${inputArgs.mkString(", ")}): F[${m.returnType}] = {"
+          lines += s"  client.${m.clientMethodName}[${m.typeArgString}](${sendRequestArgs.result.mkString(", ")})"
+          lines += s"}"
+          lines.result().mkString("\n")
         }.mkString("\n")
     }
 
@@ -132,11 +135,14 @@ object SyncClient extends HttpClientType {
           sendRequestArgs ++= m.clientCallParameters
           sendRequestArgs += "requestFilter = requestFilter"
 
-          s"""${m.requestModelClassDef.map(x => s"${x}").getOrElse("")}
-             |def ${m.name}(${inputArgs.mkString(", ")}): ${m.returnType.name} = {
-             |  client.${m.clientMethodName}[${m.typeArgString}](${sendRequestArgs.result.mkString(", ")})
-             |}
-             |""".stripMargin
+          val lines = Seq.newBuilder[String]
+          m.requestModelClassDef.foreach { x =>
+            lines += x
+          }
+          lines += s"def ${m.name}(${inputArgs.mkString(", ")}): ${m.returnType} = {"
+          lines += s"  client.${m.clientMethodName}[${m.typeArgString}](${sendRequestArgs.result.mkString(", ")})"
+          lines += s"}"
+          lines.result().mkString("\n")
         }.mkString("\n")
     }
 
@@ -195,11 +201,14 @@ object ScalaJSClient extends HttpClientType {
           sendRequestArgs ++= m.typeArgs.map(s => s"Surface.of[${s.name}]")
           sendRequestArgs += "requestFilter = requestFilter"
 
-          s"""${m.requestModelClassDef.map(x => s"${x}").getOrElse("")}
-             |def ${m.name}(${inputArgs.mkString(", ")}): Future[${m.returnType}] = {
-             |  client.${m.clientMethodName}[${m.typeArgString}](${sendRequestArgs.result.mkString(", ")})
-             |}
-             |""".stripMargin
+          val lines = Seq.newBuilder[String]
+          m.requestModelClassDef.foreach { x =>
+            lines += x
+          }
+          lines += s"def ${m.name}(${inputArgs.mkString(", ")}): Future[${m.returnType}] = {"
+          lines += s"  client.${m.clientMethodName}[${m.typeArgString}](${sendRequestArgs.result.mkString(", ")})"
+          lines += s"}"
+          lines.result().mkString("\n")
         }.mkString("\n")
     }
 

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/codegen/client/ScalaHttpClient.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/codegen/client/ScalaHttpClient.scala
@@ -79,10 +79,11 @@ object AsyncClient extends HttpClientType {
           sendRequestArgs ++= m.clientCallParameters
           sendRequestArgs += "requestFilter = requestFilter"
 
-          s"""${m.requestModelClassDef.map(x => s"\n${x}").getOrElse("")}
+          s"""${m.requestModelClassDef.map(x => s"${x}").getOrElse("")}
              |def ${m.name}(${inputArgs.mkString(", ")}): F[${m.returnType}] = {
              |  client.${m.clientMethodName}[${m.typeArgString}](${sendRequestArgs.result.mkString(", ")})
-             |}""".stripMargin
+             |}
+             |""".stripMargin
         }.mkString("\n")
     }
 
@@ -131,10 +132,11 @@ object SyncClient extends HttpClientType {
           sendRequestArgs ++= m.clientCallParameters
           sendRequestArgs += "requestFilter = requestFilter"
 
-          s"""${m.requestModelClassDef.map(x => s"\n${x}").getOrElse("")}
+          s"""${m.requestModelClassDef.map(x => s"${x}").getOrElse("")}
              |def ${m.name}(${inputArgs.mkString(", ")}): ${m.returnType.name} = {
              |  client.${m.clientMethodName}[${m.typeArgString}](${sendRequestArgs.result.mkString(", ")})
-             |}""".stripMargin
+             |}
+             |""".stripMargin
         }.mkString("\n")
     }
 
@@ -193,10 +195,11 @@ object ScalaJSClient extends HttpClientType {
           sendRequestArgs ++= m.typeArgs.map(s => s"Surface.of[${s.name}]")
           sendRequestArgs += "requestFilter = requestFilter"
 
-          s"""${m.requestModelClassDef.map(x => s"\n${x}").getOrElse("")}
+          s"""${m.requestModelClassDef.map(x => s"${x}").getOrElse("")}
              |def ${m.name}(${inputArgs.mkString(", ")}): Future[${m.returnType}] = {
              |  client.${m.clientMethodName}[${m.typeArgString}](${sendRequestArgs.result.mkString(", ")})
-             |}""".stripMargin
+             |}
+             |""".stripMargin
         }.mkString("\n")
     }
 

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/codegen/client/ScalaHttpClient.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/codegen/client/ScalaHttpClient.scala
@@ -79,9 +79,9 @@ object AsyncClient extends HttpClientType {
           sendRequestArgs ++= m.clientCallParameters
           sendRequestArgs += "requestFilter = requestFilter"
 
-          s"""def ${m.name}(${inputArgs.mkString(", ")}): F[${m.returnType}] = {
-             |  client.${m.clientMethodName}[${m.typeArgString}](${sendRequestArgs.result
-            .mkString(", ")})
+          s"""${m.requestModelClassDef.map(x => s"${x}").getOrElse("")}
+             |def ${m.name}(${inputArgs.mkString(", ")}): F[${m.returnType}] = {
+             |  client.${m.clientMethodName}[${m.typeArgString}](${sendRequestArgs.result.mkString(", ")})
              |}""".stripMargin
         }.mkString("\n")
     }
@@ -131,9 +131,9 @@ object SyncClient extends HttpClientType {
           sendRequestArgs ++= m.clientCallParameters
           sendRequestArgs += "requestFilter = requestFilter"
 
-          s"""def ${m.name}(${inputArgs.mkString(", ")}): ${m.returnType.name} = {
-             |  client.${m.clientMethodName}[${m.typeArgString}](${sendRequestArgs.result
-            .mkString(", ")})
+          s"""${m.requestModelClassDef.map(x => s"${x}").getOrElse("")}
+             |def ${m.name}(${inputArgs.mkString(", ")}): ${m.returnType.name} = {
+             |  client.${m.clientMethodName}[${m.typeArgString}](${sendRequestArgs.result.mkString(", ")})
              |}""".stripMargin
         }.mkString("\n")
     }
@@ -193,9 +193,9 @@ object ScalaJSClient extends HttpClientType {
           sendRequestArgs ++= m.typeArgs.map(s => s"Surface.of[${s.name}]")
           sendRequestArgs += "requestFilter = requestFilter"
 
-          s"""def ${m.name}(${inputArgs.mkString(", ")}): Future[${m.returnType}] = {
-             |  client.${m.clientMethodName}[${m.typeArgString}](${sendRequestArgs.result
-            .mkString(", ")})
+          s"""${m.requestModelClassDef.map(x => s"${x}").getOrElse("")}
+             |def ${m.name}(${inputArgs.mkString(", ")}): Future[${m.returnType}] = {
+             |  client.${m.clientMethodName}[${m.typeArgString}](${sendRequestArgs.result.mkString(", ")})
              |}""".stripMargin
         }.mkString("\n")
     }

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/codegen/client/ScalaHttpClient.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/codegen/client/ScalaHttpClient.scala
@@ -79,7 +79,7 @@ object AsyncClient extends HttpClientType {
           sendRequestArgs ++= m.clientCallParameters
           sendRequestArgs += "requestFilter = requestFilter"
 
-          s"""${m.requestModelClassDef.map(x => s"${x}").getOrElse("")}
+          s"""${m.requestModelClassDef.map(x => s"\n${x}").getOrElse("")}
              |def ${m.name}(${inputArgs.mkString(", ")}): F[${m.returnType}] = {
              |  client.${m.clientMethodName}[${m.typeArgString}](${sendRequestArgs.result.mkString(", ")})
              |}""".stripMargin
@@ -131,7 +131,7 @@ object SyncClient extends HttpClientType {
           sendRequestArgs ++= m.clientCallParameters
           sendRequestArgs += "requestFilter = requestFilter"
 
-          s"""${m.requestModelClassDef.map(x => s"${x}").getOrElse("")}
+          s"""${m.requestModelClassDef.map(x => s"\n${x}").getOrElse("")}
              |def ${m.name}(${inputArgs.mkString(", ")}): ${m.returnType.name} = {
              |  client.${m.clientMethodName}[${m.typeArgString}](${sendRequestArgs.result.mkString(", ")})
              |}""".stripMargin
@@ -193,7 +193,7 @@ object ScalaJSClient extends HttpClientType {
           sendRequestArgs ++= m.typeArgs.map(s => s"Surface.of[${s.name}]")
           sendRequestArgs += "requestFilter = requestFilter"
 
-          s"""${m.requestModelClassDef.map(x => s"${x}").getOrElse("")}
+          s"""${m.requestModelClassDef.map(x => s"\n${x}").getOrElse("")}
              |def ${m.name}(${inputArgs.mkString(", ")}): Future[${m.returnType}] = {
              |  client.${m.clientMethodName}[${m.typeArgString}](${sendRequestArgs.result.mkString(", ")})
              |}""".stripMargin

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/HttpRequestDispatcher.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/HttpRequestDispatcher.scala
@@ -21,7 +21,7 @@ import wvlet.log.LogSupport
 import scala.language.higherKinds
 
 /**
-  * Create a filter for dispatching HTTP requests to controller methods with @Endpoint annotation
+  * Create a filter for dispatching HTTP requests to controller methods with @Endpoint or @RPC annotation
   */
 object HttpRequestDispatcher extends LogSupport {
 

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/HttpRequestMapper.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/HttpRequestMapper.scala
@@ -194,10 +194,12 @@ object HttpRequestMapper extends LogSupport {
               val mapValue = toCanonicalKeyNameMap(m)
               while (remainingArgs.nonEmpty) {
                 val arg = remainingArgs.head
-                val argValueOpt: Option[Any] = mapValue.get(CName.toCanonicalName(arg.name)).flatMap { x =>
-                  val argCodec = codecFactory.of(arg.surface)
-                  Some(argCodec.fromMsgPack(x.toMsgpack))
-                }
+                val argValueOpt: Option[Any] = mapValue
+                  .get(CName.toCanonicalName(arg.name))
+                  .map { x =>
+                    val argCodec = codecFactory.of(arg.surface)
+                    argCodec.fromMsgPack(x.toMsgpack)
+                  }
                 setValue(arg, argValueOpt)
                 remainingArgs = remainingArgs.tail
               }

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/HttpRequestMapper.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/HttpRequestMapper.scala
@@ -108,7 +108,7 @@ object HttpRequestMapper extends LogSupport {
 
         // Build the method argument instance from the query strings for GET requests
         argSurface match {
-          // For primitive type, Seq[Primitive], and Option[Primitive] values,
+          // For primitive type, Seq[Primitive], and Option[Primitive], Option[Seq[Primitive]] values,
           // it should already be found in the query strings, so bind None here
           case _ if argSurface.isPrimitive || isPrimitiveSeq(argSurface) =>
             setValue(arg, None)

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/HttpRequestMapper.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/HttpRequestMapper.scala
@@ -179,7 +179,9 @@ object HttpRequestMapper extends LogSupport {
                 mapValue.get(CName.toCanonicalName(arg.name)) match {
                   case Some(paramValue) =>
                     // {"(param name)":(value)}
-                    Some(argCodec.fromMsgPack(paramValue.toMsgpack))
+                    Option(argCodec.fromMsgPack(paramValue.toMsgpack)).orElse {
+                      throw new IllegalArgumentException(s"Failed to parse ${paramValue} for ${arg}")
+                    }
                   case None =>
                     // When the target parameter is not found in the MapValue, try mapping the content body as a whole
                     argCodec.unpackMsgPack(msgpack)

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/HttpRequestMapper.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/HttpRequestMapper.scala
@@ -106,7 +106,6 @@ object HttpRequestMapper extends LogSupport {
 
         def isPrimitiveSeq(s: Surface): Boolean = s.isSeq && s.typeArgs.headOption.forall(_.isPrimitive)
 
-        // Build the method argument instance from the query strings for GET requests
         argSurface match {
           // For primitive type, Seq[Primitive], and Option[Primitive], Option[Seq[Primitive]] values,
           // it should already be found in the query strings, so bind None here
@@ -115,6 +114,7 @@ object HttpRequestMapper extends LogSupport {
           case o: OptionSurface if o.elementSurface.isPrimitive || isPrimitiveSeq(o.elementSurface) =>
             setValue(arg, None)
           case _ =>
+            // Build the method argument object instance using MessagePack representation of the query strings of GET
             val argCodec = codecFactory.of(argSurface)
             setValue(arg, Some(argCodec.fromMsgPack(queryParamMsgPack)))
         }

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/HttpRequestMapper.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/HttpRequestMapper.scala
@@ -14,19 +14,20 @@
 package wvlet.airframe.http.router
 
 import wvlet.airframe.codec.PrimitiveCodec.StringCodec
-import wvlet.airframe.codec.{JSONCodec, MessageCodecFactory}
+import wvlet.airframe.codec.{JSONCodec, MessageCodecFactory, ObjectCodec, ParamListCodec}
 import wvlet.airframe.http._
 import wvlet.airframe.json.JSON
-import wvlet.airframe.msgpack.spi.MessagePack
+import wvlet.airframe.msgpack.spi.Value.{MapValue, StringValue}
+import wvlet.airframe.msgpack.spi.{MessagePack, MsgPack, ValueFactory}
 import wvlet.airframe.surface.reflect.ReflectMethodSurface
-import wvlet.airframe.surface.{OptionSurface, Zero}
+import wvlet.airframe.surface.{MethodParameter, OptionSurface, Zero}
 import wvlet.log.LogSupport
 
 import scala.language.higherKinds
 import scala.util.Try
 
 /**
-  * Mapping HTTP requests to method call arguments
+  * Mapping HTTP requests to RPC/Endpoint method call arguments
   */
 object HttpRequestMapper extends LogSupport {
   def buildControllerMethodArgs[Req, Resp, F[_]](
@@ -44,80 +45,180 @@ object HttpRequestMapper extends LogSupport {
     val requestParams: HttpMultiMap = adapter.queryOf(request) ++ params
     lazy val queryParamMsgpack      = HttpMultiMapCodec.toMsgPack(requestParams)
 
-    // Build the function arguments
-    val methodArgs: Seq[Any] =
-      for (arg <- methodSurface.args) yield {
-        val argSurface = arg.surface
-        argSurface.rawType match {
-          case cl if classOf[HttpMessage.Request].isAssignableFrom(cl) =>
-            // Bind the current http request instance
-            adapter.httpRequestOf(request)
-          case cl if classOf[HttpRequest[_]].isAssignableFrom(cl) =>
-            // Bind the current http request instance
-            adapter.wrap(request)
-          case cl if adapter.requestType.isAssignableFrom(cl) =>
-            request
-          case cl if classOf[HttpContext[Req, Resp, F]].isAssignableFrom(cl) =>
-            context
-          case _ =>
-            // Build from the string value in the request params
-            val argCodec = codecFactory.of(argSurface)
-            val v: Option[Any] = requestParams.get(arg.name) match {
-              case Some(paramValue) =>
-                // Pass the String parameter to the method argument
-                argCodec.unpackMsgPack(StringCodec.toMsgPack(paramValue))
-              case None =>
-                if (adapter.methodOf(request) == HttpMethod.GET) {
-                  // Build the method argument instance from the query strings for GET requests
-                  argSurface match {
-                    case _ if argSurface.isPrimitive =>
-                      arg.getDefaultValue
-                    case o: OptionSurface if o.elementSurface.isPrimitive =>
-                      arg.getDefaultValue
-                    case _ =>
-                      argCodec.unpackMsgPack(queryParamMsgpack).orElse(arg.getDefaultValue)
-                  }
-                } else if (!argSurface.isOption) {
-                  // Build the method argument instance from the content body for non GET requests
-                  val contentBytes = adapter.contentBytesOf(request)
+    // Created a place holder for the function arguments
+    val methodArgs: Array[Any] = Array.fill[Any](methodSurface.args.size)(null)
 
-                  if (contentBytes.nonEmpty) {
-                    val msgpack =
-                      adapter.contentTypeOf(request).map(_.split(";")(0)) match {
-                        case Some("application/x-msgpack") =>
-                          contentBytes
-                        case Some("application/json") =>
-                          // JSON -> msgpack
-                          MessagePack.fromJSON(contentBytes)
-                        case _ =>
-                          // Try parsing as JSON first
-                          Try(JSON.parse(contentBytes))
-                            .map { jsonValue =>
-                              JSONCodec.toMsgPack(jsonValue)
-                            }
-                            .getOrElse {
-                              // If parsing as JSON fails, treat the content body as a regular string
-                              StringCodec.toMsgPack(adapter.contentStringOf(request))
-                            }
-                      }
-                    argCodec.unpackMsgPack(msgpack)
-                  } else {
-                    // Return the method default argument value if exists
-                    arg.getMethodArgDefaultValue(controller)
-                  }
-                } else {
-                  // Return the method default argument value if exists
-                  arg.getMethodArgDefaultValue(controller)
-                }
-            }
-            // If mapping fails, use the zero value
-            v.getOrElse(Zero.zeroOf(arg.surface))
-        }
+    // Populate http request context parameters first
+    var remainingArgs: List[MethodParameter] = Nil
+
+    for (arg <- methodSurface.args) {
+      val argSurface = arg.surface
+      val value: Any = argSurface.rawType match {
+        case cl if classOf[HttpMessage.Request].isAssignableFrom(cl) =>
+          // Bind the current http request instance
+          adapter.httpRequestOf(request)
+        case cl if classOf[HttpRequest[_]].isAssignableFrom(cl) =>
+          // Bind the current http request instance
+          adapter.wrap(request)
+        case cl if adapter.requestType.isAssignableFrom(cl) =>
+          // Bind HttpRequestAdapter[_]
+          request
+        case cl if classOf[HttpContext[Req, Resp, F]].isAssignableFrom(cl) =>
+          // Bind HttpContext
+          context
+        case _ =>
+          // Build from the string value in the request params
+          val v: Option[Any] = requestParams.get(arg.name) match {
+            case Some(paramValue) =>
+              // Pass the String parameter to the method argument
+              val argCodec = codecFactory.of(argSurface)
+              argCodec.unpackMsgPack(StringCodec.toMsgPack(paramValue))
+            case _ =>
+              None
+          }
+          v.getOrElse(null)
       }
+      if (value != null) {
+        methodArgs(arg.index) = value
+      } else {
+        remainingArgs = arg :: remainingArgs
+      }
+    }
+
+    // Populate the remaining function arguments
+
+    // If the request is GET, it should have no body, so we need to populate method args using query strings
+    if (adapter.methodOf(request) == HttpMethod.GET) {
+      while (remainingArgs.nonEmpty) {
+        val arg        = remainingArgs.head
+        val argSurface = arg.surface
+        // Build the method argument instance from the query strings for GET requests
+        argSurface match {
+          case _ if argSurface.isPrimitive =>
+            arg.getDefaultValue
+          case o: OptionSurface if o.elementSurface.isPrimitive =>
+            arg.getDefaultValue
+          case _ =>
+            // If the
+            val argCodec = codecFactory.of(argSurface)
+            argCodec.unpackMsgPack(queryParamMsgpack).orElse(arg.getDefaultValue)
+        }
+        remainingArgs = remainingArgs.tail
+      }
+    }
+
+    def readContentBodyAsMsgPack: Option[MsgPack] = {
+      // Build the method argument instance from the content body for non GET requests
+      val contentBytes = adapter.contentBytesOf(request)
+
+      if (contentBytes.nonEmpty) {
+        val msgpack =
+          adapter.contentTypeOf(request).map(_.split(";")(0)) match {
+            case Some("application/x-msgpack") =>
+              contentBytes
+            case Some("application/json") =>
+              // JSON -> msgpack
+              MessagePack.fromJSON(contentBytes)
+            case _ =>
+              // Try parsing as JSON first
+              Try(JSON.parse(contentBytes))
+                .map { jsonValue =>
+                  JSONCodec.toMsgPack(jsonValue)
+                }
+                .getOrElse {
+                  // If parsing as JSON fails, treat the content body as a regular string
+                  StringCodec.toMsgPack(adapter.contentStringOf(request))
+                }
+          }
+        Some(msgpack)
+      } else {
+        None
+      }
+    }
+
+    remainingArgs match {
+      case arg :: Nil =>
+        val argSurface = arg.surface
+        val argCodec   = codecFactory.of(argSurface)
+        // For unary functions, we can omit parameter name keys in the request body
+        readContentBodyAsMsgPack.map { msgpack =>
+          val v = MessagePack.newUnpacker(msgpack).unpackValue
+          val opt: Option[Any] = v match {
+            case m: MapValue =>
+              m.get(ValueFactory.newString(arg.name)).map { paramValue =>
+                  // {"(param name)":(value)}
+                  argCodec.unpack(paramValue.toMsgpack)
+                }
+                .orElse {
+                  // map content body as a parameter (no key is present)
+                  argCodec.unpackMsgPack(msgpack)
+                }
+            case _ =>
+              argCodec.unpackMsgPack(msgpack)
+          }
+
+          methodArgs(arg.index) = opt
+            .orElse(arg.getMethodArgDefaultValue(controller))
+            .getOrElse(Zero.zeroOf(argSurface))
+        }
+
+      case _ =>
+    }
+
+//
+//
+//            case None =>
+//                if (adapter.methodOf(request) == HttpMethod.GET) {
+//                  // Build the method argument instance from the query strings for GET requests
+//                  argSurface match {
+//                    case _ if argSurface.isPrimitive =>
+//                      arg.getDefaultValue
+//                    case o: OptionSurface if o.elementSurface.isPrimitive =>
+//                      arg.getDefaultValue
+//                    case _ =>
+//                      argCodec.unpackMsgPack(queryParamMsgpack).orElse(arg.getDefaultValue)
+//                  }
+//                } else if (!argSurface.isOption) {
+//                  // Build the method argument instance from the content body for non GET requests
+//                  val contentBytes = adapter.contentBytesOf(request)
+//
+//                  if (contentBytes.nonEmpty) {
+//                    val msgpack =
+//                      adapter.contentTypeOf(request).map(_.split(";")(0)) match {
+//                        case Some("application/x-msgpack") =>
+//                          contentBytes
+//                        case Some("application/json") =>
+//                          // JSON -> msgpack
+//                          MessagePack.fromJSON(contentBytes)
+//                        case _ =>
+//                          // Try parsing as JSON first
+//                          Try(JSON.parse(contentBytes))
+//                            .map { jsonValue =>
+//                              JSONCodec.toMsgPack(jsonValue)
+//                            }
+//                            .getOrElse {
+//                              // If parsing as JSON fails, treat the content body as a regular string
+//                              StringCodec.toMsgPack(adapter.contentStringOf(request))
+//                            }
+//                      }
+//                    argCodec.unpackMsgPack(msgpack)
+//                  } else {
+//                    // Return the method default argument value if exists
+//                    arg.getMethodArgDefaultValue(controller)
+//                  }
+//                } else {
+//                  // Return the method default argument value if exists
+//                  arg.getMethodArgDefaultValue(controller)
+//                }
+//            }
+//            // If mapping fails, use the zero value
+//            v.getOrElse(Zero.zeroOf(arg.surface))
+//        }
+//      }
     trace(
       s"Method binding for request ${adapter.pathOf(request)}: ${methodSurface.name}(${methodSurface.args
         .mkString(", ")}) <= [${methodArgs.mkString(", ")}]"
     )
-    methodArgs
+    methodArgs.toSeq
   }
 }

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/HttpRequestMapper.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/HttpRequestMapper.scala
@@ -65,7 +65,7 @@ object HttpRequestMapper extends LogSupport {
           // Bind the current http request instance
           Some(adapter.wrap(request))
         case cl if adapter.requestType.isAssignableFrom(cl) =>
-          // Bind HttpRequestAdapter[_]
+          // Bind HttpRequest[_]
           Some(request)
         case cl if classOf[HttpContext[Req, Resp, F]].isAssignableFrom(cl) =>
           // Bind HttpContext

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/HttpRequestMapper.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/HttpRequestMapper.scala
@@ -120,3 +120,4 @@ object HttpRequestMapper extends LogSupport {
     )
     methodArgs
   }
+}

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/HttpRequestMapper.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/HttpRequestMapper.scala
@@ -84,7 +84,7 @@ object HttpRequestMapper extends LogSupport {
       // Set the method argument
       value match {
         case Some(x) =>
-          methodArgs(arg.index) = value
+          methodArgs(arg.index) = x
         case None =>
           remainingArgs = arg :: remainingArgs
       }

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/HttpRequestMapper.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/HttpRequestMapper.scala
@@ -120,4 +120,3 @@ object HttpRequestMapper extends LogSupport {
     )
     methodArgs
   }
-}

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/HttpRequestMapper.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/HttpRequestMapper.scala
@@ -103,11 +103,16 @@ object HttpRequestMapper extends LogSupport {
       while (remainingArgs.nonEmpty) {
         val arg        = remainingArgs.head
         val argSurface = arg.surface
+
+        def isPrimitiveSeq(s: Surface): Boolean = s.isSeq && s.typeArgs.headOption.forall(_.isPrimitive)
+
         // Build the method argument instance from the query strings for GET requests
         argSurface match {
-          case _ if argSurface.isPrimitive =>
+          // For primitive type, Seq[Primitive], and Option[Primitive] values,
+          // it should already be found in the query strings, so bind None here
+          case _ if argSurface.isPrimitive || isPrimitiveSeq(argSurface) =>
             setValue(arg, None)
-          case o: OptionSurface if o.elementSurface.isPrimitive =>
+          case o: OptionSurface if o.elementSurface.isPrimitive || isPrimitiveSeq(o.elementSurface) =>
             setValue(arg, None)
           case _ =>
             val argCodec = codecFactory.of(argSurface)

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/Route.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/Route.scala
@@ -102,6 +102,8 @@ case class ControllerRoute(
       context.setThreadLocal(HttpBackend.TLS_KEY_RPC, RPCCallContext(rpcInterfaceCls, methodSurface, methodArgs))
       methodSurface.call(controller, methodArgs: _*)
     } catch {
+      case e: IllegalArgumentException =>
+        throw new HttpServerException(HttpStatus.BadRequest_400, e.getMessage, e)
       case e: MessageCodecException[_] if e.errorCode == MISSING_PARAMETER =>
         throw new HttpServerException(HttpStatus.BadRequest_400, e.message, e)
     }

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/Route.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/Route.scala
@@ -21,6 +21,7 @@ import wvlet.airframe.surface.{MethodSurface, Surface}
 import wvlet.log.LogSupport
 
 import scala.language.higherKinds
+import scala.util.{Failure, Success, Try}
 
 /**
   * A mapping from an HTTP endpoint to a corresponding method (or function)
@@ -94,16 +95,25 @@ case class ControllerRoute(
       context: HttpContext[Req, Resp, F],
       codecFactory: MessageCodecFactory
   ): Any = {
+    var methodArgs: Seq[Any] = Seq.empty
     try {
-      val methodArgs =
-        HttpRequestMapper.buildControllerMethodArgs(controller, methodSurface, request, context, params, codecFactory)
-
-      // Record RPC method arguments
-      context.setThreadLocal(HttpBackend.TLS_KEY_RPC, RPCCallContext(rpcInterfaceCls, methodSurface, methodArgs))
+      try {
+        methodArgs = HttpRequestMapper.buildControllerMethodArgs(
+          controller,
+          methodSurface,
+          request,
+          context,
+          params,
+          codecFactory
+        )
+      } finally {
+        // Ensure recording RPC method arguments
+        context.setThreadLocal(HttpBackend.TLS_KEY_RPC, RPCCallContext(rpcInterfaceCls, methodSurface, methodArgs))
+      }
       methodSurface.call(controller, methodArgs: _*)
     } catch {
       case e: IllegalArgumentException =>
-        throw new HttpServerException(HttpStatus.BadRequest_400, e.getMessage, e)
+        throw new HttpServerException(HttpStatus.BadRequest_400, s"${request} failed: ${e.getMessage}", e)
       case e: MessageCodecException[_] if e.errorCode == MISSING_PARAMETER =>
         throw new HttpServerException(HttpStatus.BadRequest_400, e.message, e)
     }

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/HttpRequestMapperTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/HttpRequestMapperTest.scala
@@ -178,28 +178,28 @@ object HttpRequestMapperTest extends AirSpec {
     classOf[HttpRequest[Request]].isAssignableFrom(args(2).getClass) shouldBe true
   }
 
-  test("throws an error on incompatible type") {
+  test("throw an error on incompatible type") {
     val r = findRoute("rpc8")
     intercept[IllegalArgumentException] {
       mapArgs(r, _.withJson("""{"p1":"abc"}"""))
     }
   }
 
-  test("throws an error on incompatible type in query parameters") {
+  test("throw an error on incompatible type in query parameters") {
     val r = findRoute("rpc8")
     intercept[IllegalArgumentException] {
       mapArgs(r, { r => r.withUri(s"${r.uri}?p1=abc") })
     }
   }
 
-  test("throws an error on incompatible type in request body") {
+  test("throw an error on incompatible type in request body") {
     val r = findRoute("rpc8")
     intercept[IllegalArgumentException] {
       mapArgs(r, { r => r.withContent("abc") })
     }
   }
 
-  test("throws an error when mapping JSON [1] to Int") {
+  test("throw an error when mapping JSON [1] to Int") {
     val r = findRoute("rpc8")
     intercept[IllegalArgumentException] {
       val args = mapArgs(r, { r => r.withJson("""{"p1":[1]}""") })
@@ -207,7 +207,7 @@ object HttpRequestMapperTest extends AirSpec {
     }
   }
 
-  test("throws an error on incompatible JSON [1] to Option[X]") {
+  test("throw an error on incompatible JSON [1] to Option[X]") {
     val r = findRoute("rpc9")
     intercept[IllegalArgumentException] {
       val args = mapArgs(r, { r => r.withJson("""{"p1":[1]}""") })
@@ -234,28 +234,33 @@ object HttpRequestMapperTest extends AirSpec {
     }
   }
 
-  test("Map query parameters to Seq[X]") {
+  test("map query parameters to Seq[X]") {
     val r    = findRoute("endpoint3")
     val args = mapArgs(r, { r => r.withUri(s"${r.uri}?p1=apple") }, method = HttpMethod.GET)
     args shouldBe Seq(Seq("apple"))
   }
 
-  test("Map multiple query parameters to Seq[X]") {
+  test("map multiple query parameters to Seq[X]") {
     val r    = findRoute("endpoint3")
     val args = mapArgs(r, { r => r.withUri(s"${r.uri}?p1=apple&p1=banana") }, method = HttpMethod.GET)
     args shouldBe Seq(Seq("apple", "banana"))
   }
 
-  test("Map empty parameters to Seq[X]") {
+  test("map empty parameters to Seq[X]") {
     val r    = findRoute("endpoint3")
     val args = mapArgs(r, identity, method = HttpMethod.GET)
     args shouldBe Seq(Seq.empty)
   }
 
-  test("Map empty parameters to Option[Seq[X]]") {
+  test("map empty parameters to Option[Seq[X]]") {
     val r    = findRoute("endpoint4")
     val args = mapArgs(r, identity, method = HttpMethod.GET)
     args shouldBe Seq(None)
   }
 
+  test("map multiple query parameters to Option[Seq[X]]") {
+    val r    = findRoute("endpoint4")
+    val args = mapArgs(r, { r => r.withUri(s"${r.uri}?p1=apple&p1=banana") }, method = HttpMethod.GET)
+    args shouldBe Seq(Some(Seq("apple", "banana")))
+  }
 }

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/HttpRequestMapperTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/HttpRequestMapperTest.scala
@@ -42,6 +42,7 @@ object HttpRequestMapperTest extends AirSpec {
         req: HttpRequest[Request]
     ): Unit = {}
     def rpc8(p1: Int): Unit = {}
+    def rpc9(p1: Option[Int]): Unit = {}
   }
 
   trait MyApi2 {
@@ -192,6 +193,22 @@ object HttpRequestMapperTest extends AirSpec {
     val r = findRoute("rpc8")
     intercept[IllegalArgumentException] {
       mapArgs(r, { r => r.withContent("abc") })
+    }
+  }
+
+  test("throws an error when mapping JSON [1] to Int") {
+    val r = findRoute("rpc8")
+    intercept[IllegalArgumentException] {
+      val args = mapArgs(r, { r => r.withJson("""{"p1":[1]}""") })
+      warn(args)
+    }
+  }
+
+  test("throws an error on incompatible JSON [1] to Option[X]") {
+    val r = findRoute("rpc9")
+    intercept[IllegalArgumentException] {
+      val args = mapArgs(r, { r => r.withJson("""{"p1":[1]}""") })
+      warn(args)
     }
   }
 

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/HttpRequestMapperTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/HttpRequestMapperTest.scala
@@ -50,6 +50,9 @@ object HttpRequestMapperTest extends AirSpec {
 
     @Endpoint(method = HttpMethod.GET, path = "/v1/endpoint2")
     def endpoint2(p1: NestedRequest2): Unit = {}
+
+    @Endpoint(method = HttpMethod.GET, path = "/v1/endpoint3")
+    def endpoint3(p1: Seq[String]): Unit = {}
   }
 
   private val api    = new MyApi {}
@@ -204,10 +207,29 @@ object HttpRequestMapperTest extends AirSpec {
     args shouldBe Seq(NestedRequest2(1))
   }
 
-  test("throws an error when incompatible input is found when constructing nested objects with GET") {
+  test("throw an error when incompatible input is found when constructing nested objects with GET") {
     val r = findRoute("endpoint2")
     intercept[IllegalArgumentException] {
       mapArgs(r, { r => r.withUri(s"${r.uri}?id=abc") }, method = HttpMethod.GET)
     }
+  }
+
+  test("Map query parameters to Seq[X]") {
+    val r    = findRoute("endpoint3")
+    val args = mapArgs(r, { r => r.withUri(s"${r.uri}?p1=apple") }, method = HttpMethod.GET)
+    args shouldBe Seq(Seq("apple"))
+  }
+
+  test("Map multiple query parameters to Seq[X]") {
+    val r    = findRoute("endpoint3")
+    val args = mapArgs(r, { r => r.withUri(s"${r.uri}?p1=apple&p1=banana") }, method = HttpMethod.GET)
+    args shouldBe Seq(Seq("apple", "banana"))
+  }
+
+  test("Map empty parameters to Seq[X]") {
+    pending("Fix empty parameter mapping to Seq[X]")
+    val r    = findRoute("endpoint3")
+    val args = mapArgs(r, identity, method = HttpMethod.GET)
+    args shouldBe Seq(Seq.empty)
   }
 }

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/HttpRequestMapperTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/HttpRequestMapperTest.scala
@@ -54,6 +54,9 @@ object HttpRequestMapperTest extends AirSpec {
 
     @Endpoint(method = HttpMethod.GET, path = "/v1/endpoint3")
     def endpoint3(p1: Seq[String]): Unit = {}
+
+    @Endpoint(method = HttpMethod.GET, path = "/v1/endpoint4")
+    def endpoint4(p1: Option[Seq[String]]): Unit = {}
   }
 
   private val api    = new MyApi {}
@@ -244,9 +247,15 @@ object HttpRequestMapperTest extends AirSpec {
   }
 
   test("Map empty parameters to Seq[X]") {
-    pending("Fix empty parameter mapping to Seq[X]")
     val r    = findRoute("endpoint3")
     val args = mapArgs(r, identity, method = HttpMethod.GET)
     args shouldBe Seq(Seq.empty)
   }
+
+  test("Map empty parameters to Option[Seq[X]]") {
+    val r    = findRoute("endpoint4")
+    val args = mapArgs(r, identity, method = HttpMethod.GET)
+    args shouldBe Seq(None)
+  }
+
 }

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/HttpRequestMapperTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/HttpRequestMapperTest.scala
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.http
+import wvlet.airframe.codec.MessageCodecFactory
+import wvlet.airframe.http.router.{HttpRequestMapper, Route}
+import wvlet.airframe.surface.reflect.ReflectMethodSurface
+import wvlet.airspec.AirSpec
+
+import scala.concurrent.Future
+
+/**
+  *
+ */
+object HttpRequestMapperTest extends AirSpec {
+
+  case class NestedRequest(name: String, msg: String)
+
+  @RPC
+  trait MyApi {
+    def f1(p1: String): String                    = p1
+    def f2(p1: String, p2: Int): String           = s"${p1},${p2}"
+    def f3(p1: NestedRequest)                     = s"${p1}"
+    def f4(p1: String, p2: NestedRequest): String = s"${p1},${p2}"
+  }
+
+  private val api    = new MyApi {}
+  private val router = Router.of[MyApi]
+
+  private def mapArgs(route: Route, jsonBody: String): Seq[Any] = {
+    val args = HttpRequestMapper.buildControllerMethodArgs[HttpMessage.Request, HttpMessage.Response, Future](
+      controller = api,
+      methodSurface = route.methodSurface.asInstanceOf[ReflectMethodSurface],
+      request = Http.POST(route.path).withJson(jsonBody),
+      context = HttpContext.mockContext,
+      params = Map.empty,
+      codecFactory = MessageCodecFactory.defaultFactoryForJSON
+    )
+    args
+  }
+
+  test("map a single primitive argument") {
+    val r    = router.routes.find(_.methodSurface.name == "f1").get
+    val args = mapArgs(r, """{"p1":"hello"}""")
+    args shouldBe Seq("hello")
+  }
+
+  test("map multiple primitive arguments") {
+    val r    = router.routes.find(_.methodSurface.name == "f2").get
+    val args = mapArgs(r, """{"p1":"hello","p2":2020}""")
+    args shouldBe Seq("hello", 2020)
+  }
+
+  test("map a single request object") {
+    val r    = router.routes.find(_.methodSurface.name == "f3").get
+    val args = mapArgs(r, """{"name":"hello","msg":"world"}""")
+    args shouldBe Seq(NestedRequest("hello", "world"))
+  }
+
+  test("map a primitive value and a single request object") {
+    val r    = router.routes.find(_.methodSurface.name == "f4").get
+    val args = mapArgs(r, """{"p1":"Yo!","p2":{"name":"hello","msg":"world"}}""")
+    args shouldBe Seq("Yo!", NestedRequest("hello", "world"))
+  }
+
+}

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/HttpRequestMapperTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/HttpRequestMapperTest.scala
@@ -75,8 +75,8 @@ object HttpRequestMapperTest extends AirSpec {
 
   test("map a primitive value and a single request object") {
     val r    = router.routes.find(_.methodSurface.name == "f4").get
-    val args = mapArgs(r, _.withJson("""{"p1":"Yo!","p2":{"name":"hello","msg":"world"}}"""))
-    args shouldBe Seq("Yo!", NestedRequest("hello", "world"))
+    val args = mapArgs(r, _.withJson("""{"p1":"Yes","p2":{"name":"hello","msg":"world"}}"""))
+    args shouldBe Seq("Yes", NestedRequest("hello", "world"))
   }
 
 }

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/RouterTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/RouterTest.scala
@@ -14,12 +14,11 @@
 package wvlet.airframe.http
 
 import wvlet.airframe.Session
+import wvlet.airframe.codec.MessageCodecFactory
 import wvlet.airframe.http.example.ControllerExample.User
 import wvlet.airframe.http.example._
 import wvlet.airframe.http.router.{ControllerProvider, RouteMatcher}
 import wvlet.airframe.surface.Surface
-import wvlet.airframe.codec.MessageCodecFactory
-import wvlet.airframe.http.HttpMessage.{Request, Response}
 import wvlet.airspec.AirSpec
 
 /**
@@ -138,7 +137,7 @@ class RouterTest extends AirSpec {
       }
     }
 
-    def call[A](request: HttpMessage.Request, exepected: A): Unit = {
+    def call[A](request: HttpMessage.Request, expected: A): Unit = {
       val ret =
         router
           .findRoute(request)
@@ -147,7 +146,7 @@ class RouterTest extends AirSpec {
           }
 
       ret shouldBe defined
-      ret.get shouldBe exepected
+      ret.get shouldBe expected
     }
 
     call(Http.GET("/user/10"), ControllerExample.User("10", "leo"))

--- a/airframe-http/src/main/scala/wvlet/airframe/http/HttpClient.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/HttpClient.scala
@@ -12,8 +12,6 @@
  * limitations under the License.
  */
 package wvlet.airframe.http
-import java.net.URLEncoder
-
 import wvlet.airframe.codec.MessageCodec
 import wvlet.airframe.control.Retry
 import wvlet.airframe.control.Retry.RetryContext

--- a/airframe-http/src/main/scala/wvlet/airframe/http/HttpContext.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/HttpContext.scala
@@ -92,7 +92,7 @@ object HttpContext {
   /**
     * Mock HttpContext for testing
     */
-  private[http] def mockContext: HttpContext[Request, Response, Future] = {
+  def mockContext: HttpContext[Request, Response, Future] = {
     new HttpContext[Request, Response, Future] {
       override protected def backend: HttpBackend[
         Request,

--- a/airframe-http/src/main/scala/wvlet/airframe/http/RPC.java
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/RPC.java
@@ -22,8 +22,8 @@ import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * An annotation used for defining RPC interfaces.
- * All public methods inside the class marked with @RPC will be HTTP endpoints.
+ * An annotation for defining RPC interfaces.
+ * All public methods inside the class marked with `@RPC` will be HTTP endpoints.
  */
 @Retention(RUNTIME)
 @Target({TYPE, METHOD})

--- a/airframe-msgpack/.jvm/src/main/scala/wvlet/airframe/msgpack/spi/Compat.scala
+++ b/airframe-msgpack/.jvm/src/main/scala/wvlet/airframe/msgpack/spi/Compat.scala
@@ -15,7 +15,14 @@ package wvlet.airframe.msgpack.spi
 import java.io.{InputStream, OutputStream}
 
 import org.msgpack.{core => mj}
-import wvlet.airframe.msgpack.impl.{BufferPackerImpl, PackerImpl, UnpackerImpl}
+import wvlet.airframe.msgpack.impl.{
+  BufferPackerImpl,
+  PackerImpl,
+  PureScalaBufferPacker,
+  PureScalaBufferUnpacker,
+  UnpackerImpl
+}
+import wvlet.airframe.msgpack.io.ByteArrayBuffer
 
 /**
   * For compatibility with Scala, Scala.js
@@ -27,7 +34,8 @@ object Compat {
   def doubleToLongBits(v: Double): Long = java.lang.Double.doubleToRawLongBits(v)
 
   def newBufferPacker: BufferPacker = {
-    new BufferPackerImpl(mj.MessagePack.newDefaultBufferPacker())
+    new PureScalaBufferPacker
+    //new BufferPackerImpl(mj.MessagePack.newDefaultBufferPacker())
   }
 
   def newPacker(out: OutputStream): Packer = {
@@ -45,8 +53,8 @@ object Compat {
   }
 
   def newUnpacker(msgpack: Array[Byte], offset: Int, len: Int): Unpacker = {
-    // TODO use pure-scala unpacker
-    //new PureScalaBufferUnpacker(ByteArrayBuffer.fromArray(msgpack, offset, len))
-    new UnpackerImpl(mj.MessagePack.newDefaultUnpacker(msgpack, offset, len))
+    //new UnpackerImpl(mj.MessagePack.newDefaultUnpacker(msgpack, offset, len))
+    // Use pure-scala unpacker
+    new PureScalaBufferUnpacker(ByteArrayBuffer.fromArray(msgpack, offset, len))
   }
 }

--- a/airframe-msgpack/src/main/scala/wvlet/airframe/msgpack/spi/Value.scala
+++ b/airframe-msgpack/src/main/scala/wvlet/airframe/msgpack/spi/Value.scala
@@ -236,6 +236,8 @@ object Value {
     def get(key: Value): Option[Value] = entries.get(key)
     def size: Int                      = entries.size
 
+    def isEmpty: Boolean  = entries.isEmpty
+    def nonEmpty: Boolean = entries.nonEmpty
     override def toJson: String = {
       s"{${entries.map(x => s"${x._1.toJson}:${x._2.toJson}").mkString(",")}}"
     }

--- a/airframe-msgpack/src/test/scala/wvlet/airframe/msgpack/spi/ValueTest.scala
+++ b/airframe-msgpack/src/test/scala/wvlet/airframe/msgpack/spi/ValueTest.scala
@@ -142,6 +142,8 @@ class ValueTest extends AirSpec with PropertyCheck {
       newString("name")    -> newString("mitsu")
     )
     // a key ("name") should be overwritten
+    m.isEmpty shouldBe false
+    m.nonEmpty shouldBe true
     m.size shouldBe 3
     m.get(StringValue("id")) shouldBe Some(LongValue(1001))
     m.get(StringValue("name")) shouldBe Some(StringValue("mitsu"))

--- a/airframe-surface/shared/src/main/scala/wvlet/airframe/surface/Surface.scala
+++ b/airframe-surface/shared/src/main/scala/wvlet/airframe/surface/Surface.scala
@@ -93,7 +93,7 @@ trait MethodParameter extends Parameter {
   def method: MethodRef
 
   /**
-    * Method owner instnce is necessary to find by-name parameter default values
+    * Method owner instance is necessary to find by-name parameter default values
     * @param methodOwner
     * @return
     */

--- a/airframe-surface/shared/src/main/scala/wvlet/airframe/surface/Surface.scala
+++ b/airframe-surface/shared/src/main/scala/wvlet/airframe/surface/Surface.scala
@@ -34,6 +34,7 @@ trait Surface extends Serializable {
   def isOption: Boolean
   def isAlias: Boolean
   def isPrimitive: Boolean
+  def isSeq: Boolean = classOf[Seq[_]].isAssignableFrom(rawType)
 
   def objectFactory: Option[ObjectFactory] = None
 }

--- a/sbt-airframe/src/sbt-test/sbt-airframe/generate-client/server/src/main/scala/myapp/server/MyServer.scala
+++ b/sbt-airframe/src/sbt-test/sbt-airframe/generate-client/server/src/main/scala/myapp/server/MyServer.scala
@@ -4,6 +4,7 @@ import wvlet.airframe.http.Router
 import wvlet.airframe.http.finagle._
 import wvlet.log.LogSupport
 import myapp.spi.MyService
+import myapp.spi.MyRPC._
 import com.twitter.util.Await
 
 class MyServiceImpl extends myapp.spi.MyService {
@@ -12,7 +13,10 @@ class MyServiceImpl extends myapp.spi.MyService {
 }
 
 class MyRPCImpl extends myapp.spi.MyRPC {
-  override def world() = myapp.spi.MyRPC.World("world")
+  override def world()                                                                 = myapp.spi.MyRPC.World("world")
+  override def addEntry(id: Int, name: String)                                         = s"${id}:${name}"
+  override def createPage(createPageRequest: CreatePageRequest): String                = s"${0}:${createPageRequest}"
+  override def createPageWithId(id: Int, createPageRequest: CreatePageRequest): String = s"${id}:${createPageRequest}"
 }
 
 object MyServer extends LogSupport {
@@ -47,6 +51,18 @@ object MyServer extends LogSupport {
       val ret2 = syncClient.myRPC.world()
       info(ret2)
       assert(ret2 == myapp.spi.MyRPC.World("world"))
+
+      val ret3 = syncClient.myRPC.addEntry(1234, "rpc")
+      info(ret3)
+      assert(ret3 == "1234:rpc")
+
+      val ret4 = syncClient.myRPC.createPage(CreatePageRequest("hello"))
+      info(ret4)
+      assert(ret4 == """0:CreatePageRequest(hello)""")
+
+      val ret5 = syncClient.myRPC.createPageWithId(10, CreatePageRequest("hello"))
+      info(ret5)
+      assert(ret5 == """10:CreatePageRequest(hello)""")
     }
   }
 }

--- a/sbt-airframe/src/sbt-test/sbt-airframe/generate-client/spi/src/main/scala/myapp/spi/MyRPC.scala
+++ b/sbt-airframe/src/sbt-test/sbt-airframe/generate-client/spi/src/main/scala/myapp/spi/MyRPC.scala
@@ -7,8 +7,13 @@ trait MyRPC {
   import MyRPC._
 
   def world(): World
+  def addEntry(id: Int, name: String): String
+
+  def createPage(createPageRequest: CreatePageRequest): String
+  def createPageWithId(id: Int, createPageRequest: CreatePageRequest): String
 }
 
 object MyRPC {
   case class World(name: String)
+  case class CreatePageRequest(name: String)
 }

--- a/sbt-airframe/src/sbt-test/sbt-airframe/js-client/build.sbt
+++ b/sbt-airframe/src/sbt-test/sbt-airframe/js-client/build.sbt
@@ -17,6 +17,7 @@ lazy val client =
     .in(file("client"))
     .enablePlugins(AirframeHttpPlugin)
     .settings(
+      airframeHttpGeneratorOption := "-l trace",
       airframeHttpClients := Seq("myapp.spi:scalajs")
     )
     .jsSettings(

--- a/sbt-airframe/src/sbt-test/sbt-airframe/js-client/spi/src/main/scala/myspp/spi/MyService.scala
+++ b/sbt-airframe/src/sbt-test/sbt-airframe/js-client/spi/src/main/scala/myspp/spi/MyService.scala
@@ -19,3 +19,13 @@ trait MyService {
   @Endpoint(method = HttpMethod.GET, path = "/v1/hello/:id")
   def hello(id: Int): String
 }
+
+@RPC
+trait MyRPC {
+  import MyRPC._
+  def hello(time: Long, request: HelloRequest): String
+}
+
+object MyRPC {
+  case class HelloRequest()
+}


### PR DESCRIPTION
Addresses #1100

- [x] Support an arbitrary number of function arguments for RPC calls.
- [x] sbt-airframe: If RPC call requires multiple arguments, wrap them into a single case class and send it as JSON or MsgPack. 
- [x] Changed to throw IllegalArgumentException and 400 (BadRequest) response when incompatible type data is used in HTTP requests. Note this change still doesn't cover cases described in #978 (unnecessary attributes are given) 
- [x] Properly handle application/octet-stream requests so as not to bind uploaded file contents to RPC arguments
