### PR TITLE
airframe-http: #1129 Deprecate no-key unary mapping for RPC

### DIFF
--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/Router.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/Router.scala
@@ -146,7 +146,8 @@ case class Router(
                   controllerSurface,
                   endPoint.method(),
                   prefixPath + endPoint.path(),
-                  m
+                  m,
+                  isRPC = false
                 )
             }
         case (None, Some(rpc)) =>
@@ -164,9 +165,16 @@ case class Router(
             .collect {
               case (m: ReflectMethodSurface, Some(rpc)) =>
                 val path = if (rpc.path().nonEmpty) rpc.path() else s"/${m.name}"
-                ControllerRoute(rpcInterfaceCls, controllerSurface, HttpMethod.POST, prefixPath + path, m)
+                ControllerRoute(rpcInterfaceCls, controllerSurface, HttpMethod.POST, prefixPath + path, m, isRPC = true)
               case (m: ReflectMethodSurface, None) =>
-                ControllerRoute(rpcInterfaceCls, controllerSurface, HttpMethod.POST, prefixPath + s"/${m.name}", m)
+                ControllerRoute(
+                  rpcInterfaceCls,
+                  controllerSurface,
+                  HttpMethod.POST,
+                  prefixPath + s"/${m.name}",
+                  m,
+                  isRPC = true
+                )
             }
       }
     }

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/Route.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/Route.scala
@@ -41,6 +41,11 @@ trait Route {
   def returnTypeSurface: Surface
 
   /**
+    * Returns true if this Route is for `@RPC` call, otherwise returns false (regular `@Endpoint` calls)
+    */
+  def isRPC: Boolean
+
+  /**
     * Find a corresponding controller and call the matching methods
     */
   def call[Req: HttpRequestAdapter, Resp, F[_]](
@@ -71,7 +76,8 @@ case class ControllerRoute(
     controllerSurface: Surface,
     method: String,
     path: String,
-    methodSurface: ReflectMethodSurface
+    methodSurface: ReflectMethodSurface,
+    isRPC: Boolean
 ) extends Route
     with LogSupport {
   require(
@@ -104,7 +110,8 @@ case class ControllerRoute(
           request,
           context,
           params,
-          codecFactory
+          codecFactory,
+          isRPC = isRPC
         )
       } finally {
         // Ensure recording RPC method arguments

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/RPCTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/RPCTest.scala
@@ -30,6 +30,9 @@ object RPCTest extends AirSpec {
   test("Create a router from RPC annotation") {
     val r = Router.add[MyRPCService]
     debug(r)
+
+    r.routes.forall(_.isRPC) shouldBe true
+
     val m1 = r.routes.find(_.path == "/v1/wvlet.airframe.http.RPCTest.MyRPCService/hello")
     m1 shouldBe defined
     m1.get.method shouldBe HttpMethod.POST

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/RouterTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/RouterTest.scala
@@ -36,6 +36,7 @@ class RouterTest extends AirSpec {
 
     trace(r.routes)
     r.routes.filter(_.path == "/user/:id").size shouldBe 3
+    r.routes.forall(_.isRPC == false) shouldBe true
     val post = r.routes.find(p => p.path == "/user" && p.method == HttpMethod.POST)
     post shouldBe defined
   }


### PR DESCRIPTION
This PR will force using parameter names as keys of RPC call request body. 

For example, if the rpc method is `def f(p1:Int, p2:ComplexObj)`, the request body always needs to have param name -> param value structure:
```
{"p1":1, "p2":{..}}
```

- This will fix unexpected RPC mapping reported in #1129 and will make the request body generation protocol more consistent. 
- sbt-airframe automatically generates such request body, so no client code change will be required. Just need to regenerate RPC ServiceClient with `airframeHttpReload` command. 
- This PR indicates that if you modify RPC method argument names, it will change the RPC request body structure too. So when designing public APIs with airframe-rpc, you need to be careful about the parameter names and their changes. This will be a problem if a client generates an HTTP client based on an older version of the RPC interface (some parameter names will not match between client and RPC server).


This will resolve #1129 and #1100 