### PR TITLE
airframe-codec: Support Either and Throwable class serde 

### DIFF
--- a/airframe-codec/.jvm/src/test/scala/wvlet/airframe/codec/MessageCodecTest.scala
+++ b/airframe-codec/.jvm/src/test/scala/wvlet/airframe/codec/MessageCodecTest.scala
@@ -59,7 +59,7 @@ class MessageCodecTest extends AirSpec {
   }
 
   def `throw MessageCodecException upon invalid JSON data`: Unit = {
-    val ex = intercept[MessageCodecException[_]] {
+    val ex = intercept[MessageCodecException] {
       val a = MessageCodec.fromJson[ExtractTest]("""{"id":"invalid_id"}""")
     }
     ex.errorCode shouldBe INVALID_DATA

--- a/airframe-codec/src/main/scala/wvlet/airframe/codec/LazyCodec.scala
+++ b/airframe-codec/src/main/scala/wvlet/airframe/codec/LazyCodec.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.codec
+import wvlet.airframe.msgpack.spi.{Packer, Unpacker}
+import wvlet.airframe.surface.Surface
+
+/**
+  * For generating codec for recursive types.
+  *
+  * For example, if type X has a recursion like X(name:String, child:Option[X]), LazyCodec will be used to generate a
+  * codec instance as MessageCodec[X](StringCodec, OptionCodec(LazyCodec[X])).
+  */
+case class LazyCodec[A](surface: Surface, codecFactory: MessageCodecFactory) extends MessageCodec[A] {
+  private lazy val ref: MessageCodec[A] = codecFactory.ofSurface(surface).asInstanceOf[MessageCodec[A]]
+
+  override def pack(p: Packer, v: A): Unit = {
+    ref.pack(p, v)
+  }
+  override def unpack(u: Unpacker, v: MessageContext): Unit = {
+    ref.unpack(u, v)
+  }
+}

--- a/airframe-codec/src/main/scala/wvlet/airframe/codec/MessageCodec.scala
+++ b/airframe-codec/src/main/scala/wvlet/airframe/codec/MessageCodec.scala
@@ -137,7 +137,7 @@ trait MessageCodec[A] extends LogSupport {
     if (v.hasError) {
       throw v.getError.get
     } else if (v.isNull) {
-      throw new MessageCodecException[A](INVALID_DATA, this, s"Invalid JSON data for ${this}:\n${json}")
+      throw new MessageCodecException(INVALID_DATA, this, s"Invalid JSON data for ${this}:\n${json}")
     } else {
       v.getLastValue.asInstanceOf[A]
     }

--- a/airframe-codec/src/main/scala/wvlet/airframe/codec/MessageCodecException.scala
+++ b/airframe-codec/src/main/scala/wvlet/airframe/codec/MessageCodecException.scala
@@ -13,13 +13,15 @@
  */
 package wvlet.airframe.codec
 
+import scala.language.higherKinds
+
 trait CodecErrorCode
 case object INVALID_DATA      extends CodecErrorCode
 case object MISSING_PARAMETER extends CodecErrorCode
 
 /**
   */
-class MessageCodecException[A](val errorCode: CodecErrorCode, val codec: MessageCodec[A], val message: String)
+class MessageCodecException(val errorCode: CodecErrorCode, val codec: MessageCodec[_], val message: String)
     extends Exception(message) {
   override def getMessage = s"[${errorCode.toString}] ${message} -- codec: ${codec}"
 }

--- a/airframe-codec/src/main/scala/wvlet/airframe/codec/MessageCodecFactory.scala
+++ b/airframe-codec/src/main/scala/wvlet/airframe/codec/MessageCodecFactory.scala
@@ -44,11 +44,10 @@ case class MessageCodecFactory(codecFinder: MessageCodecFinder = Compat.messageC
 
   protected[codec] def ofSurface(surface: Surface, seen: Set[Surface] = Set.empty): MessageCodec[_] = {
     // TODO Create a fast object codec with code generation (e.g., Scala macros)
-
     if (cache.contains(surface)) {
       cache(surface)
     } else if (seen.contains(surface)) {
-      throw new IllegalArgumentException(s"Codec for recursive types is not supported: ${surface}")
+      LazyCodec(surface, this)
     } else {
       val seenSet = seen + surface
 

--- a/airframe-codec/src/main/scala/wvlet/airframe/codec/MessageCodecFinder.scala
+++ b/airframe-codec/src/main/scala/wvlet/airframe/codec/MessageCodecFinder.scala
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 package wvlet.airframe.codec
-import wvlet.airframe.codec.ScalaStandardCodec.{OptionCodec, TupleCodec}
+import wvlet.airframe.codec.ScalaStandardCodec.{EitherCodec, OptionCodec, TupleCodec}
 import wvlet.airframe.surface.{Alias, EnumSurface, GenericSurface, Surface}
 
 /**
@@ -74,6 +74,8 @@ object MessageCodecFinder {
       case o if o.isOption =>
         val elementSurface = o.typeArgs(0)
         OptionCodec(factory.ofSurface(elementSurface, seenSet))
+      case et: Surface if classOf[Either[_, _]].isAssignableFrom(et.rawType) =>
+        EitherCodec(factory.ofSurface(et.typeArgs(0)), factory.ofSurface(et.typeArgs(1)))
       // Tuple
       case g: GenericSurface
           if classOf[Product].isAssignableFrom(g.rawType) && g.rawType.getName.startsWith("scala.Tuple") =>

--- a/airframe-codec/src/main/scala/wvlet/airframe/codec/PrimitiveCodec.scala
+++ b/airframe-codec/src/main/scala/wvlet/airframe/codec/PrimitiveCodec.scala
@@ -17,7 +17,6 @@ import java.time.Instant
 import java.util.Base64
 
 import wvlet.airframe.codec.PrimitiveCodec.IntArrayCodec.unpack
-import wvlet.airframe.codec.StandardCodec.ThrowableCodec
 import wvlet.airframe.json.JSON.JSONValue
 import wvlet.airframe.json.Json
 import wvlet.airframe.msgpack.spi.Value.ExtensionValue

--- a/airframe-codec/src/main/scala/wvlet/airframe/codec/PrimitiveCodec.scala
+++ b/airframe-codec/src/main/scala/wvlet/airframe/codec/PrimitiveCodec.scala
@@ -880,6 +880,16 @@ object PrimitiveCodec {
             pack(p, k)
             pack(p, v)
           }
+        case e: Either[_, _] =>
+          p.packArrayHeader(2)
+          e match {
+            case Left(l) =>
+              pack(p, l)
+              p.packNil
+            case Right(r) =>
+              p.packNil
+              pack(p, r)
+          }
         case v: Throwable =>
           ThrowableCodec.pack(p, v)
         case _ =>

--- a/airframe-codec/src/main/scala/wvlet/airframe/codec/ScalaStandardCodec.scala
+++ b/airframe-codec/src/main/scala/wvlet/airframe/codec/ScalaStandardCodec.scala
@@ -261,9 +261,12 @@ object ScalaStandardCodec {
               }
             }
           }
-        case _ =>
+        case other =>
           u.skipValue
-          v.setIncompatibleFormatException(this, s"EitherCodec ${this} can read only Array[2] MessagePack value")
+          v.setIncompatibleFormatException(
+            this,
+            s"EitherCodec ${this} can read only Array[2] MessagePack value, but found ${other}"
+          )
       }
     }
   }

--- a/airframe-codec/src/main/scala/wvlet/airframe/codec/StandardCodec.scala
+++ b/airframe-codec/src/main/scala/wvlet/airframe/codec/StandardCodec.scala
@@ -13,10 +13,8 @@
  */
 package wvlet.airframe.codec
 
-import java.io.{PrintWriter, StringWriter}
 import java.util.UUID
 
-import wvlet.airframe.msgpack.spi._
 import wvlet.airframe.surface.Surface
 
 /**
@@ -32,42 +30,4 @@ object StandardCodec {
 
   val standardCodec: Map[Surface, MessageCodec[_]] =
     PrimitiveCodec.primitiveCodec ++ PrimitiveCodec.primitiveArrayCodec ++ javaClassCodec
-
-  object ThrowableCodec extends MessageCodec[Throwable] {
-    override def pack(p: Packer, v: Throwable): Unit = {
-      p.packMapHeader(4)
-      // param 1
-      p.packString("type")
-      p.packString(v.getClass.getName)
-
-      // param 2
-      p.packString("message")
-      val msg = v.getMessage
-      if (msg == null) {
-        p.packNil
-      } else {
-        p.packString(msg)
-      }
-
-      // param 3
-      val s = new StringWriter
-      val w = new PrintWriter(s)
-      v.printStackTrace(w)
-      w.flush()
-      w.close()
-      p.packString("stackTrace")
-      p.packString(s.toString)
-
-      // param 4
-      p.packString("cause")
-      val cause = v.getCause
-      if (cause == null || cause == v) {
-        p.packNil
-      } else {
-        ThrowableCodec.pack(p, cause)
-      }
-    }
-    // We do not support deserialization of generic Throwable classes
-    override def unpack(u: Unpacker, v: MessageContext): Unit = ???
-  }
 }

--- a/airframe-codec/src/main/scala/wvlet/airframe/codec/ThrowableCodec.scala
+++ b/airframe-codec/src/main/scala/wvlet/airframe/codec/ThrowableCodec.scala
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.codec
+
+import wvlet.airframe.msgpack.spi.{Packer, Unpacker}
+import wvlet.airframe.surface.Surface
+
+/**
+  * Codec for Exception (Throwable) classes
+  */
+object ThrowableCodec extends MessageCodec[Throwable] {
+
+  private lazy val genericExceptionSurface = Surface.of[GenericException]
+  // This needs to be lazy as MessageCodecFactory will load ThrowableCodec
+  private lazy val genericExceptionCodec =
+    MessageCodec.ofSurface(genericExceptionSurface).asInstanceOf[MessageCodec[GenericException]]
+
+  override def pack(p: Packer, v: Throwable): Unit = {
+    val m = GenericException.fromThrowable(v)
+    genericExceptionCodec.pack(p, m)
+  }
+  // We do not support deserialization of generic Throwable classes
+  override def unpack(u: Unpacker, v: MessageContext): Unit = {
+    genericExceptionCodec.unpack(u, v)
+  }
+}
+
+/**
+  * Generic representation of Throwable for RPC messaging and logging exception
+  * @param exceptionClass
+  * @param message
+  * @param stackTrace
+  * @param cause
+  */
+case class GenericException(
+    exceptionClass: String,
+    message: Option[String] = None,
+    stackTrace: Seq[GenericStackTraceElement] = Seq.empty,
+    cause: Option[GenericException] = None
+) extends Throwable(message.getOrElse(null), cause.getOrElse(null)) {
+  override def getStackTrace: Array[StackTraceElement] = stackTrace.map(_.toJavaStackTraceElement).toArray
+}
+
+object GenericException {
+  def fromThrowable(e: Throwable, seen: Set[Throwable] = Set.empty): GenericException = {
+    val exceptionClass = e.getClass.getName
+    val message        = Option(e.getMessage)
+
+    val stackTrace = for (x <- e.getStackTrace) yield {
+      GenericStackTraceElement(
+        className = x.getClassName,
+        methodName = x.getMethodName,
+        fileName = Option(x.getFileName),
+        lineNumber = x.getLineNumber
+      )
+    }
+
+    val cause = Option(e.getCause).flatMap { ce =>
+      if (seen.contains(ce)) {
+        None
+      } else {
+        Some(GenericException.fromThrowable(ce, seen + e))
+      }
+    }
+
+    GenericException(
+      exceptionClass = exceptionClass,
+      message = message,
+      stackTrace = stackTrace,
+      cause = cause
+    )
+  }
+}
+
+/**
+  * Generic stacktrace representation
+  */
+case class GenericStackTraceElement(
+    className: String,
+    methodName: String,
+    fileName: Option[String],
+    lineNumber: Int
+) {
+  def toJavaStackTraceElement: StackTraceElement = {
+    new StackTraceElement(className, methodName, fileName.getOrElse(null), lineNumber)
+  }
+}

--- a/airframe-codec/src/test/scala/wvlet/airframe/codec/ObjectCodecTest.scala
+++ b/airframe-codec/src/test/scala/wvlet/airframe/codec/ObjectCodecTest.scala
@@ -103,7 +103,7 @@ class ObjectCodecTest extends CodecSpec {
 
   def `support @required annotation`: Unit = {
     val codec = MessageCodec.of[B]
-    val ex = intercept[MessageCodecException[_]] {
+    val ex = intercept[MessageCodecException] {
       codec.unpackJson("{}")
     }
     warn(ex.getMessage)

--- a/airframe-codec/src/test/scala/wvlet/airframe/codec/PrimitiveCodecTest.scala
+++ b/airframe-codec/src/test/scala/wvlet/airframe/codec/PrimitiveCodecTest.scala
@@ -18,7 +18,8 @@ import java.time.Instant
 
 import org.scalacheck.util.Pretty
 import wvlet.airframe.codec.PrimitiveCodec.LongCodec
-import wvlet.airframe.json.JSON.JSONString
+import wvlet.airframe.json.JSON
+import wvlet.airframe.json.JSON.{JSONArray, JSONObject, JSONString}
 import wvlet.airframe.msgpack.spi.MessagePack
 import wvlet.airframe.msgpack.spi.Value.StringValue
 import wvlet.airframe.surface.{ArraySurface, GenericSurface, Surface}
@@ -457,6 +458,25 @@ object PrimitiveCodecTest extends CodecSpec with PropertyCheck {
     val codec = MessageCodec.of[Seq[Any]]
     val seq   = codec.fromJson("[null, 1]")
     seq shouldBe Seq(null, 1)
+  }
+
+  def `pack Either (Left) in AnyCodec`: Unit = {
+    val codec = MessageCodec.of[Any]
+    val json  = codec.toJson(Left(new NullPointerException("NPE")))
+
+    val eitherCodec = MessageCodec.of[Either[GenericException, String]]
+    val ex          = eitherCodec.fromJson(json).left.get
+    ex.exceptionClass shouldBe "java.lang.NullPointerException"
+    ex.message shouldBe "NPE"
+  }
+
+  def `pack Either (Right) in AnyCodec`: Unit = {
+    val codec = MessageCodec.of[Any]
+    val json  = codec.toJson(Right("hello Either"))
+
+    val eitherCodec = MessageCodec.of[Either[GenericException, String]]
+    val msg         = eitherCodec.fromJson(json).right.get
+    msg shouldBe "hello Either"
   }
 
   case class BinaryData(data: Array[Byte])

--- a/airframe-codec/src/test/scala/wvlet/airframe/codec/ScalaStandardCodecTest.scala
+++ b/airframe-codec/src/test/scala/wvlet/airframe/codec/ScalaStandardCodecTest.scala
@@ -12,8 +12,6 @@
  * limitations under the License.
  */
 package wvlet.airframe.codec
-import java.lang.reflect.InvocationTargetException
-
 import wvlet.airframe.json.JSON
 import wvlet.airframe.json.JSON.{JSONArray, JSONObject, JSONString}
 import wvlet.airframe.surface.Surface
@@ -173,7 +171,31 @@ class ScalaStandardCodecTest extends CodecSpec {
       case JSONArray(Seq(JSON.JSONNull, JSONString(v))) if v == "Hello Either" =>
       // ok
       case _ =>
-        fail("cannot reatch here")
+        fail("cannot reach here")
     }
+  }
+
+  def `read valid JSON input for Either`: Unit = {
+    val codec = MessageCodec.of[Either[Throwable, String]]
+    codec.unpackJson("""[{"exceptionClass":"java.lang.NullPointerException","message":"NPE"}, null]""")
+    codec.unpackJson("""[null, "hello"]""")
+  }
+
+  def `reject invalid JSON input for Either`: Unit = {
+    val codec = MessageCodec.of[Either[Throwable, String]]
+
+    def testInvalid(json: String): Unit = {
+      intercept[MessageCodecException] {
+        codec.unpackJson(json)
+      }
+    }
+
+    testInvalid("""["hello", "hello"]""")
+    testInvalid("""[{"exceptionClass":"java.lang.NullPointerException","message":"NPE"}, "hello"]""")
+    testInvalid("""[null, null]""")
+    testInvalid("""[]""")
+    testInvalid("""["hello"]""")
+    testInvalid("""[null, "hello", null]""")
+    testInvalid("""{"exceptionClass":"java.lang.NullPointerException","message":"NPE"}""")
   }
 }

--- a/airframe-codec/src/test/scala/wvlet/airframe/codec/ScalaStandardCodecTest.scala
+++ b/airframe-codec/src/test/scala/wvlet/airframe/codec/ScalaStandardCodecTest.scala
@@ -114,6 +114,7 @@ class ScalaStandardCodecTest extends CodecSpec {
         x.getMethodName.contains("Left") shouldBe true
       case _ =>
         warn(stackTrace.mkString("\n"))
+        fail("should not reach here")
     }
   }
 

--- a/airframe-codec/src/test/scala/wvlet/airframe/codec/ScalaStandardCodecTest.scala
+++ b/airframe-codec/src/test/scala/wvlet/airframe/codec/ScalaStandardCodecTest.scala
@@ -108,7 +108,7 @@ class ScalaStandardCodecTest extends CodecSpec {
 
     // Should generate standard Java stack traces
     val stackTrace = ge.getStackTrace
-    val errorLoc   = stackTrace.find(x => x.getFileName.contains("ScalaStandardCodecTest"))
+    val errorLoc   = stackTrace.find(x => x.getClassName.contains("ScalaStandardCodecTest"))
     errorLoc match {
       case Some(x) =>
         x.getMethodName.contains("Left") shouldBe true

--- a/airframe-codec/src/test/scala/wvlet/airframe/codec/ScalaStandardCodecTest.scala
+++ b/airframe-codec/src/test/scala/wvlet/airframe/codec/ScalaStandardCodecTest.scala
@@ -106,11 +106,15 @@ class ScalaStandardCodecTest extends CodecSpec {
     ge.exceptionClass shouldBe "java.lang.IllegalArgumentException"
     ge.cause shouldBe None
 
-    // Should generate standard stack traces
+    // Should generate standard Java stack traces
     val stackTrace = ge.getStackTrace
     val errorLoc   = stackTrace.find(x => x.getFileName.contains("ScalaStandardCodecTest"))
-    errorLoc shouldBe defined
-    errorLoc.get.getMethodName.contains("Left") shouldBe true
+    errorLoc match {
+      case Some(x) =>
+        x.getMethodName.contains("Left") shouldBe true
+      case _ =>
+        warn(stackTrace.mkString("\n"))
+    }
   }
 
   def `Either Left should produce Array[JSON objects, null]` : Unit = {

--- a/airframe-codec/src/test/scala/wvlet/airframe/codec/ScalaStandardCodecTest.scala
+++ b/airframe-codec/src/test/scala/wvlet/airframe/codec/ScalaStandardCodecTest.scala
@@ -84,4 +84,12 @@ class ScalaStandardCodecTest extends CodecSpec {
       (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21)
     )
   }
+
+  def `support Either`: Unit = {
+    val codec   = MessageCodec.of[Either[Throwable, String]]
+    val msgpack = codec.pack(Left(new IllegalArgumentException("test exception")))
+    val either  = codec.unpack(msgpack)
+    info(either)
+  }
+
 }

--- a/airframe-codec/src/test/scala/wvlet/airframe/codec/ScalaStandardCodecTest.scala
+++ b/airframe-codec/src/test/scala/wvlet/airframe/codec/ScalaStandardCodecTest.scala
@@ -108,7 +108,7 @@ class ScalaStandardCodecTest extends CodecSpec {
 
     // Should generate standard stack traces
     val stackTrace = ge.getStackTrace
-    val errorLoc   = stackTrace.find(x => x.getFileName.contains("ScalaStandardCodecTest.scala"))
+    val errorLoc   = stackTrace.find(x => x.getFileName.contains("ScalaStandardCodecTest"))
     errorLoc shouldBe defined
     errorLoc.get.getMethodName.contains("Left") shouldBe true
   }

--- a/airframe-codec/src/test/scala/wvlet/airframe/codec/ScalaStandardCodecTest.scala
+++ b/airframe-codec/src/test/scala/wvlet/airframe/codec/ScalaStandardCodecTest.scala
@@ -108,7 +108,7 @@ class ScalaStandardCodecTest extends CodecSpec {
 
     // Should generate standard stack traces
     val stackTrace = ge.getStackTrace
-    val errorLoc   = stackTrace.find(x => x.getFileName == "ScalaStandardCodecTest.scala")
+    val errorLoc   = stackTrace.find(x => x.getFileName.contains("ScalaStandardCodecTest.scala"))
     errorLoc shouldBe defined
     errorLoc.get.getMethodName.contains("Left") shouldBe true
   }
@@ -129,7 +129,7 @@ class ScalaStandardCodecTest extends CodecSpec {
 
   def `support Either Left with nested exception`: Unit = {
     val codec   = MessageCodec.of[Either[Throwable, String]]
-    val et      = Left(new InvocationTargetException(new NullPointerException("NPE")))
+    val et      = Left(new Exception(new NullPointerException("NPE")))
     val msgpack = codec.pack(et)
     val either  = codec.unpack(msgpack)
 

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/Route.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/Route.scala
@@ -21,7 +21,6 @@ import wvlet.airframe.surface.{MethodSurface, Surface}
 import wvlet.log.LogSupport
 
 import scala.language.higherKinds
-import scala.util.{Failure, Success, Try}
 
 /**
   * A mapping from an HTTP endpoint to a corresponding method (or function)
@@ -121,7 +120,7 @@ case class ControllerRoute(
     } catch {
       case e: IllegalArgumentException =>
         throw new HttpServerException(HttpStatus.BadRequest_400, s"${request} failed: ${e.getMessage}", e)
-      case e: MessageCodecException[_] if e.errorCode == MISSING_PARAMETER =>
+      case e: MessageCodecException if e.errorCode == MISSING_PARAMETER =>
         throw new HttpServerException(HttpStatus.BadRequest_400, e.message, e)
     }
   }

--- a/airframe-msgpack/src/main/scala/wvlet/airframe/msgpack/spi/Unpacker.scala
+++ b/airframe-msgpack/src/main/scala/wvlet/airframe/msgpack/spi/Unpacker.scala
@@ -31,8 +31,9 @@ trait Unpacker extends AutoCloseable {
 
   /**
     * Peeks a Nil byte and read it if the next byte is actually a Nil value,
-    * read the Nil value (proceed the cursor) and return true.
-    * If the next byte is not Nil, it will return false
+    * then proceed the cursor 1 byte and return true.
+    *
+    * If the next byte is not Nil, it will return false and the cursor position will not be changed.
     *
     * @return true if a nil value is read and the cursor is proceeded 1 bytes. false if the next value is not
     *         Nil and the cursor position will not change.

--- a/airframe-msgpack/src/main/scala/wvlet/airframe/msgpack/spi/Unpacker.scala
+++ b/airframe-msgpack/src/main/scala/wvlet/airframe/msgpack/spi/Unpacker.scala
@@ -28,6 +28,14 @@ trait Unpacker extends AutoCloseable {
   def skipValue(count: Int): Unit
 
   def unpackNil: Unit
+
+  /**
+    * Peeks a Nil byte and read it if the next byte is actually a Nil value,
+    * read the Nil value (proceed the cursor) and return true.
+    * If the next byte is not Nil, it will return false
+    *
+    * @return true if a nil value is read
+    */
   def tryUnpackNil: Boolean
   def unpackBoolean: Boolean
   def unpackByte: Byte

--- a/airframe-msgpack/src/main/scala/wvlet/airframe/msgpack/spi/Unpacker.scala
+++ b/airframe-msgpack/src/main/scala/wvlet/airframe/msgpack/spi/Unpacker.scala
@@ -34,7 +34,8 @@ trait Unpacker extends AutoCloseable {
     * read the Nil value (proceed the cursor) and return true.
     * If the next byte is not Nil, it will return false
     *
-    * @return true if a nil value is read
+    * @return true if a nil value is read and the cursor is proceeded 1 bytes. false if the next value is not
+    *         Nil and the cursor position will not change.
     */
   def tryUnpackNil: Boolean
   def unpackBoolean: Boolean


### PR DESCRIPTION
- Support Either[Left, Right] type in airframe-codec. It uses Array(left, right) representation. This will support returning Either[Throwable, A] type in airframe-http RPC interfaces. If we use a special exception class like Either[CustomException, A], we can inject a custom exception codec to MessageCodecFactory. 
- For encoding/decoding Either[Throwable, A], added GenericException class, which can report exception class name, message, stack traces, and the cause in details. 
  - This will produce well-formatted JSON output when recording Exception class. The previous version was using a special array encoding, which might be difficult to parse. 
  - A reason we do not deserialize the original Exception type is for avoiding Gadget attack (see an example in jackson  https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062), which becomes possible when deserializing arbitrary Java types. Another reason is it will add more complexity to the MessageCodec.unpack 
- To support nested GenericException(cause:GenericException), introduced LazyCodec[A] to defer codec generation

This will close #1147 