### PR TITLE
Add SocketTimeoutException as a retryable failure

### DIFF
--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/HttpClientTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/HttpClientTest.scala
@@ -98,10 +98,12 @@ class HttpClientTest extends AirSpec {
       new ExecutionException(new ConnectException("connect")),
       new ExecutionException(new EOFException("eof")),
       new ExecutionException(new TimeoutException("timeout")),
+      new ExecutionException(new SocketTimeoutException("timeout")),
       new ExecutionException(new BindException("exception")),
       new ExecutionException(new ConnectException("exception")),
       new ExecutionException(new NoRouteToHostException("exception")),
       new ExecutionException(new PortUnreachableException("exception")),
+      new ExecutionException(new SocketException("Socket closed")),
       new InvocationTargetException(new TimeoutException("timeout at reflection call"))
     )
 


### PR DESCRIPTION
Closes #1168 

Add the following exceptions as retryable failures.

- java.net.SocketTimeoutException
- java.net.SocketException and the message is "Socket closed"