### PR TITLE
airframe-http: Various client fixes

### DIFF
--- a/airframe-http-finagle/src/main/scala/wvlet/airframe/http/finagle/FinagleClient.scala
+++ b/airframe-http-finagle/src/main/scala/wvlet/airframe/http/finagle/FinagleClient.scala
@@ -199,8 +199,14 @@ class FinagleClient(address: ServerAddress, config: FinagleClientConfig)
             codec.unpack(msgpack)
           } catch {
             case NonFatal(e) =>
-              warn(s"Failed to parse the response body (${r}): ${r.contentString}")
-              throw e
+              val msg = s"Failed to parse the response body ${r}: ${r.contentString}"
+              warn(msg)
+              throw new HttpClientException(
+                r,
+                HttpStatus.ofCode(r.statusCode),
+                msg,
+                e
+              )
           }
         }
     }

--- a/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/FinagleClientTest.scala
+++ b/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/FinagleClientTest.scala
@@ -15,6 +15,7 @@ package wvlet.airframe.http.finagle
 
 import com.twitter.finagle.http.{Request, Response, Status}
 import com.twitter.util.Await
+import wvlet.airframe.Design
 import wvlet.airframe.control.Control.withResource
 import wvlet.airframe.http._
 import wvlet.airspec.AirSpec
