### PR TITLE
airframe-http-rx: #1117 Add RxVar.forceSet and forceUpdate

### DIFF
--- a/airframe-http-rx/src/main/scala/wvlet/airframe/http/rx/Rx.scala
+++ b/airframe-http-rx/src/main/scala/wvlet/airframe/http/rx/Rx.scala
@@ -144,16 +144,24 @@ object Rx extends LogSupport {
     def :=(newValue: A): Unit  = set(newValue)
     def set(newValue: A): Unit = update { x: A => newValue }
 
+    def forceSet(newValue: A): Unit = update({ x: A => newValue }, force = true)
+
     /**
       * Updates the variable and trigger the recalculation of the subscribers
       * currentValue => newValue
       */
-    def update(updater: A => A): Unit = {
+    def update(updater: A => A, force: Boolean = false): Unit = {
       val newValue = updater(currentValue)
-      if (currentValue != newValue) {
+      if (force || currentValue != newValue) {
         currentValue = newValue
         subscribers.map { s => s(newValue) }
       }
     }
+
+    /**
+      * Update the variable and force notification to subscribers
+      * @param updater
+      */
+    def forceUpdate(updater: A => A): Unit = update(updater, force = true)
   }
 }

--- a/airframe-http-rx/src/test/scala/wvlet/airframe/http/rx/RxTest.scala
+++ b/airframe-http-rx/src/test/scala/wvlet/airframe/http/rx/RxTest.scala
@@ -66,6 +66,35 @@ object RxTest extends AirSpec {
     v.get shouldBe 2
   }
 
+  test("force update RxVar") {
+
+    val v     = Rx.variable(1)
+    val count = new AtomicInteger(0)
+    v.subscribe(newValue => count.incrementAndGet())
+
+    v.get shouldBe 1
+    count.get() shouldBe 1
+    v.set(1)
+    v.get shouldBe 1
+    count.get() shouldBe 1
+
+    v.forceSet(1)
+    v.get shouldBe 1
+    count.get() shouldBe 2
+
+    v.forceUpdate(x => x * 2)
+    v.get shouldBe 2
+    count.get() shouldBe 3
+
+    v.forceUpdate(x => x)
+    v.get shouldBe 2
+    count.get() shouldBe 4
+
+    v.update(x => x)
+    v.get shouldBe 2
+    count.get() shouldBe 4
+  }
+
   test("chain Rx operators") {
     val v  = Rx.const(2)
     val v1 = v.map(_ + 1)


### PR DESCRIPTION
This is useful when we need to force rewrite RxElement even when there is no data change. 