### PR TITLE
Upgrade to Scala 2.12.12, 2.13.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,7 +109,7 @@ jobs:
           key: ${{ runner.os }}-scala-js_2.13-${{ hashFiles('**/*.sbt') }}
           restore-keys: ${{ runner.os }}-scala-js_2.13-
       - name: Scala.js test
-        run: ./sbt ++2.13.2 "; projectJS/test"
+        run: ./sbt ++2.13.3 "; projectJS/test"
   test_sbt_plugin:
     name: sbt-airframe
     runs-on: ubuntu-latest

--- a/build.sbt
+++ b/build.sbt
@@ -2,8 +2,8 @@ import sbtcrossproject.{CrossType, crossProject}
 import xerial.sbt.pack.PackPlugin.publishPackArchiveTgz
 
 val SCALA_2_11 = "2.11.12"
-val SCALA_2_12 = "2.12.11"
-val SCALA_2_13 = "2.13.2"
+val SCALA_2_12 = "2.12.12"
+val SCALA_2_13 = "2.13.3"
 
 val untilScala2_12      = SCALA_2_12 :: SCALA_2_11 :: Nil
 val targetScalaVersions = SCALA_2_13 :: untilScala2_12


### PR DESCRIPTION
- https://github.com/scala/scala/releases/tag/v2.12.12
- https://github.com/scala/scala/releases/tag/v2.13.3

These Scala versions added `-Xasync` option, so that scala-async can be efficiently implemented by using the compile-time information. The previous version of scala-async was a macro-based implementation, which was slow and incomplete. 

Related:
- scala-async 1.0.0-M1 https://github.com/scala/scala-async/releases/tag/v1.0.0-M1, which requires -Xasync option. 1.0.0 will be released soon

scala-async will support Scala.js too. This would be useful for writing Future-based async code instead of writing chains of Futures (e.g., Conductor's Future-based operation code will benefit from scala-async). I think reading this SIP https://docs.scala-lang.org/sips/async.html is good enough to understand the motivation why scala-async was developed. 