@@ -40,6 +41,11 @@ trait FinagleClientTestApi extends LogSupport {
   @Endpoint(method = HttpMethod.GET, path = "/user/:id")
   def get(id: Int, request: Request): User = {
     User(id, "leo", getRequestId(request))
+  }
+
+  @Endpoint(method = HttpMethod.GET, path = "/user/:id/invalid")
+  def getInvalidUser(id: Int, request: Request): HttpMessage.Response = {
+    Http.response(HttpStatus.Ok_200).withJson("""{"id":"abc","user":"NA","requestId":"xxx"}""")
   }
 
   @Endpoint(method = HttpMethod.GET, path = "/user/info")
@@ -99,137 +105,139 @@ trait FinagleClientTestApi extends LogSupport {
 /**
   */
 class FinagleClientTest extends AirSpec {
-  val r = Router.add[FinagleClientTestApi]
-  val d = finagleDefaultDesign
-    .bind[FinagleServerConfig].toInstance(
-      FinagleServerConfig(name = "test-server", router = r)
-    )
-    .noLifeCycleLogging
+  private val r = Router.add[FinagleClientTestApi]
 
-  def `create client`: Unit = {
+  override protected def design: Design =
+    Finagle.server
+      .withName("test-server")
+      .withRouter(r)
+      .designWithSyncClient
+
+  def `convert HTTP responses into objects`(client: FinagleSyncClient): Unit = {
     def addRequestId(request: Request): Request = {
       request.headerMap.put("X-Request-Id", "10")
       request
     }
+    // Sending an implementation specific Request type
+    val ret = client.send(Request("/")).contentString
+    ret shouldBe "Ok"
 
-    d.build[FinagleServer] { server =>
-      withResource(FinagleClient.newSyncClient(server.localAddress)) { client =>
-        // Sending an implementation specific Request type
-        val ret = client.send(Request("/")).contentString
-        ret shouldBe "Ok"
+    // Using HTTP request wrappers
+    client.get[User]("/user/1") shouldBe User(1, "leo", "N/A")
+    client.getResource[UserRequest, User]("/user/info", UserRequest(2, "kai")) shouldBe User(2, "kai", "N/A")
+    client.getResource[UserRequest, User]("/user/info2", UserRequest(2, "kai")) shouldBe User(2, "kai", "N/A")
+    client.list[Seq[User]]("/user") shouldBe Seq(User(1, "leo", "N/A"))
 
-        // Using HTTP request wrappers
-        client.get[User]("/user/1") shouldBe User(1, "leo", "N/A")
-        client.getResource[UserRequest, User]("/user/info", UserRequest(2, "kai")) shouldBe User(2, "kai", "N/A")
-        client.getResource[UserRequest, User]("/user/info2", UserRequest(2, "kai")) shouldBe User(2, "kai", "N/A")
-        client.list[Seq[User]]("/user") shouldBe Seq(User(1, "leo", "N/A"))
+    client.post[User]("/user", User(2, "yui", "N/A")) shouldBe User(2, "yui", "N/A")
+    client.postOps[User, User]("/user", User(2, "yui", "N/A")) shouldBe User(2, "yui", "N/A")
 
-        client.post[User]("/user", User(2, "yui", "N/A")) shouldBe User(2, "yui", "N/A")
-        client.postOps[User, User]("/user", User(2, "yui", "N/A")) shouldBe User(2, "yui", "N/A")
+    client.put[User]("/user", User(10, "aina", "N/A")) shouldBe User(10, "aina", "N/A")
+    client.putOps[User, User]("/user", User(10, "aina", "N/A")) shouldBe User(10, "aina", "N/A")
 
-        client.put[User]("/user", User(10, "aina", "N/A")) shouldBe User(10, "aina", "N/A")
-        client.putOps[User, User]("/user", User(10, "aina", "N/A")) shouldBe User(10, "aina", "N/A")
+    client.patch[User]("/user", User(20, "joy", "N/A")) shouldBe User(20, "joy", "N/A")
+    client.patchOps[User, User]("/user", User(20, "joy", "N/A")) shouldBe User(20, "joy", "N/A")
 
-        client.patch[User]("/user", User(20, "joy", "N/A")) shouldBe User(20, "joy", "N/A")
-        client.patchOps[User, User]("/user", User(20, "joy", "N/A")) shouldBe User(20, "joy", "N/A")
+    client.delete[User]("/user/1") shouldBe User(1, "xxx", "N/A")
+    client.deleteOps[DeleteRequestBody, User]("/user/1", DeleteRequestBody(true)) shouldBe User(1, "xxx", "N/A")
 
-        client.delete[User]("/user/1") shouldBe User(1, "xxx", "N/A")
-        client.deleteOps[DeleteRequestBody, User]("/user/1", DeleteRequestBody(true)) shouldBe User(1, "xxx", "N/A")
+    // application/x-msgpack test
+    client.get[User]("/user/1", { r => r.accept = "application/x-msgpack"; r }) shouldBe User(1, "leo", "N/A")
+    client.post[User]("/user", User(2, "yui", "N/A"), { r => r.accept = "application/x-msgpack"; r }) shouldBe User(
+      2,
+      "yui",
+      "N/A"
+    )
 
-        // application/x-msgpack test
-        client.get[User]("/user/1", { r => r.accept = "application/x-msgpack"; r }) shouldBe User(1, "leo", "N/A")
-        client.post[User]("/user", User(2, "yui", "N/A"), { r => r.accept = "application/x-msgpack"; r }) shouldBe User(
-          2,
-          "yui",
-          "N/A"
-        )
+    // Get a response as is
+    client.get[Response]("/response").contentString shouldBe "raw response"
 
-        // Get a response as is
-        client.get[Response]("/response").contentString shouldBe "raw response"
+    // Using a custom HTTP header
+    client.get[User]("/user/1", addRequestId) shouldBe User(1, "leo", "10")
+    client.getResource[UserRequest, User]("/user/info", UserRequest(2, "kai"), addRequestId) shouldBe User(
+      2,
+      "kai",
+      "10"
+    )
+    client.getResource[UserRequest, User]("/user/info2", UserRequest(2, "kai"), addRequestId) shouldBe User(
+      2,
+      "kai",
+      "10"
+    )
 
-        // Using a custom HTTP header
-        client.get[User]("/user/1", addRequestId) shouldBe User(1, "leo", "10")
-        client.getResource[UserRequest, User]("/user/info", UserRequest(2, "kai"), addRequestId) shouldBe User(
-          2,
-          "kai",
-          "10"
-        )
-        client.getResource[UserRequest, User]("/user/info2", UserRequest(2, "kai"), addRequestId) shouldBe User(
-          2,
-          "kai",
-          "10"
-        )
+    client.list[Seq[User]]("/user", addRequestId) shouldBe Seq(User(1, "leo", "10"))
 
-        client.list[Seq[User]]("/user", addRequestId) shouldBe Seq(User(1, "leo", "10"))
+    client.post[User]("/user", User(2, "yui", "N/A"), addRequestId) shouldBe User(2, "yui", "10")
+    client.postOps[User, User]("/user", User(2, "yui", "N/A"), addRequestId) shouldBe User(2, "yui", "10")
+    client
+      .postRaw[User](
+        "/user",
+        User(2, "yui", "N/A"),
+        addRequestId
+      ).contentString shouldBe """{"id":2,"name":"yui","requestId":"10"}"""
 
-        client.post[User]("/user", User(2, "yui", "N/A"), addRequestId) shouldBe User(2, "yui", "10")
-        client.postOps[User, User]("/user", User(2, "yui", "N/A"), addRequestId) shouldBe User(2, "yui", "10")
-        client
-          .postRaw[User](
-            "/user",
-            User(2, "yui", "N/A"),
-            addRequestId
-          ).contentString shouldBe """{"id":2,"name":"yui","requestId":"10"}"""
+    client.put[User]("/user", User(10, "aina", "N/A"), addRequestId) shouldBe User(10, "aina", "10")
+    client.putOps[User, User]("/user", User(10, "aina", "N/A"), addRequestId) shouldBe User(10, "aina", "10")
+    client
+      .putRaw[User](
+        "/user",
+        User(10, "aina", "N/A"),
+        addRequestId
+      ).contentString shouldBe """{"id":10,"name":"aina","requestId":"10"}"""
 
-        client.put[User]("/user", User(10, "aina", "N/A"), addRequestId) shouldBe User(10, "aina", "10")
-        client.putOps[User, User]("/user", User(10, "aina", "N/A"), addRequestId) shouldBe User(10, "aina", "10")
-        client
-          .putRaw[User](
-            "/user",
-            User(10, "aina", "N/A"),
-            addRequestId
-          ).contentString shouldBe """{"id":10,"name":"aina","requestId":"10"}"""
+    client.patch[User]("/user", User(20, "joy", "N/A"), addRequestId) shouldBe User(20, "joy", "10")
+    client.patchOps[User, User]("/user", User(20, "joy", "N/A"), addRequestId) shouldBe User(20, "joy", "10")
+    client
+      .patchRaw[User](
+        "/user",
+        User(20, "joy", "N/A"),
+        addRequestId
+      ).contentString shouldBe """{"id":20,"name":"joy","requestId":"10"}"""
 
-        client.patch[User]("/user", User(20, "joy", "N/A"), addRequestId) shouldBe User(20, "joy", "10")
-        client.patchOps[User, User]("/user", User(20, "joy", "N/A"), addRequestId) shouldBe User(20, "joy", "10")
-        client
-          .patchRaw[User](
-            "/user",
-            User(20, "joy", "N/A"),
-            addRequestId
-          ).contentString shouldBe """{"id":20,"name":"joy","requestId":"10"}"""
-
-        client.delete[User]("/user/1", addRequestId) shouldBe User(1, "xxx", "10")
-        client.deleteOps[DeleteRequestBody, User]("/user/1", DeleteRequestBody(true), addRequestId) shouldBe User(
-          1,
-          "xxx",
-          "10"
-        )
-        client.deleteRaw("/user/1", addRequestId).contentString shouldBe """{"id":1,"name":"xxx","requestId":"10"}"""
-      }
-    }
+    client.delete[User]("/user/1", addRequestId) shouldBe User(1, "xxx", "10")
+    client.deleteOps[DeleteRequestBody, User]("/user/1", DeleteRequestBody(true), addRequestId) shouldBe User(
+      1,
+      "xxx",
+      "10"
+    )
+    client.deleteRaw("/user/1", addRequestId).contentString shouldBe """{"id":1,"name":"xxx","requestId":"10"}"""
   }
 
-  def `fail request`: Unit = {
-    d.build[FinagleServer] { server =>
-      withResource(
-        Finagle.client
-          .withMaxRetry(3)
-          .withBackOff(initialIntervalMillis = 1)
-          .newSyncClient(server.localAddress)
-      ) { client =>
-        warn("Starting http client failure tests")
+  def `fail request`(server: FinagleServer): Unit = {
+    withResource(
+      Finagle.client
+        .withMaxRetry(3)
+        .withBackOff(initialIntervalMillis = 1)
+        .newSyncClient(server.localAddress)
+    ) { client =>
+      warn("Starting http client failure tests")
 
-        {
-          // Test max retry failure
-          val ex = intercept[HttpClientMaxRetryException] {
-            val resp = client.get[String]("/busy")
-          }
-          warn(ex.getMessage)
-          ex.retryContext.retryCount shouldBe 3
-          ex.retryContext.maxRetry shouldBe 3
-          val cause = ex.retryContext.lastError.asInstanceOf[HttpClientException]
-          cause.status shouldBe HttpStatus.InternalServerError_500
+      {
+        // Test max retry failure
+        val ex = intercept[HttpClientMaxRetryException] {
+          val resp = client.get[String]("/busy")
         }
+        warn(ex.getMessage)
+        ex.retryContext.retryCount shouldBe 3
+        ex.retryContext.maxRetry shouldBe 3
+        val cause = ex.retryContext.lastError.asInstanceOf[HttpClientException]
+        cause.status shouldBe HttpStatus.InternalServerError_500
+      }
 
-        {
-          // Non retryable response
-          val cause = intercept[HttpClientException] {
-            client.get[String]("/forbidden")
-          }
-          warn(cause.getMessage)
-          cause.status shouldBe HttpStatus.Forbidden_403
+      {
+        // Non retryable response
+        val cause = intercept[HttpClientException] {
+          client.get[String]("/forbidden")
         }
+        warn(cause.getMessage)
+        cause.status shouldBe HttpStatus.Forbidden_403
+      }
+
+      {
+        // Parse invalid json response
+        val e = intercept[Exception] {
+          client.get[User]("/user/1/invalid")
+        }
+        warn(e)
       }
     }
   }

--- a/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/FinagleClientTest.scala
+++ b/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/FinagleClientTest.scala
@@ -234,10 +234,11 @@ class FinagleClientTest extends AirSpec {
 
       {
         // Parse invalid json response
-        val e = intercept[Exception] {
+        val e = intercept[HttpClientException] {
           client.get[User]("/user/1/invalid")
         }
-        warn(e)
+        e.status shouldBe HttpStatus.Ok_200
+        e.getCause.getClass shouldBe classOf[IllegalArgumentException]
       }
     }
   }

--- a/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/FinagleClientTest.scala
+++ b/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/FinagleClientTest.scala
@@ -136,6 +136,14 @@ class FinagleClientTest extends AirSpec {
         client.delete[User]("/user/1") shouldBe User(1, "xxx", "N/A")
         client.deleteOps[DeleteRequestBody, User]("/user/1", DeleteRequestBody(true)) shouldBe User(1, "xxx", "N/A")
 
+        // application/x-msgpack test
+        client.get[User]("/user/1", { r => r.accept = "application/x-msgpack"; r }) shouldBe User(1, "leo", "N/A")
+        client.post[User]("/user", User(2, "yui", "N/A"), { r => r.accept = "application/x-msgpack"; r }) shouldBe User(
+          2,
+          "yui",
+          "N/A"
+        )
+
         // Get a response as is
         client.get[Response]("/response").contentString shouldBe "raw response"
 

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/HttpResponseCodec.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/HttpResponseCodec.scala
@@ -23,8 +23,8 @@ class HttpResponseCodec[Resp: HttpResponseAdapter] extends MessageCodec[HttpResp
   override def pack(p: Packer, v: HttpResponse[_]): Unit = {
     v.contentType match {
       case Some("application/x-msgpack") =>
+        // Raw msgpack response
         val b = v.contentBytes
-        p.packArrayHeader(b.length)
         p.writePayload(b)
       case Some(x) if x.startsWith("application/json") =>
         // JSON -> MsgPack

--- a/airframe-surface/jvm/src/main/scala/wvlet/airframe/surface/reflect/ReflectSurfaceFactory.scala
+++ b/airframe-surface/jvm/src/main/scala/wvlet/airframe/surface/reflect/ReflectSurfaceFactory.scala
@@ -616,7 +616,7 @@ object ReflectSurfaceFactory extends LogSupport {
     }
 
     private class ReflectObjectFactory extends ObjectFactory {
-      private lazy val isStatic = mirror.classSymbol(rawType).isStatic
+      private val isStatic = mirror.classSymbol(rawType).isStatic
       private def outerInstance: Option[AnyRef] = {
         if (isStatic) {
           None

--- a/examples/src/main/scala/wvlet/airframe/examples/http/Http_02_ObjectMapping.scala
+++ b/examples/src/main/scala/wvlet/airframe/examples/http/Http_02_ObjectMapping.scala
@@ -15,7 +15,7 @@ package wvlet.airframe.examples.http
 
 import com.twitter.finagle.http.Response
 import wvlet.airframe.control.Control.withResource
-import wvlet.airframe.http.finagle.{FinagleClient, FinagleServer}
+import wvlet.airframe.http.finagle.{Finagle, FinagleClient, FinagleServer}
 import wvlet.airframe.http.{Endpoint, HttpMethod, Router, finagle}
 import wvlet.log.LogSupport
 
@@ -63,7 +63,11 @@ object Http_02_ObjectMapping extends App with LogSupport {
   }
 
   val router = Router.add[MyApp]
-  val design = finagle.newFinagleServerDesign(name = "myapp", router = router)
+  val design =
+    Finagle.server
+      .withName("myapp")
+      .withRouter(router)
+      .design
 
   design.build[FinagleServer] { server =>
     withResource(FinagleClient.newSyncClient(server.localAddress)) { client =>

--- a/examples/src/main/scala/wvlet/airframe/examples/http/Http_02_ObjectMapping.scala
+++ b/examples/src/main/scala/wvlet/airframe/examples/http/Http_02_ObjectMapping.scala
@@ -16,7 +16,7 @@ package wvlet.airframe.examples.http
 import com.twitter.finagle.http.Response
 import wvlet.airframe.control.Control.withResource
 import wvlet.airframe.http.finagle.{Finagle, FinagleClient, FinagleServer}
-import wvlet.airframe.http.{Endpoint, HttpMethod, Router, finagle}
+import wvlet.airframe.http.{Endpoint, HttpMethod, Router}
 import wvlet.log.LogSupport
 
 /**
@@ -78,7 +78,7 @@ object Http_02_ObjectMapping extends App with LogSupport {
 
       client.get[Response]("/v1/resource/resource_path")
     }
-
+  // Add this code to keep running the server process
   //server.waitServerTermination
   }
 }

--- a/examples/src/main/scala/wvlet/airframe/examples/http/Http_03_Client.scala
+++ b/examples/src/main/scala/wvlet/airframe/examples/http/Http_03_Client.scala
@@ -28,7 +28,9 @@ object Http_03_Client extends App with LogSupport {
   case class User(id: String, name: String)
   trait MyApp extends LogSupport {
     @Endpoint(method = HttpMethod.GET, path = "/user/:id")
-    def getUser(id: String): User = User(id, "xxx")
+    def getUser(id: String): User = {
+      User(id, "xxx")
+    }
   }
 
   val router = Router.add[MyApp]
@@ -61,6 +63,7 @@ object Http_03_Client extends App with LogSupport {
 
     // Read the response as is
     val request = client.send(Request("/user/2"))
-    debug(request.contentString)
+    val content = request.contentString
+    debug(content)
   }
 }

--- a/examples/src/main/scala/wvlet/airframe/examples/http/Http_03_Client.scala
+++ b/examples/src/main/scala/wvlet/airframe/examples/http/Http_03_Client.scala
@@ -34,7 +34,10 @@ object Http_03_Client extends App with LogSupport {
 
   val router = Router.add[MyApp]
   val design =
-    newFinagleServerDesign(name = "myapp", router = router)
+    Finagle.server
+      .withName("myapp")
+      .withRouter(router)
+      .design
 
   design.build[FinagleServer] { server =>
     // Create a new http client to access the server.

--- a/examples/src/main/scala/wvlet/airframe/examples/http/Http_03_Client.scala
+++ b/examples/src/main/scala/wvlet/airframe/examples/http/Http_03_Client.scala
@@ -18,8 +18,7 @@ import java.util.concurrent.TimeUnit
 import com.twitter.finagle.Http
 import com.twitter.finagle.http.Request
 import com.twitter.util.Duration
-import wvlet.airframe.control.Control.withResource
-import wvlet.airframe.http.finagle.{Finagle, FinagleClient, FinagleServer, newFinagleServerDesign}
+import wvlet.airframe.http.finagle.{Finagle, FinagleSyncClient}
 import wvlet.airframe.http.{Endpoint, HttpMethod, Router}
 import wvlet.log.LogSupport
 
@@ -33,33 +32,35 @@ object Http_03_Client extends App with LogSupport {
   }
 
   val router = Router.add[MyApp]
-  val design =
-    Finagle.server
-      .withName("myapp")
-      .withRouter(router)
-      .design
 
-  design.build[FinagleServer] { server =>
-    // Create a new http client to access the server.
-    withResource {
-      Finagle.client
-      // Max retry attempts
-        .withMaxRetry(3)
-        // Use backoff (or jittering)
-        .withBackOff(1)
-        // Set request timeout
-        .withTimeout(Duration(90, TimeUnit.SECONDS))
-        // Add Finagle specific configuration
-        .withInitializer { client: Http.Client => client.withHttp2 } // optional
-        .newSyncClient(server.localAddress)
-    } { client =>
-      // Read the JSON response as an object
-      val user = client.get[User]("/user/1")
-      debug(user)
+  val serverDesign = Finagle.server
+    .withName("myapp")
+    .withRouter(router)
+    .design
 
-      // Read the response as is
-      val request = client.send(Request("/user/2"))
-      debug(request.contentString)
-    }
+  val clietnDesign =
+    Finagle.client
+    // Max retry attempts
+      .withMaxRetry(3)
+      // Use backoff (or jittering)
+      .withBackOff(1)
+      // Set request timeout
+      .withTimeout(Duration(90, TimeUnit.SECONDS))
+      // Add Finagle specific configuration
+      .withInitializer { client: Http.Client => client.withHttp2 } // optional
+      // Create a new http client to access the server.
+      .syncClientDesign
+
+  val design = serverDesign + clietnDesign
+
+  design.build[FinagleSyncClient] { client =>
+    // FinagleServer will be started here
+    // Read the JSON response as an object
+    val user = client.get[User]("/user/1")
+    debug(user)
+
+    // Read the response as is
+    val request = client.send(Request("/user/2"))
+    debug(request.contentString)
   }
 }


### PR DESCRIPTION
- [x] Use the default design builder in Finagle examples
- [x] Resolve ReflectObjectFactory.isStatic early because sbt may unload classloader early and causes NPE for Thread.getContextClassLoader. This often happened when testing examples project.
- [x] Fix HttpResposneCodec to properly read raw MsgPack 
- [x] Use custom codec properly in FinagleClient
- [x] Throw HttpClientException with 200 code when the request succeeded but converting the response body into the target object failed