### PR TITLE
airframe-http: #1128 Add Router.verifyRoutes to check duplicated endpoints

### DIFF
--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/Router.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/Router.scala
@@ -84,6 +84,14 @@ case class Router(
   def findRoute[Req: HttpRequestAdapter](request: Req): Option[RouteMatch] = routeMatcher.findRoute(request)
 
   /**
+    * Call this method to verify duplicated routes in an early phase
+    */
+  def verifyRoutes: Unit = {
+    // Instantiate the route mappings to check duplicate routes
+    routeMatcher
+  }
+
+  /**
     * Add methods annotated with @Endpoint to the routing table
     */
   def add[Controller]: Router = macro RouterMacros.add[Controller]
@@ -127,7 +135,7 @@ case class Router(
     val endpointOpt = controllerSurface.findAnnotationOf[Endpoint]
     val rpcOpt      = controllerSurface.findAnnotationOf[RPC]
 
-    val newRoutes: Seq[Route] = {
+    val newRoutes: Seq[ControllerRoute] = {
       (endpointOpt, rpcOpt) match {
         case (Some(endpoint), Some(rpcOpt)) =>
           throw new IllegalArgumentException(
@@ -159,7 +167,7 @@ case class Router(
           } else {
             s"${rpc.path()}/${serviceFullName}"
           }
-          controllerMethodSurfaces
+          val routes = controllerMethodSurfaces
             .filter(_.isPublic)
             .map { m => (m, m.findAnnotationOf[RPC]) }
             .collect {
@@ -169,6 +177,7 @@ case class Router(
               case (m: ReflectMethodSurface, None) =>
                 ControllerRoute(rpcInterfaceCls, controllerSurface, HttpMethod.POST, prefixPath + s"/${m.name}", m)
             }
+          routes
       }
     }
 

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/codegen/RouteScanner.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/codegen/RouteScanner.scala
@@ -83,6 +83,8 @@ object RouteScanner extends LogSupport {
         router = router.addInternal(s, methods)
       }
     }
+    // Check whether the route is valid or not
+    router.verifyRoutes
     router
   }
 

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/RPCTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/RPCTest.scala
@@ -71,4 +71,18 @@ object RPCTest extends AirSpec {
     m.get.method shouldBe HttpMethod.POST
     m.get.methodSurface.name shouldBe "hello"
   }
+
+  @RPC
+  trait RPCOverload {
+    def hello: String
+    def hello(s: String): String
+  }
+
+  test("Should detect RPC method overload") {
+    val r = Router.add[RPCOverload]
+    val e = intercept[IllegalArgumentException] {
+      r.verifyRoutes
+    }
+    e.getMessage.contains("RPCOverload/hello")
+  }
 }


### PR DESCRIPTION
Because of the complexity of mapping RPC functions to HTTP endpoints, we should avoid using method overload (e.g., def m(p1), def m(p1, p2,...)). The current behavior is IllegalArgumentException is thrown when Router is used for building HTTP filters.

This PR adds Router.verifyRoutes so that we can manually find the presence of method overload early. 