### PR TITLE
Shutdown OkHttpClient explicitly

### DIFF
--- a/airframe-http-okhttp/src/main/scala/wvlet/airframe/http/okhttp/OkHttpClient.scala
+++ b/airframe-http-okhttp/src/main/scala/wvlet/airframe/http/okhttp/OkHttpClient.scala
@@ -242,7 +242,10 @@ class OkHttpClient(address: ServerAddress, config: OkHttpClientConfig)
     convert[OperationResponse](send(r, requestFilter))
   }
 
-  def close(): Unit = {}
+  def close(): Unit = {
+    client.dispatcher().executorService().shutdown()
+    client.connectionPool().evictAll()
+  }
 
 }
 

--- a/airframe-http-okhttp/src/main/scala/wvlet/airframe/http/okhttp/OkHttpClient.scala
+++ b/airframe-http-okhttp/src/main/scala/wvlet/airframe/http/okhttp/OkHttpClient.scala
@@ -242,7 +242,7 @@ class OkHttpClient(address: ServerAddress, config: OkHttpClientConfig)
     convert[OperationResponse](send(r, requestFilter))
   }
 
-  def close(): Unit = {
+  override def close(): Unit = {
     client.dispatcher().executorService().shutdown()
     client.connectionPool().evictAll()
   }


### PR DESCRIPTION
According to OkHttp document, we don't need to shutdown OkHttp explicitly.
https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/#shutdown-isnt-necessary

However, particularly, in CLI applications, because OkHttp threads remain (during max-idle period?) the process doesn't exit even after execution without explicit `System.exit(0)` call. It would better to shutdown explicitly in lifecycle hook.