### PR TITLE
Use a link to the release note URL for git tag annotaiton

### DIFF
--- a/scripts/release.rb
+++ b/scripts/release.rb
@@ -62,8 +62,10 @@ release_notes <<= notes[8..-1]
 # Update the release note
 File.write(RELEASE_NOTES_FILE, release_notes.join)
 
+version_link = "https://wvlet.org/airframe/docs/release-notes\##{next_version.gsub(/\W/,'')}"
+
 run "git commit #{RELEASE_NOTES_FILE} -m \"Release #{next_version}\""
-run "git tag -a -F #{TMP_RELEASE_NOTES_FILE} v#{next_version}"
+run "git tag -a -m \"Airframe #{next_version}\" -m \"Release notes: #{version_link}\" v#{next_version}"
 run "git push --follow-tags"
 
 File.delete(TMP_RELEASE_NOTES_FILE)


### PR DESCRIPTION
This PR is for creating a link to the release note page for each git tag commit, instead of copying the detailed release descriptions 

Currently, git tag page is a bit messy because Markdown format is not recognized by GitHub https://github.com/wvlet/airframe/releases/tag/v20.6.1