### PR TITLE
airframe-rx: Add RxOption[A] 

### DIFF
--- a/airframe-http-rx/src/main/scala/wvlet/airframe/http/rx/Rx.scala
+++ b/airframe-http-rx/src/main/scala/wvlet/airframe/http/rx/Rx.scala
@@ -51,7 +51,7 @@ object Rx extends LogSupport {
 
   def apply[A](v: A): RxVar[A]                        = variable(v)
   def variable[A](v: A): RxVar[A]                     = new RxVar(v)
-  def optionVariable[A](v: Option[A]): RxOptionVar[A] = new RxOptionVar(Rx.variable(v))
+  def optionVariable[A](v: Option[A]): RxOptionVar[A] = variable(v).toOption
   def option[A](v: Option[A]): RxOption[A]            = RxOptionOp(Rx.const(v))
   val none: RxOption[Nothing]                         = RxOptionOp(Rx.const(None))
 

--- a/airframe-http-rx/src/main/scala/wvlet/airframe/http/rx/Rx.scala
+++ b/airframe-http-rx/src/main/scala/wvlet/airframe/http/rx/Rx.scala
@@ -47,17 +47,18 @@ trait Rx[+A] extends LogSupport {
 }
 
 object Rx extends LogSupport {
-  def const[A](v: A): Rx[A]       = SingleOp(v)
+  def const[A](v: A): Rx[A] = SingleOp(v)
+
+  def apply[A](v: A): RxVar[A]    = new RxVar(v)
   def variable[A](v: A): RxVar[A] = Rx.apply(v)
+
   def option[A](v: A): RxOption[A] = {
     v match {
       case null => none
       case _    => RxOption(Rx.const(Some(v)))
     }
   }
-  val none: RxOption[Nothing] = RxOption(Rx.const(None.asInstanceOf[Option[Nothing]]))
-
-  def apply[A](v: A): RxVar[A] = new RxVar(v)
+  val none: RxOption[Nothing] = RxOption(Rx.const(None))
 
   /**
     * Mapping a Scala Future into Rx

--- a/airframe-http-rx/src/main/scala/wvlet/airframe/http/rx/Rx.scala
+++ b/airframe-http-rx/src/main/scala/wvlet/airframe/http/rx/Rx.scala
@@ -50,7 +50,7 @@ object Rx extends LogSupport {
   def apply[A](v: A): RxVar[A]    = new RxVar(v)
   def variable[A](v: A): RxVar[A] = Rx.apply(v)
   def optionVariable[A](v: Option[A]): RxOptionVar[A] = {
-    new RxOptionVar(v.getOrElse(null.asInstanceOf[A]))
+    new RxOptionVar(v)
   }
 
   def option[A](v: A): RxOption[A] = {

--- a/airframe-http-rx/src/main/scala/wvlet/airframe/http/rx/Rx.scala
+++ b/airframe-http-rx/src/main/scala/wvlet/airframe/http/rx/Rx.scala
@@ -47,19 +47,11 @@ trait Rx[+A] extends LogSupport {
 object Rx extends LogSupport {
   def const[A](v: A): Rx[A] = SingleOp(v)
 
-  def apply[A](v: A): RxVar[A]    = new RxVar(v)
-  def variable[A](v: A): RxVar[A] = Rx.apply(v)
-  def optionVariable[A](v: Option[A]): RxOptionVar[A] = {
-    new RxOptionVar(v)
-  }
-
-  def option[A](v: A): RxOption[A] = {
-    v match {
-      case null => none
-      case _    => RxOption(Rx.const(Some(v)))
-    }
-  }
-  val none: RxOption[Nothing] = RxOption(Rx.const(None))
+  def apply[A](v: A): RxVar[A]                        = new RxVar(v)
+  def variable[A](v: A): RxVar[A]                     = Rx.apply(v)
+  def optionVariable[A](v: Option[A]): RxOptionVar[A] = new RxOptionVar(v)
+  def option[A](v: A): RxOption[A]                    = RxOption(Rx.const(Option(v)))
+  val none: RxOption[Nothing]                         = RxOption(Rx.const(None))
 
   /**
     * Mapping a Scala Future into Rx

--- a/airframe-http-rx/src/main/scala/wvlet/airframe/http/rx/RxOption.scala
+++ b/airframe-http-rx/src/main/scala/wvlet/airframe/http/rx/RxOption.scala
@@ -17,17 +17,17 @@ import wvlet.airframe.http.rx.Rx.{FilterOp, FlatMapOp, MapOp}
 /**
   * An wrapper of Rx[A] for Option[A] type values
   */
-private[rx] trait RxOptionOps[+A] extends Rx[A] {
+private[rx] trait RxOption[+A] extends Rx[A] {
   protected def in: Rx[Option[A]]
 
   override def parents: Seq[Rx[_]]                 = Seq(in)
-  override def withName(name: String): RxOption[A] = RxOption(in.withName(name))
+  override def withName(name: String): RxOption[A] = RxOptionOp(in.withName(name))
 
   override def map[B](f: A => B): RxOption[B] = {
-    RxOption(MapOp(in, { x: Option[A] => x.map(f) }))
+    RxOptionOp(MapOp(in, { x: Option[A] => x.map(f) }))
   }
   override def flatMap[B](f: A => Rx[B]): RxOption[B] = {
-    RxOption[B](
+    RxOptionOp[B](
       FlatMapOp(
         in,
         { x: Option[A] =>
@@ -43,7 +43,7 @@ private[rx] trait RxOptionOps[+A] extends Rx[A] {
   }
 
   override def filter(f: A => Boolean): RxOption[A] = {
-    RxOption(
+    RxOptionOp(
       in.map {
         case Some(x) if f(x) => Some(x)
         case _               => None
@@ -54,16 +54,14 @@ private[rx] trait RxOptionOps[+A] extends Rx[A] {
   override def withFilter(f: A => Boolean): RxOption[A] = filter(f)
 }
 
-case class RxOption[+A](in: Rx[Option[A]]) extends RxOptionOps[A]
+case class RxOptionOp[+A](in: Rx[Option[A]]) extends RxOption[A]
 
 /**
   * RxVar implementation for Option[A] type values
-  * @param initValue
   * @tparam A
   */
-class RxOptionVar[A](initValue: Option[A]) extends RxOptionOps[A] with RxVarOps[Option[A]] {
+class RxOptionVar[A](variable: RxVar[Option[A]]) extends RxOption[A] with RxVarOps[Option[A]] {
   override def toString: String            = s"RxOptionVar(${variable.get})"
-  private val variable                     = new RxVar(initValue)
   override protected def in: Rx[Option[A]] = variable
 
   override def get: Option[A] = variable.get

--- a/airframe-http-rx/src/main/scala/wvlet/airframe/http/rx/RxOption.scala
+++ b/airframe-http-rx/src/main/scala/wvlet/airframe/http/rx/RxOption.scala
@@ -55,26 +55,16 @@ private[rx] trait RxOptionOps[+A] extends Rx[A] {
 
 case class RxOption[+A](in: Rx[Option[A]]) extends RxOptionOps[A]
 
-class RxOptionVar[A](initValue: A) extends RxOptionOps[A] {
-  private val variable                     = new RxVar(Option(initValue))
+class RxOptionVar[A](initValue: Option[A]) extends RxOptionOps[A] with RxVarOps[Option[A]] {
+  override def toString: String            = s"RxOptionVar(${variable.get})"
+  private val variable                     = new RxVar(initValue)
   override protected def in: Rx[Option[A]] = variable
 
-  def foreach[U](f: Option[A] => U): Cancelable = {
+  override def get: Option[A] = variable.get
+  override def foreach[U](f: Option[A] => U): Cancelable = {
     variable.foreach(f)
   }
-
-  def get: Option[A]                      = variable.get
-  def :=(newValue: Option[A]): Unit       = set(newValue)
-  def set(newValue: Option[A]): Unit      = update { x: Option[A] => newValue }
-  def forceSet(newValue: Option[A]): Unit = update({ x: Option[A] => newValue }, force = true)
-
-  /**
-    * Update the variable and force notification to subscribers
-    * @param updater
-    */
-  def forceUpdate(updater: Option[A] => Option[A]): Unit = update(updater, force = true)
-
-  def update(updater: Option[A] => Option[A], force: Boolean = false): Unit = {
+  override def update(updater: Option[A] => Option[A], force: Boolean = false): Unit = {
     variable.update(updater, force)
   }
 }

--- a/airframe-http-rx/src/main/scala/wvlet/airframe/http/rx/RxOption.scala
+++ b/airframe-http-rx/src/main/scala/wvlet/airframe/http/rx/RxOption.scala
@@ -1,6 +1,6 @@
 /*
  * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
+ * you may not use this fi
  * You may obtain a copy of the License at
  *
  *    http://www.apache.org/licenses/LICENSE-2.0
@@ -12,12 +12,13 @@
  * limitations under the License.
  */
 package wvlet.airframe.http.rx
-import wvlet.airframe.http.rx.Rx.{FlatMapOp, MapOp}
+import wvlet.airframe.http.rx.Rx.{FilterOp, FlatMapOp, MapOp}
 
 /**
   */
 case class RxOption[+A](in: Rx[Option[A]]) extends Rx[A] {
-  override def parents: Seq[Rx[_]] = Seq(in)
+  override def parents: Seq[Rx[_]]                 = Seq(in)
+  override def withName(name: String): RxOption[A] = RxOption(in.withName(name))
 
   override def map[B](f: A => B): RxOption[B] = {
     RxOption(MapOp(in, { x: Option[A] => x.map(f) }))
@@ -37,4 +38,15 @@ case class RxOption[+A](in: Rx[Option[A]]) extends Rx[A] {
       )
     )
   }
+
+  override def filter(f: A => Boolean): RxOption[A] = {
+    RxOption(
+      in.map {
+        case Some(x) if f(x) => Some(x)
+        case _               => None
+      }
+    )
+  }
+
+  override def withFilter(f: A => Boolean): RxOption[A] = filter(f)
 }

--- a/airframe-http-rx/src/main/scala/wvlet/airframe/http/rx/RxOption.scala
+++ b/airframe-http-rx/src/main/scala/wvlet/airframe/http/rx/RxOption.scala
@@ -54,7 +54,7 @@ private[rx] trait RxOption[+A] extends Rx[A] {
   override def withFilter(f: A => Boolean): RxOption[A] = filter(f)
 }
 
-case class RxOptionOp[+A](in: Rx[Option[A]]) extends RxOption[A]
+case class RxOptionOp[+A](override protected val in: Rx[Option[A]]) extends RxOption[A]
 
 /**
   * RxVar implementation for Option[A] type values

--- a/airframe-http-rx/src/main/scala/wvlet/airframe/http/rx/RxOption.scala
+++ b/airframe-http-rx/src/main/scala/wvlet/airframe/http/rx/RxOption.scala
@@ -15,6 +15,7 @@ package wvlet.airframe.http.rx
 import wvlet.airframe.http.rx.Rx.{FilterOp, FlatMapOp, MapOp}
 
 /**
+  * An wrapper of Rx[A] for Option[A] type values
   */
 private[rx] trait RxOptionOps[+A] extends Rx[A] {
   protected def in: Rx[Option[A]]
@@ -55,6 +56,11 @@ private[rx] trait RxOptionOps[+A] extends Rx[A] {
 
 case class RxOption[+A](in: Rx[Option[A]]) extends RxOptionOps[A]
 
+/**
+  * RxVar implementation for Option[A] type values
+  * @param initValue
+  * @tparam A
+  */
 class RxOptionVar[A](initValue: Option[A]) extends RxOptionOps[A] with RxVarOps[Option[A]] {
   override def toString: String            = s"RxOptionVar(${variable.get})"
   private val variable                     = new RxVar(initValue)

--- a/airframe-http-rx/src/main/scala/wvlet/airframe/http/rx/RxVar.scala
+++ b/airframe-http-rx/src/main/scala/wvlet/airframe/http/rx/RxVar.scala
@@ -14,6 +14,7 @@
 package wvlet.airframe.http.rx
 
 import scala.collection.mutable.ArrayBuffer
+import scala.language.higherKinds
 
 /**
   * A reactive variable supporting update and propagation of the updated value to the chained operators
@@ -22,6 +23,9 @@ class RxVar[A](protected var currentValue: A) extends Rx[A] with RxVarOps[A] {
   override def toString: String                       = s"RxVar(${currentValue})"
   override def parents: Seq[Rx[_]]                    = Seq.empty
   private var subscribers: ArrayBuffer[Subscriber[A]] = ArrayBuffer.empty
+
+  override def toOption[X, A1 >: A](implicit ev: A1 <:< Option[X]): RxOptionVar[X] =
+    new RxOptionVar(this.asInstanceOf[RxVar[Option[X]]])
 
   override def get: A = currentValue
 

--- a/airframe-http-rx/src/main/scala/wvlet/airframe/http/rx/RxVar.scala
+++ b/airframe-http-rx/src/main/scala/wvlet/airframe/http/rx/RxVar.scala
@@ -12,17 +12,15 @@
  * limitations under the License.
  */
 package wvlet.airframe.http.rx
-import wvlet.airframe.http.rx.Rx.RxBase
 
 import scala.collection.mutable.ArrayBuffer
 
 /**
   * A reactive variable supporting update and propagation of the updated value to the chained operators
   */
-class RxVar[A](protected var currentValue: A) extends RxBase[A] {
-  override def toString: String    = s"RxVar(${currentValue})"
-  override def parents: Seq[Rx[_]] = Seq.empty
-
+class RxVar[A](protected var currentValue: A) extends Rx[A] {
+  override def toString: String                       = s"RxVar(${currentValue})"
+  override def parents: Seq[Rx[_]]                    = Seq.empty
   private var subscribers: ArrayBuffer[Subscriber[A]] = ArrayBuffer.empty
 
   def get: A = currentValue
@@ -37,10 +35,15 @@ class RxVar[A](protected var currentValue: A) extends RxBase[A] {
     }
   }
 
-  def :=(newValue: A): Unit  = set(newValue)
-  def set(newValue: A): Unit = update { x: A => newValue }
-
+  def :=(newValue: A): Unit       = set(newValue)
+  def set(newValue: A): Unit      = update { x: A => newValue }
   def forceSet(newValue: A): Unit = update({ x: A => newValue }, force = true)
+
+  /**
+    * Update the variable and force notification to subscribers
+    * @param updater
+    */
+  def forceUpdate(updater: A => A): Unit = update(updater, force = true)
 
   /**
     * Updates the variable and trigger the recalculation of the subscribers
@@ -56,10 +59,4 @@ class RxVar[A](protected var currentValue: A) extends RxBase[A] {
       }
     }
   }
-
-  /**
-    * Update the variable and force notification to subscribers
-    * @param updater
-    */
-  def forceUpdate(updater: A => A): Unit = update(updater, force = true)
 }

--- a/airframe-http-rx/src/main/scala/wvlet/airframe/http/rx/RxVar.scala
+++ b/airframe-http-rx/src/main/scala/wvlet/airframe/http/rx/RxVar.scala
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.http.rx
+import wvlet.airframe.http.rx.Rx.RxBase
+
+import scala.collection.mutable.ArrayBuffer
+
+/**
+  * A reactive variable supporting update and propagation of the updated value to the chained operators
+  */
+class RxVar[A](protected var currentValue: A) extends RxBase[A] {
+  override def toString: String    = s"RxVar(${currentValue})"
+  override def parents: Seq[Rx[_]] = Seq.empty
+
+  private var subscribers: ArrayBuffer[Subscriber[A]] = ArrayBuffer.empty
+
+  def get: A = currentValue
+  def foreach[U](f: A => U): Cancelable = {
+    val s = Subscriber(f)
+    // Register a subscriber for propagating future changes
+    subscribers += s
+    f(currentValue)
+    Cancelable { () =>
+      // Unsubscribe if cancelled
+      subscribers -= s
+    }
+  }
+
+  def :=(newValue: A): Unit  = set(newValue)
+  def set(newValue: A): Unit = update { x: A => newValue }
+
+  def forceSet(newValue: A): Unit = update({ x: A => newValue }, force = true)
+
+  /**
+    * Updates the variable and trigger the recalculation of the subscribers
+    * currentValue => newValue
+    */
+  def update(updater: A => A, force: Boolean = false): Unit = {
+    val newValue = updater(currentValue)
+    if (force || currentValue != newValue) {
+      currentValue = newValue
+      subscribers.map { s =>
+        // The subscriber instance might be null if it is cleaned up in JS
+        Option(s).foreach(_.apply(newValue))
+      }
+    }
+  }
+
+  /**
+    * Update the variable and force notification to subscribers
+    * @param updater
+    */
+  def forceUpdate(updater: A => A): Unit = update(updater, force = true)
+}

--- a/airframe-http-rx/src/test/scala/wvlet/airframe/http/rx/RxOptionTest.scala
+++ b/airframe-http-rx/src/test/scala/wvlet/airframe/http/rx/RxOptionTest.scala
@@ -18,7 +18,7 @@ import wvlet.airspec.AirSpec
   */
 class RxOptionTest extends AirSpec {
   test("eval") {
-    val opt = Rx.option("world")
+    val opt = Rx.option(Some("world"))
     val v   = opt.map(x => s"hello ${x}")
     v.run(x => x shouldBe "hello world")
   }
@@ -30,39 +30,40 @@ class RxOptionTest extends AirSpec {
   }
 
   test("filter true") {
-    val opt = Rx.option("world")
+    val opt = Rx.option(Some("world"))
     val v   = opt.filter(_.startsWith("world")).map(x => s"hello ${x}")
     v.run(x => x shouldBe "hello world")
   }
 
   test("filter false") {
-    val opt = Rx.option("world")
+    val opt = Rx.option(Some("world"))
     val v   = opt.filter(_.startsWith("xxx")).map(x => s"hello ${x}")
     v.run(x => fail("should not reach here"))
   }
 
   test("add name") {
-    val r = Rx.option("hello").withName("opt test")
+    val r = Rx.option(Some("hello")).withName("opt test")
     debug(r)
   }
 
-  test("wrap null") {
-    val opt = Rx.option[String](null)
-    val x   = opt.map(x => x)
-    x.run(_ => fail("should not reach here"))
-  }
-
   test("flatMap") {
-    val opt = Rx.option("hello")
+    val opt = Rx.option(Some("hello"))
     val v   = opt.flatMap(x => Rx.const(s"hello ${x}"))
     v.run(x => x shouldBe "hello hello")
   }
 
   test("for-comprehension") {
-    val a = for (x <- Rx.option("hello")) yield {
+    val a = for (x <- Rx.option(Some("hello"))) yield {
       x + " world"
     }
     a.run(_ shouldBe "hello world")
+  }
+
+  test("toOption") {
+    val opt = Rx.const(Some("hello")).toOption
+    val a   = opt.map(x => s"${x} option")
+
+    a.run(_ shouldBe "hello option")
   }
 
   test("option variable") {

--- a/airframe-http-rx/src/test/scala/wvlet/airframe/http/rx/RxOptionTest.scala
+++ b/airframe-http-rx/src/test/scala/wvlet/airframe/http/rx/RxOptionTest.scala
@@ -85,4 +85,14 @@ class RxOptionTest extends AirSpec {
     o.run(_ shouldBe "good morning world")
   }
 
+  test("convert RxVar to RxOptionVar") {
+    val v = Rx(Some("hello")).toOption
+    val o = v.map { x => s"${x} world" }
+
+    o.run(_ shouldBe "hello world")
+
+    v := None
+    o.run(_ shouldBe None)
+  }
+
 }

--- a/airframe-http-rx/src/test/scala/wvlet/airframe/http/rx/RxOptionTest.scala
+++ b/airframe-http-rx/src/test/scala/wvlet/airframe/http/rx/RxOptionTest.scala
@@ -83,16 +83,23 @@ class RxOptionTest extends AirSpec {
 
     v.set(Some("good morning"))
     o.run(_ shouldBe "good morning world")
+      // We need to cancel the run to unregister the subscription
+      .cancel
+
+    v.set(None)
+    o.run(x => fail("should not reach here"))
   }
 
   test("convert RxVar to RxOptionVar") {
     val v = Rx(Some("hello")).toOption
     val o = v.map { x => s"${x} world" }
-
-    o.run(_ shouldBe "hello world")
+    o.run(_ shouldBe "hello world").cancel
 
     v := None
-    o.run(_ shouldBe None)
+    o.run(x => fail("should not reach here")).cancel
+
+    v := Some("good morning")
+    o.run(_ shouldBe "good morning world").cancel
   }
 
 }

--- a/airframe-http-rx/src/test/scala/wvlet/airframe/http/rx/RxOptionTest.scala
+++ b/airframe-http-rx/src/test/scala/wvlet/airframe/http/rx/RxOptionTest.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.http.rx
+import wvlet.airspec.AirSpec
+
+/**
+  */
+class RxOptionTest extends AirSpec {
+  test("eval RxOption") {
+    val opt = Rx.option("world")
+    val v   = opt.map(x => s"hello ${x}")
+    v.run(x => x shouldBe "hello world")
+  }
+
+  test("support none") {
+    val opt = Rx.none
+    val v   = opt.map(x => s"hello ${x}")
+    v.run(x => fail("should not reach here"))
+  }
+
+  test("filter true") {
+    val opt = Rx.option("world")
+    val v   = opt.filter(_.startsWith("world")).map(x => s"hello ${x}")
+    v.run(x => x shouldBe "hello world")
+  }
+
+  test("filter false") {
+    val opt = Rx.option("world")
+    val v   = opt.filter(_.startsWith("xxx")).map(x => s"hello ${x}")
+    v.run(x => fail("should not reach here"))
+  }
+}

--- a/airframe-http-rx/src/test/scala/wvlet/airframe/http/rx/RxOptionTest.scala
+++ b/airframe-http-rx/src/test/scala/wvlet/airframe/http/rx/RxOptionTest.scala
@@ -17,13 +17,13 @@ import wvlet.airspec.AirSpec
 /**
   */
 class RxOptionTest extends AirSpec {
-  test("eval RxOption") {
+  test("eval") {
     val opt = Rx.option("world")
     val v   = opt.map(x => s"hello ${x}")
     v.run(x => x shouldBe "hello world")
   }
 
-  test("support none") {
+  test("none") {
     val opt = Rx.none
     val v   = opt.map(x => s"hello ${x}")
     v.run(x => fail("should not reach here"))
@@ -40,4 +40,16 @@ class RxOptionTest extends AirSpec {
     val v   = opt.filter(_.startsWith("xxx")).map(x => s"hello ${x}")
     v.run(x => fail("should not reach here"))
   }
+
+  test("add name") {
+    val r = Rx.option("hello").withName("opt test")
+    info(r)
+  }
+
+  test("wrap null") {
+    val opt = Rx.option[String](null)
+    val x   = opt.map(x => x)
+    x.run(_ => fail("should not reach here"))
+  }
+
 }

--- a/airframe-http-rx/src/test/scala/wvlet/airframe/http/rx/RxOptionTest.scala
+++ b/airframe-http-rx/src/test/scala/wvlet/airframe/http/rx/RxOptionTest.scala
@@ -65,4 +65,23 @@ class RxOptionTest extends AirSpec {
     a.run(_ shouldBe "hello world")
   }
 
+  test("option variable") {
+    val v = Rx.optionVariable(Some("hello"))
+    val o = v.map { x => s"${x} world" }
+    o.run(_ shouldBe "hello world")
+  }
+
+  test("eval option variable") {
+    val v = Rx.optionVariable(Some("hello"))
+    v.run(_ shouldBe "hello")
+  }
+
+  test("set option variable") {
+    val v = Rx.optionVariable(Some("hello"))
+    val o = v.map { x => s"${x} world" }
+
+    v.set(Some("good morning"))
+    o.run(_ shouldBe "good morning world")
+  }
+
 }

--- a/airframe-http-rx/src/test/scala/wvlet/airframe/http/rx/RxOptionTest.scala
+++ b/airframe-http-rx/src/test/scala/wvlet/airframe/http/rx/RxOptionTest.scala
@@ -43,13 +43,26 @@ class RxOptionTest extends AirSpec {
 
   test("add name") {
     val r = Rx.option("hello").withName("opt test")
-    info(r)
+    debug(r)
   }
 
   test("wrap null") {
     val opt = Rx.option[String](null)
     val x   = opt.map(x => x)
     x.run(_ => fail("should not reach here"))
+  }
+
+  test("flatMap") {
+    val opt = Rx.option("hello")
+    val v   = opt.flatMap(x => Rx.const(s"hello ${x}"))
+    v.run(x => x shouldBe "hello hello")
+  }
+
+  test("for-comprehension") {
+    val a = for (x <- Rx.option("hello")) yield {
+      x + " world"
+    }
+    a.run(_ shouldBe "hello world")
   }
 
 }

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/codegen/GrpcClientGeneratorTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/codegen/GrpcClientGeneratorTest.scala
@@ -13,7 +13,6 @@
  */
 package wvlet.airframe.http.codegen
 import example.rpc.RPCExample
-import wvlet.airframe.http.RPC
 import wvlet.airspec.AirSpec
 
 /**


### PR DESCRIPTION
This is for simplifying Rx[Option[A]] handling. Currently, we need to nest multiple map calls:
```scala
val a = Rx.variable(Some("hello")) 
a.map { opt =>
   opt.map { x => div(s"message: ${x}") }
} // Rx[Option[RxElement]]
```

This code will be simpler like:
```scala
val a: RxOptionVar[A] = Rx.optionVariable(Some("hello"))
a.map { x => div(s" message: ${x}") } // Rx[Option[RxElement]]

a := Some("new value")
```

This PR also supports Rx[A].toOption if A is Option[_] type 

This also closes #1200 