### PR TITLE
airframe-http: #1131 Add a sync client using URLConnection 

### DIFF
--- a/airframe-control/src/main/scala/wvlet/airframe/control/IO.scala
+++ b/airframe-control/src/main/scala/wvlet/airframe/control/IO.scala
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.control
+import java.io.{ByteArrayOutputStream, File, InputStream}
+import java.net.URL
+import java.nio.charset.StandardCharsets
+
+import wvlet.airframe.control.Control.withResource
+
+/**
+  *
+ */
+object IO {
+
+  def readAsString(f: File): String = {
+    readAsString(f.toURI.toURL)
+  }
+
+  def readAsString(url: URL): String = {
+    withResource(url.openStream()) { in => readAsString(in) }
+  }
+
+  def readAsString(in: InputStream): String = {
+    readFully(in) { data => new String(data, StandardCharsets.UTF_8) }
+  }
+
+  def readFully[U](in: InputStream)(f: Array[Byte] => U): U = {
+    val byteArray =
+      if (in == null) {
+        Array.emptyByteArray
+      } else {
+        withResource(new ByteArrayOutputStream) { b =>
+          val buf = new Array[Byte](8192)
+          withResource(in) { src =>
+            var readBytes = 0
+            while ({
+              readBytes = src.read(buf);
+              readBytes != -1
+            }) {
+              b.write(buf, 0, readBytes)
+            }
+          }
+          b.toByteArray
+        }
+      }
+    f(byteArray)
+  }
+
+}

--- a/airframe-control/src/main/scala/wvlet/airframe/control/IO.scala
+++ b/airframe-control/src/main/scala/wvlet/airframe/control/IO.scala
@@ -32,10 +32,10 @@ object IO {
   }
 
   def readAsString(in: InputStream): String = {
-    readFully(in) { data => new String(data, StandardCharsets.UTF_8) }
+    new String(readFully(in), StandardCharsets.UTF_8)
   }
 
-  def readFully[U](in: InputStream)(f: Array[Byte] => U): U = {
+  def readFully(in: InputStream): Array[Byte] = {
     val byteArray =
       if (in == null) {
         Array.emptyByteArray
@@ -54,7 +54,7 @@ object IO {
           b.toByteArray
         }
       }
-    f(byteArray)
+    byteArray
   }
 
 }

--- a/airframe-http/.js/src/main/scala/wvlet/airframe/http/Compat.scala
+++ b/airframe-http/.js/src/main/scala/wvlet/airframe/http/Compat.scala
@@ -20,11 +20,5 @@ private object Compat extends CompatApi {
   override def urlEncode(s: String): String = {
     scala.scalajs.js.URIUtils.encodeURI(s)
   }
-  override def newSyncClient(
-      serverAddress: String,
-      config: HttpClientConfig
-  ): HttpSyncClient[
-    HttpMessage.Request,
-    HttpMessage.Response
-  ] = ???
+  override def defaultHttpClientBackend: HttpClientBackend = ???
 }

--- a/airframe-http/.js/src/main/scala/wvlet/airframe/http/js/JSHttpClient.scala
+++ b/airframe-http/.js/src/main/scala/wvlet/airframe/http/js/JSHttpClient.scala
@@ -56,7 +56,7 @@ object JSHttpClient {
   // An http client that can be used for local testing
   def localClient = JSHttpClient()
 
-  def defaultHttpClientRetrier: RetryContext = {
+  def defaultHttpClientRetryer: RetryContext = {
     Retry
       .withBackOff(maxRetry = 3)
       .withResultClassifier(HttpClientException.classifyHttpResponse[Response])
@@ -69,7 +69,7 @@ case class JSHttpClientConfig(
     serverAddress: Option[ServerAddress] = None,
     requestEncoding: MessageEncoding = MessageEncoding.MessagePackEncoding,
     requestFilter: Request => Request = identity,
-    retryContext: RetryContext = JSHttpClient.defaultHttpClientRetrier,
+    retryContext: RetryContext = JSHttpClient.defaultHttpClientRetryer,
     codecFactory: MessageCodecFactory = MessageCodecFactory.defaultFactoryForJSON
 ) {
   def withServerAddress(newServerAddress: ServerAddress): JSHttpClientConfig = {
@@ -88,7 +88,9 @@ case class JSHttpClientConfig(
 }
 
 /**
-  * HttpClient utilities for Scala.js
+  * HttpClient utilities for Scala.js.
+  *
+  * We do not implement HttpClient[F, Request, Response] interface as no TypeTag is available in Scala.js
   */
 case class JSHttpClient(config: JSHttpClientConfig = JSHttpClientConfig()) extends LogSupport {
   import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/Compat.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/Compat.scala
@@ -14,7 +14,7 @@
 package wvlet.airframe.http
 import java.net.URLEncoder
 
-import wvlet.airframe.http.client.{DefaultHttpClientBackend, URLConnectionClient, URLConnectionClientConfig}
+import wvlet.airframe.http.client.URLConnectionClientBackend
 
 /**
   *
@@ -23,5 +23,8 @@ object Compat extends CompatApi {
   override def urlEncode(s: String): String = {
     URLEncoder.encode(s, "UTF-8")
   }
-  override def defaultHttpClientBackend: HttpClientBackend = DefaultHttpClientBackend
+  override def defaultHttpClientBackend: HttpClientBackend = {
+    // TODO: Use JDK11's HttpClient backend
+    URLConnectionClientBackend
+  }
 }

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/Compat.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/Compat.scala
@@ -14,11 +14,26 @@
 package wvlet.airframe.http
 import java.net.URLEncoder
 
+import wvlet.airframe.http.client.{URLConnectionClient, URLConnectionClientConfig}
+
 /**
   *
   */
 object Compat extends CompatApi {
   override def urlEncode(s: String): String = {
     URLEncoder.encode(s, "UTF-8")
+  }
+  override def newSyncClient(
+      serverAddress: String,
+      config: HttpClientConfig
+  ): HttpSyncClient[HttpMessage.Request, HttpMessage.Response] = {
+    new URLConnectionClient(
+      ServerAddress(serverAddress),
+      URLConnectionClientConfig(
+        requestFilter = config.requestFilter,
+        retryContext = config.retryContext,
+        codecFactory = config.codecFactory
+      )
+    )
   }
 }

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/client/DefaultHttpClientBackend.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/client/DefaultHttpClientBackend.scala
@@ -11,15 +11,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.airframe.http
+package wvlet.airframe.http.client
 import wvlet.airframe.http.HttpMessage.{Request, Response}
-
-import scala.concurrent.Future
+import wvlet.airframe.http.{HttpClientBackend, HttpClientConfig, HttpSyncClient, ServerAddress}
 
 /**
-  * An interface for using different implementation betweeen Scala JVM and Scala.js
-  */
-trait CompatApi {
-  def urlEncode(s: String): String
-  def defaultHttpClientBackend: HttpClientBackend
+  *
+ */
+object DefaultHttpClientBackend extends HttpClientBackend {
+  def newSyncClient(serverAddress: String, clientConfig: HttpClientConfig): HttpSyncClient[Request, Response] = {
+    new URLConnectionClient(
+      ServerAddress(serverAddress),
+      URLConnectionClientConfig(
+        requestFilter = clientConfig.requestFilter,
+        retryContext = clientConfig.retryContext,
+        codecFactory = clientConfig.codecFactory
+      )
+    )
+  }
 }

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/client/URLConnectionClient.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/client/URLConnectionClient.scala
@@ -181,12 +181,19 @@ class URLConnectionClient(address: ServerAddress, config: URLConnectionClientCon
     convert[OperationResponse](send(Http.request(resourcePath), requestFilter))
   }
 
+  private def toJson[Resource: TypeTag](resource: Resource): String = {
+    val resourceCodec = config.codecFactory.of[Resource]
+    // TODO: Support non-json content body
+    val json = resourceCodec.toJson(resource)
+    json
+  }
+
   override def post[Resource: TypeTag](
       resourcePath: String,
       resource: Resource,
       requestFilter: Request => Request
   ): Resource = {
-    val r = Http.POST(resourcePath).withJsonOf(resource, config.codecFactory)
+    val r = Http.POST(resourcePath).withJson(toJson(resource))
     convert[Resource](send(r, requestFilter))
   }
 
@@ -206,7 +213,7 @@ class URLConnectionClient(address: ServerAddress, config: URLConnectionClientCon
       resource: Resource,
       requestFilter: Request => Request
   ): OperationResponse = {
-    val r = Http.POST(resourcePath).withJsonOf(resource, config.codecFactory)
+    val r = Http.POST(resourcePath).withJson(toJson(resource))
     convert[OperationResponse](send(r, requestFilter))
   }
 
@@ -215,7 +222,7 @@ class URLConnectionClient(address: ServerAddress, config: URLConnectionClientCon
       resource: Resource,
       requestFilter: Request => Request
   ): Resource = {
-    val r = Http.PUT(resourcePath).withJsonOf(resource, config.codecFactory)
+    val r = Http.PUT(resourcePath).withJson(toJson(resource))
     convert[Resource](send(r, requestFilter))
   }
 
@@ -233,7 +240,7 @@ class URLConnectionClient(address: ServerAddress, config: URLConnectionClientCon
       resource: Resource,
       requestFilter: Request => Request
   ): OperationResponse = {
-    val r = Http.PUT(resourcePath).withJsonOf(resource, config.codecFactory)
+    val r = Http.PUT(resourcePath).withJson(toJson(resource))
     convert[OperationResponse](send(r, requestFilter))
   }
 
@@ -259,7 +266,7 @@ class URLConnectionClient(address: ServerAddress, config: URLConnectionClientCon
       requestFilter: Request => Request
   ): OperationResponse = {
 
-    val r = Http.DELETE(resourcePath).withJsonOf(resource, config.codecFactory)
+    val r = Http.DELETE(resourcePath).withJson(toJson(resource))
     convert[OperationResponse](send(r, requestFilter))
   }
 
@@ -268,7 +275,7 @@ class URLConnectionClient(address: ServerAddress, config: URLConnectionClientCon
       resource: Resource,
       requestFilter: Request => Request
   ): Resource = {
-    val r = Http.PATCH(resourcePath).withJsonOf(resource, config.codecFactory)
+    val r = Http.PATCH(resourcePath).withJson(toJson(resource))
     convert[Resource](send(r, requestFilter))
   }
 
@@ -285,7 +292,7 @@ class URLConnectionClient(address: ServerAddress, config: URLConnectionClientCon
       resource: Resource,
       requestFilter: Request => Request
   ): OperationResponse = {
-    val r = Http.PATCH(resourcePath).withJsonOf(resource, config.codecFactory)
+    val r = Http.PATCH(resourcePath).withJson(toJson(resource))
     convert[OperationResponse](send(r, requestFilter))
   }
 

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/client/URLConnectionClient.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/client/URLConnectionClient.scala
@@ -122,9 +122,7 @@ class URLConnectionClient(address: ServerAddress, config: URLConnectionClientCon
     }
 
     // TODO: For supporting streaming read, we need to extend HttpMessage class
-    val responseContentBytes = IO.readFully(is) { bytes =>
-      bytes
-    }
+    val responseContentBytes = IO.readFully(is)
     response.withContent(responseContentBytes)
   }
 

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/client/URLConnectionClient.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/client/URLConnectionClient.scala
@@ -1,0 +1,217 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.http.client
+
+import java.io.{InputStream, OutputStream}
+import java.net.HttpURLConnection
+import java.util.concurrent.TimeUnit
+
+import wvlet.airframe.codec.{MessageCodec, MessageCodecFactory}
+import wvlet.airframe.control.Retry.RetryContext
+import wvlet.airframe.control.{Control, IO}
+import wvlet.airframe.http.HttpMessage.{Request, Response}
+import wvlet.airframe.http._
+import wvlet.airframe.http.router.HttpResponseCodec
+
+import scala.concurrent.duration.Duration
+import scala.jdk.CollectionConverters._
+import scala.reflect.runtime.universe.TypeTag
+
+case class URLConnectionClientConfig(
+    requestFilter: Request => Request = identity,
+    connectionFilter: HttpURLConnection => HttpURLConnection = identity,
+    readTimeout: Duration = Duration(90, TimeUnit.SECONDS),
+    connectTimeout: Duration = Duration(90, TimeUnit.SECONDS),
+    retryContext: RetryContext = HttpClient.defaultHttpClientRetry[Request, Response],
+    codecFactory: MessageCodecFactory = MessageCodecFactory.defaultFactoryForJSON,
+    followRedirect: Boolean = true
+)
+
+/**
+  *
+ */
+class URLConnectionClient(address: ServerAddress, config: URLConnectionClientConfig)
+    extends HttpSyncClient[Request, Response] {
+
+  override def send(
+      req: Request,
+      requestFilter: Request => Request
+  ): Response = {
+
+    // Apply the default filter first and then the given custom filter
+    val request = requestFilter(config.requestFilter(req))
+
+    val url = s"${address.uri}${request.uri}"
+
+    config.retryContext.run {
+      val conn0: HttpURLConnection = new java.net.URL(url).openConnection().asInstanceOf[HttpURLConnection]
+      conn0.setRequestMethod(request.method)
+      for (e <- request.header.entries) {
+        conn0.setRequestProperty(e.key, e.value)
+      }
+      conn0.setDoInput(true)
+      conn0.setReadTimeout(config.readTimeout.toMillis.toInt)
+      conn0.setConnectTimeout(config.connectTimeout.toMillis.toInt)
+      conn0.setInstanceFollowRedirects(config.followRedirect)
+
+      val conn    = config.connectionFilter(conn0)
+      val content = req.contentBytes
+      if (content.nonEmpty) {
+        conn.setDoOutput(true)
+        Control.withResource(conn.getOutputStream()) { out: OutputStream =>
+          out.write(content)
+          out.flush()
+        }
+      }
+
+      Control.withResource(conn.getInputStream()) { in: InputStream =>
+        val status = HttpStatus.ofCode(conn.getResponseCode)
+
+        val header = HttpMultiMap.newBuilder
+        for ((k, vv) <- conn.getHeaderFields().asScala if k != null; v <- vv.asScala) {
+          header += k -> v
+        }
+        // TODO: Support stream?
+        val responseContentBytes = IO.readFully(in) { bytes =>
+          bytes
+        }
+
+        val response = Http.response(status).withHeader(header.result()).withContent(responseContentBytes)
+        response
+      }
+    }
+  }
+
+  override def sendSafe(
+      req: Request,
+      requestFilter: Request => Request
+  ): Response = {
+    try {
+      send(req, requestFilter)
+    } catch {
+      case e: HttpClientException =>
+        e.response.toHttpResponse
+    }
+  }
+
+  private val responseCodec = new HttpResponseCodec[Response]
+
+  private def convert[A: TypeTag](response: Response): A = {
+    if (implicitly[TypeTag[A]] == scala.reflect.runtime.universe.typeTag[Response]) {
+      // Can return the response as is
+      response.asInstanceOf[A]
+    } else {
+      // Need a conversion
+      val codec   = MessageCodec.of[A]
+      val msgpack = responseCodec.toMsgPack(response)
+      codec.unpack(msgpack)
+    }
+  }
+
+  override def get[Resource: TypeTag](
+      resourcePath: String,
+      requestFilter: Request => Request
+  ): Resource = {
+    convert[Resource](send(Http.request(resourcePath), requestFilter))
+  }
+
+  override def getOps[
+      Resource: TypeTag,
+      OperationResponse: TypeTag
+  ](
+      resourcePath: String,
+      resource: Resource,
+      requestFilter: Request => Request
+  ): OperationResponse = ???
+
+  override def list[OperationResponse: TypeTag](
+      resourcePath: String,
+      requestFilter: Request => Request
+  ): OperationResponse = {
+    convert[OperationResponse](send(Http.request(resourcePath), requestFilter))
+  }
+
+  override def post[Resource: TypeTag](
+      resourcePath: String,
+      resource: Resource,
+      requestFilter: Request => Request
+  ): Resource = ???
+
+  override def postRaw[Resource: TypeTag](
+      resourcePath: String,
+      resource: Resource,
+      requestFilter: Request => Request
+  ): Response = ???
+  override def postOps[
+      Resource: TypeTag,
+      OperationResponse: TypeTag
+  ](
+      resourcePath: String,
+      resource: Resource,
+      requestFilter: Request => Request
+  ): OperationResponse = ???
+  override def put[Resource: TypeTag](
+      resourcePath: String,
+      resource: Resource,
+      requestFilter: Request => Request
+  ): Resource = ???
+  override def putRaw[Resource: TypeTag](
+      resourcePath: String,
+      resource: Resource,
+      requestFilter: Request => Request
+  ): Response = ???
+  override def putOps[
+      Resource: TypeTag,
+      OperationResponse: TypeTag
+  ](
+      resourcePath: String,
+      resource: Resource,
+      requestFilter: Request => Request
+  ): OperationResponse = ???
+  override def delete[OperationResponse: TypeTag](
+      resourcePath: String,
+      requestFilter: Request => Request
+  ): OperationResponse = ???
+  override def deleteRaw(
+      resourcePath: String,
+      requestFilter: Request => Request
+  ): Response = ???
+  override def deleteOps[
+      Resource: TypeTag,
+      OperationResponse: TypeTag
+  ](
+      resourcePath: String,
+      resource: Resource,
+      requestFilter: Request => Request
+  ): OperationResponse = ???
+  override def patch[Resource: TypeTag](
+      resourcePath: String,
+      resource: Resource,
+      requestFilter: Request => Request
+  ): Resource = ???
+  override def patchRaw[Resource: TypeTag](
+      resourcePath: String,
+      resource: Resource,
+      requestFilter: Request => Request
+  ): Response = ???
+  override def patchOps[
+      Resource: TypeTag,
+      OperationResponse: TypeTag
+  ](
+      resourcePath: String,
+      resource: Resource,
+      requestFilter: Request => Request
+  ): OperationResponse       = ???
+  override def close(): Unit = ???
+}

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/client/URLConnectionClient.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/client/URLConnectionClient.scala
@@ -94,9 +94,8 @@ class URLConnectionClient(address: ServerAddress, config: URLConnectionClientCon
         for ((k, vv) <- conn.getHeaderFields().asScala if k != null; v <- vv.asScala) {
           h += k -> v
         }
-        val header = h.result()
-
-        val is = header.get(HttpHeader.ContentEncoding).map(_.toLowerCase) match {
+        val response = Http.response(status).withHeader(h.result())
+        val is = response.contentEncoding.map(_.toLowerCase) match {
           case _ if in == null => in
           case Some("gzip")    => new GZIPInputStream(in)
           case Some("deflate") => new InflaterInputStream(in)
@@ -109,8 +108,7 @@ class URLConnectionClient(address: ServerAddress, config: URLConnectionClientCon
         val responseContentBytes = IO.readFully(is) { bytes =>
           bytes
         }
-        val response = Http.response(status).withHeader(header).withContent(responseContentBytes)
-        response
+        response.withContent(responseContentBytes)
       }
     }
   }

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/client/URLConnectionClient.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/client/URLConnectionClient.scala
@@ -65,7 +65,13 @@ class URLConnectionClient(address: ServerAddress, config: URLConnectionClientCon
       }
       conn0.setDoInput(true)
 
-      def timeoutMillis(d: Duration): Int = if (d.isFinite()) d.toMillis.toInt else 0
+      def timeoutMillis(d: Duration): Int = {
+        if (d.isFinite) {
+          d.toMillis.toInt
+        } else {
+          0
+        }
+      }
       conn0.setReadTimeout(timeoutMillis(config.readTimeout))
       conn0.setConnectTimeout(timeoutMillis(config.connectTimeout))
       conn0.setInstanceFollowRedirects(config.followRedirect)

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/client/URLConnectionClientBackend.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/client/URLConnectionClientBackend.scala
@@ -18,7 +18,7 @@ import wvlet.airframe.http.{HttpClientBackend, HttpClientConfig, HttpSyncClient,
 /**
   *
  */
-object DefaultHttpClientBackend extends HttpClientBackend {
+object URLConnectionClientBackend extends HttpClientBackend {
   def newSyncClient(serverAddress: String, clientConfig: HttpClientConfig): HttpSyncClient[Request, Response] = {
     new URLConnectionClient(
       ServerAddress(serverAddress),

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/client/URLConnectionClientTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/client/URLConnectionClientTest.scala
@@ -12,27 +12,36 @@
  * limitations under the License.
  */
 package wvlet.airframe.http.client
-import wvlet.airframe.control.Control
-import wvlet.airframe.http.{Http, HttpStatus}
+import wvlet.airframe.Design
+import wvlet.airframe.http.HttpMessage.{Request, Response}
+import wvlet.airframe.http.{Http, HttpStatus, HttpSyncClient}
 import wvlet.airspec.AirSpec
 
 /**
   *
  */
-class URLConnectionClientTest extends AirSpec {
+object URLConnectionClientTest extends AirSpec {
 
-  test("Create an http client") {
-    Control.withResource(Http.client.newSyncClient("https://wvlet.org")) { client =>
-      val resp = client.sendSafe(Http.GET("/airframe/index.html"))
-      debug(resp)
-      resp.status shouldBe HttpStatus.Ok_200
-      debug(resp.contentString)
+  type Client = HttpSyncClient[Request, Response]
 
-      val errorResp = client.sendSafe(Http.GET("/non-existing-path"))
-      debug(errorResp)
-      errorResp.status shouldBe HttpStatus.NotFound_404
-      debug(errorResp.contentString)
-    }
+  override protected def design: Design =
+    Design.newDesign
+      .bind[Client].toInstance(
+        Http.client.newSyncClient("https://wvlet.org")
+      )
+
+  test("Read content with 200") { client: Client =>
+    val resp = client.sendSafe(Http.GET("/airframe/index.html"))
+    debug(resp)
+    resp.status shouldBe HttpStatus.Ok_200
+    debug(resp.contentString)
+  }
+
+  test("Handle 404 (Not Found)") { client: Client =>
+    val errorResp = client.sendSafe(Http.GET("/non-existing-path"))
+    debug(errorResp)
+    errorResp.status shouldBe HttpStatus.NotFound_404
+    debug(errorResp.contentString)
   }
 
 }

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/client/URLConnectionClientTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/client/URLConnectionClientTest.scala
@@ -77,6 +77,11 @@ object URLConnectionClientTest extends AirSpec {
 
     }
 
+    test("getOps") {
+      val m = client.getOps[Person, Map[String, Any]]("/get", p)
+      m("args") shouldBe Map("id" -> "1", "name" -> "leo")
+    }
+
     test("xxxOps") {
       check(client.postOps[Person, Map[String, Any]]("/post", p))
       check(client.putOps[Person, Map[String, Any]]("/put", p))

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/client/URLConnectionClientTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/client/URLConnectionClientTest.scala
@@ -23,10 +23,16 @@ class URLConnectionClientTest extends AirSpec {
 
   test("Create an http client") {
     Control.withResource(Http.client.newSyncClient("https://wvlet.org")) { client =>
-      val resp = client.send(Http.GET("/airframe/index.html"))
+      val resp = client.sendSafe(Http.GET("/airframe/index.html"))
       debug(resp)
       resp.status shouldBe HttpStatus.Ok_200
       debug(resp.contentString)
+
+      val errorResp = client.sendSafe(Http.GET("/non-existing-path"))
+      debug(errorResp)
+      errorResp.status shouldBe HttpStatus.NotFound_404
+      debug(errorResp.contentString)
     }
   }
+
 }

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/client/URLConnectionClientTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/client/URLConnectionClientTest.scala
@@ -13,35 +13,87 @@
  */
 package wvlet.airframe.http.client
 import wvlet.airframe.Design
-import wvlet.airframe.http.HttpMessage.{Request, Response}
-import wvlet.airframe.http.{Http, HttpStatus, HttpSyncClient}
+import wvlet.airframe.codec.MessageCodec
+import wvlet.airframe.control.Retry.MaxRetryException
+import wvlet.airframe.http.Http.SyncClient
+import wvlet.airframe.http.HttpMessage.Response
+import wvlet.airframe.http.{Http, HttpStatus}
 import wvlet.airspec.AirSpec
 
 /**
   *
  */
 object URLConnectionClientTest extends AirSpec {
-
-  type Client = HttpSyncClient[Request, Response]
-
   override protected def design: Design =
     Design.newDesign
-      .bind[Client].toInstance(
-        Http.client.newSyncClient("https://wvlet.org")
+      .bind[SyncClient].toInstance(
+        Http.client
+          .withRetryContext(_.withMaxRetry(1))
+          .newSyncClient("https://httpbin.org/") // Using a public REST test server
       )
 
-  test("Read content with 200") { client: Client =>
-    val resp = client.sendSafe(Http.GET("/airframe/index.html"))
-    debug(resp)
-    resp.status shouldBe HttpStatus.Ok_200
-    debug(resp.contentString)
+  case class Person(id: Int, name: String)
+  val p     = Person(1, "leo")
+  val pJson = MessageCodec.of[Person].toJson(p)
+
+  private def check(r: Response): Unit = {
+    r.status shouldBe HttpStatus.Ok_200
+    val m = MessageCodec.of[Map[String, Any]].fromJson(r.contentString)
+    check(m)
   }
 
-  test("Handle 404 (Not Found)") { client: Client =>
-    val errorResp = client.sendSafe(Http.GET("/non-existing-path"))
-    debug(errorResp)
-    errorResp.status shouldBe HttpStatus.NotFound_404
-    debug(errorResp.contentString)
+  private def check(m: Map[String, Any]): Unit = {
+    m("json") shouldBe Map("id" -> 1, "name" -> "leo")
   }
 
+  test("sync client") { client: SyncClient =>
+    test("Read content with 200") {
+      val resp = client.sendSafe(Http.GET("/get"))
+      debug(resp)
+      resp.status shouldBe HttpStatus.Ok_200
+      debug(resp.contentString)
+    }
+
+    test("user-agent") {
+      val resp = client.get[Map[String, String]]("/user-agent", _.withUserAgent("airframe-http"))
+      resp.get("user-agent") shouldBe Some("airframe-http")
+    }
+
+    test("delete") {
+      client.delete[String]("/delete")
+      val resp = client.deleteRaw("/delete")
+      resp.status shouldBe HttpStatus.Ok_200
+    }
+
+    test("patch") {
+      // URLConnection doesn't support patch, so we need to use POST endpoint + X-HTTP-Method-Override header
+      check(client.patchRaw[Person]("/post", p))
+      check(client.patchOps[Person, Map[String, Any]]("/post", p))
+    }
+
+    test("xxxRaw") {
+      check(client.postRaw[Person]("/post", p))
+      check(client.putRaw[Person]("/put", p))
+
+    }
+
+    test("xxxOps") {
+      check(client.postOps[Person, Map[String, Any]]("/post", p))
+      check(client.putOps[Person, Map[String, Any]]("/put", p))
+    }
+
+    test("Handle 404 (Not Found)") {
+      val errorResp = client.sendSafe(Http.GET("/status/404"))
+      debug(errorResp)
+      errorResp.status shouldBe HttpStatus.NotFound_404
+      debug(errorResp.contentString)
+    }
+
+    test("Handle 5xx retry") {
+      warn(s"Run 5xx retry test")
+      intercept[MaxRetryException] {
+        client.get[String]("/status/500")
+      }
+    }
+  }
 }

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/client/URLConnectionClientTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/client/URLConnectionClientTest.scala
@@ -11,20 +11,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.airframe.http
+package wvlet.airframe.http.client
+import wvlet.airframe.control.Control
+import wvlet.airframe.http.{Http, HttpStatus}
+import wvlet.airspec.AirSpec
 
 /**
-  * Scala.js specific implementation
-  */
-private object Compat extends CompatApi {
-  override def urlEncode(s: String): String = {
-    scala.scalajs.js.URIUtils.encodeURI(s)
+  *
+ */
+class URLConnectionClientTest extends AirSpec {
+
+  test("Create an http client") {
+    Control.withResource(Http.client.newSyncClient("https://wvlet.org")) { client =>
+      val resp = client.send(Http.GET("/airframe/index.html"))
+      debug(resp)
+      resp.status shouldBe HttpStatus.Ok_200
+      debug(resp.contentString)
+    }
   }
-  override def newSyncClient(
-      serverAddress: String,
-      config: HttpClientConfig
-  ): HttpSyncClient[
-    HttpMessage.Request,
-    HttpMessage.Response
-  ] = ???
 }

--- a/airframe-http/src/main/scala/wvlet/airframe/http/CompatApi.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/CompatApi.scala
@@ -12,10 +12,12 @@
  * limitations under the License.
  */
 package wvlet.airframe.http
+import wvlet.airframe.http.HttpMessage.{Request, Response}
 
 /**
   * An interface for using different implementation betweeen Scala JVM and Scala.js
   */
 trait CompatApi {
   def urlEncode(s: String): String
+  def newSyncClient(serverAddress: String, config: HttpClientConfig): HttpSyncClient[Request, Response]
 }

--- a/airframe-http/src/main/scala/wvlet/airframe/http/CompatApi.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/CompatApi.scala
@@ -12,9 +12,6 @@
  * limitations under the License.
  */
 package wvlet.airframe.http
-import wvlet.airframe.http.HttpMessage.{Request, Response}
-
-import scala.concurrent.Future
 
 /**
   * An interface for using different implementation betweeen Scala JVM and Scala.js

--- a/airframe-http/src/main/scala/wvlet/airframe/http/Http.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/Http.scala
@@ -13,10 +13,20 @@
  */
 package wvlet.airframe.http
 import wvlet.airframe.codec.MessageCodecFactory
+import wvlet.airframe.http.HttpMessage.{Request, Response}
 import wvlet.airframe.http.impl.HttpMacros
+
+import scala.concurrent.Future
 
 object Http {
 
+  // Aliases for http clients using standard HttpMessage.Request/Response
+  type SyncClient  = HttpSyncClient[Request, Response]
+  type AsyncClient = HttpClient[Future, Request, Response]
+
+  /**
+    * An entry point for building a new HttpClient
+    */
   def client: HttpClientConfig = HttpClientConfig()
 
   /**

--- a/airframe-http/src/main/scala/wvlet/airframe/http/Http.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/Http.scala
@@ -17,6 +17,8 @@ import wvlet.airframe.http.impl.HttpMacros
 
 object Http {
 
+  def client: HttpClientConfig = HttpClientConfig()
+
   /**
     * Create a new request
     */

--- a/airframe-http/src/main/scala/wvlet/airframe/http/HttpClientBackend.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/HttpClientBackend.scala
@@ -12,16 +12,12 @@
  * limitations under the License.
  */
 package wvlet.airframe.http
-import java.net.URLEncoder
-
-import wvlet.airframe.http.client.{DefaultHttpClientBackend, URLConnectionClient, URLConnectionClientConfig}
+import wvlet.airframe.http.HttpMessage.{Request, Response}
 
 /**
   *
   */
-object Compat extends CompatApi {
-  override def urlEncode(s: String): String = {
-    URLEncoder.encode(s, "UTF-8")
-  }
-  override def defaultHttpClientBackend: HttpClientBackend = DefaultHttpClientBackend
+trait HttpClientBackend {
+  def newSyncClient(severAddress: String, clientConfig: HttpClientConfig): HttpSyncClient[Request, Response]
+  // def newClient(serverAddress: ServerAddress, clientConfig: HttpClientConfig): HttpClient[F, Request, Response] = ???
 }

--- a/airframe-http/src/main/scala/wvlet/airframe/http/HttpClientConfig.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/HttpClientConfig.scala
@@ -34,6 +34,6 @@ case class HttpClientConfig(
     this.copy(requestFilter = newRequestFilter)
   def withCodecFactory(newCodecFactory: MessageCodecFactory): HttpClientConfig =
     this.copy(codecFactory = newCodecFactory)
-  def withRetryContext(newRetryContext: RetryContext): HttpClientConfig =
-    this.copy(retryContext = newRetryContext)
+  def withRetryContext(filter: RetryContext => RetryContext): HttpClientConfig =
+    this.copy(retryContext = filter(retryContext))
 }

--- a/airframe-http/src/main/scala/wvlet/airframe/http/HttpClientConfig.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/HttpClientConfig.scala
@@ -20,18 +20,20 @@ import wvlet.airframe.http.HttpMessage.{Request, Response}
   *
  */
 case class HttpClientConfig(
+    backend: HttpClientBackend = Compat.defaultHttpClientBackend,
     requestFilter: Request => Request = identity,
     retryContext: RetryContext = HttpClient.defaultHttpClientRetry[Request, Response],
     codecFactory: MessageCodecFactory = MessageCodecFactory.defaultFactoryForJSON
 ) {
   def newSyncClient(serverAddress: String): HttpSyncClient[Request, Response] =
-    Compat.newSyncClient(serverAddress, this)
+    backend.newSyncClient(serverAddress, this)
 
+  def withBackend(newBackend: HttpClientBackend): HttpClientConfig =
+    this.copy(backend = newBackend)
   def withRequestFilter(newRequestFilter: Request => Request): HttpClientConfig =
     this.copy(requestFilter = newRequestFilter)
   def withCodecFactory(newCodecFactory: MessageCodecFactory): HttpClientConfig =
     this.copy(codecFactory = newCodecFactory)
-
   def withRetryContext(newRetryContext: RetryContext): HttpClientConfig =
     this.copy(retryContext = newRetryContext)
 }

--- a/airframe-http/src/main/scala/wvlet/airframe/http/HttpClientConfig.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/HttpClientConfig.scala
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.http
+import wvlet.airframe.codec.MessageCodecFactory
+import wvlet.airframe.control.Retry.RetryContext
+import wvlet.airframe.http.HttpMessage.{Request, Response}
+
+/**
+  *
+ */
+case class HttpClientConfig(
+    requestFilter: Request => Request = identity,
+    retryContext: RetryContext = HttpClient.defaultHttpClientRetry[Request, Response],
+    codecFactory: MessageCodecFactory = MessageCodecFactory.defaultFactoryForJSON
+) {
+  def newSyncClient(serverAddress: String): HttpSyncClient[Request, Response] =
+    Compat.newSyncClient(serverAddress, this)
+
+  def withRequestFilter(newRequestFilter: Request => Request): HttpClientConfig =
+    this.copy(requestFilter = newRequestFilter)
+  def withCodecFactory(newCodecFactory: MessageCodecFactory): HttpClientConfig =
+    this.copy(codecFactory = newCodecFactory)
+
+  def withRetryContext(newRetryContext: RetryContext): HttpClientConfig =
+    this.copy(retryContext = newRetryContext)
+}

--- a/airframe-http/src/main/scala/wvlet/airframe/http/HttpMessage.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/HttpMessage.scala
@@ -174,8 +174,19 @@ object HttpMessage {
     override def toContentBytes: Array[Byte] = content
   }
 
-  def stringMessage(content: String): StringMessage            = StringMessage(content)
-  def byteArrayMessage(content: Array[Byte]): ByteArrayMessage = ByteArrayMessage(content)
+  def stringMessage(content: String): Message = {
+    if (content == null || content.isEmpty) {
+      EmptyMessage
+    } else {
+      StringMessage(content)
+    }
+  }
+  def byteArrayMessage(content: Array[Byte]): Message = {
+    if (content == null || content.isEmpty)
+      EmptyMessage
+    else
+      ByteArrayMessage(content)
+  }
 
   case class Request(
       method: String = HttpMethod.GET,

--- a/airframe-http/src/main/scala/wvlet/airframe/http/HttpMessage.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/HttpMessage.scala
@@ -28,12 +28,12 @@ trait HttpMessage[Raw] {
   def getHeader(key: String): Option[String] = header.get(key)
   def getAllHeader(key: String): Seq[String] = header.getAll(key)
 
-  def allow: Option[String]         = header.get(HttpHeader.Allow)
-  def accept: Seq[String]           = Http.parseAcceptHeader(header.get(HttpHeader.Accept))
-  def authorization: Option[String] = header.get(HttpHeader.Authorization)
-  def cacheControl: Option[String]  = header.get(HttpHeader.CacheControl)
-  def contentType: Option[String] =
-    header.get(HttpHeader.ContentType).orElse(header.get("content-type"))
+  def allow: Option[String]           = header.get(HttpHeader.Allow)
+  def accept: Seq[String]             = Http.parseAcceptHeader(header.get(HttpHeader.Accept))
+  def authorization: Option[String]   = header.get(HttpHeader.Authorization)
+  def cacheControl: Option[String]    = header.get(HttpHeader.CacheControl)
+  def contentType: Option[String]     = header.get(HttpHeader.ContentType)
+  def contentEncoding: Option[String] = header.get(HttpHeader.ContentEncoding)
   def contentLength: Option[Long]     = header.get(HttpHeader.ContentLength).map(_.toLong)
   def date: Option[String]            = header.get(HttpHeader.Date)
   def expires: Option[String]         = header.get(HttpHeader.Expires)

--- a/docs/airframe-http.md
+++ b/docs/airframe-http.md
@@ -3,7 +3,7 @@ id: airframe-http
 title: airframe-http: Web Service IDL
 ---
 
-airframe-http is a library for creating HTTP web servers at ease. airframe-http-finagle is an extention of airframe-http to use Finagle as a backend HTTP server.
+airframe-http is a library for creating HTTP web servers at ease. airframe-http-finagle is an extension of airframe-http to use Finagle as a backend HTTP server.
 
 - Blog article: [Airframe HTTP: Building Low-Friction Web Services Over Finagle](https://medium.com/@taroleo/airframe-http-a-minimalist-approach-for-building-web-services-in-scala-743ba41af7f)
 
@@ -406,3 +406,47 @@ The generated HTTP access log files can be processed in Fluentd. For example, if
   time_key time
 </source>
 ```
+
+
+# HTTP Clients
+
+airframe-http has several HTTP client implementations (FinagleClient, OkHttp client, URLConnection client, etc.).    
+
+## Simple Http Client (No extra dependency) 
+
+```scala
+import wvlet.airframe.http.Http 
+
+// Creating a URLConnection based client 
+val client = Http.client.newSyncClient("http://localhost:8080")
+val response = client.sendSafe(Http.request("/v1/info")) 
+// Use client.send(Request) for throwing HttpClientException upon 4xx, 5xx errors
+```
+
+Note: URLConnection-based client cannot send PATCH requests due to [a bug of JDK](https://stackoverflow.com/questions/25163131/httpurlconnection-invalid-http-method-patch)
+
+
+## Finagle Http Client
+```scala
+import wvlet.airframe.http.finagle.Finagle
+
+// Asynchronous HTTP client backed by Finagle (Using twitter-util Future) 
+Finagle.client.newClient("http://localhost:8080")
+
+// a Finagle-based sync client 
+Finagle.client.newSyncClient(host_name)   
+```
+
+## OkHttp Client
+
+
+```scala
+libraryDependencies += "org.wvlet.airframe" %% "airframe-http-okhttp" % (version)
+```
+
+```scala
+// Create an OkHttp-based sync http client
+OkHttpClient.newClient(host_name, config...)
+```
+
+


### PR DESCRIPTION
This PR is for adding a handy http client implementation based on java.net.URLConnection, which doesn't require extra dependencies.

- [x] Add Http client implementation using URLConnection
- [x] Add URLConnection specific exception handling
- [x] Add test cases
- [x] Add factory methods
- [x] Add http client documentations

If we can use jdk11, https://openjdk.java.net/groups/net/httpclient/intro.html seems better. 
