### PR TITLE
airframe-grpc: Generate both sync and async clients inside the same class

### DIFF
--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/codegen/HttpClientIR.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/codegen/HttpClientIR.scala
@@ -76,8 +76,8 @@ object HttpClientIR extends LogSupport {
   case class ClientClassDef(clsName: String, services: Seq[ClientServiceDef])     extends ClientCodeIR
   case class ClientServiceDef(serviceName: String, methods: Seq[ClientMethodDef]) extends ClientCodeIR
   case class ClientRequestModelClassDef(name: String, parameter: Seq[Parameter]) {
-    def code =
-      s"private case class ${name}(${parameter
+    def code(isPrivate: Boolean = true) =
+      s"${if (isPrivate) "private " else ""}case class ${name}(${parameter
         .map { p =>
           s"${p.name}: ${p.surface.name}"
         }.mkString(", ")})"

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/codegen/client/ScalaHttpClient.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/codegen/client/ScalaHttpClient.scala
@@ -28,7 +28,14 @@ object ScalaHttpClient {
 
   def indent(body: String, level: Int = 1): String = {
     body
-      .split("\n").map { x => s"${"  " * level}${x}" }
+      .split("\n")
+      .map { x =>
+        if (x.trim.isEmpty) {
+          ""
+        } else {
+          s"${"  " * level}${x}"
+        }
+      }
       .mkString("\n")
   }
 }

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/codegen/client/ScalaHttpClient.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/codegen/client/ScalaHttpClient.scala
@@ -79,7 +79,7 @@ object AsyncClient extends HttpClientType {
 
           val lines = Seq.newBuilder[String]
           m.requestModelClassDef.foreach { x =>
-            lines += x.code
+            lines += x.code()
           }
           lines += s"def ${m.name}(${inputArgs.mkString(", ")}): F[${m.returnType}] = {"
           lines += s"  client.${m.clientMethodName}[${m.typeArgString}](${sendRequestArgs.result.mkString(", ")})"
@@ -135,7 +135,7 @@ object SyncClient extends HttpClientType {
 
           val lines = Seq.newBuilder[String]
           m.requestModelClassDef.foreach { x =>
-            lines += x.code
+            lines += x.code()
           }
           lines += s"def ${m.name}(${inputArgs.mkString(", ")}): ${m.returnType} = {"
           lines += s"  client.${m.clientMethodName}[${m.typeArgString}](${sendRequestArgs.result.mkString(", ")})"
@@ -201,7 +201,7 @@ object ScalaJSClient extends HttpClientType {
 
           val lines = Seq.newBuilder[String]
           m.requestModelClassDef.foreach { x =>
-            lines += x.code
+            lines += x.code()
           }
           lines += s"def ${m.name}(${inputArgs.mkString(", ")}): Future[${m.returnType}] = {"
           lines += s"  client.${m.clientMethodName}[${m.typeArgString}](${sendRequestArgs.result.mkString(", ")})"

--- a/airframe-http/.jvm/src/test/scala/example/grpc/Greeter.scala
+++ b/airframe-http/.jvm/src/test/scala/example/grpc/Greeter.scala
@@ -11,29 +11,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.airframe.http.codegen.client
-import wvlet.airframe.http.codegen.HttpClientIR.ClientSourceDef
+package example.grpc
+
+import wvlet.airframe.http.RPC
 
 /**
   */
-trait HttpClientType {
-  def name: String
-  def defaultFileName: String
-  def defaultClassName: String
-  def generate(src: ClientSourceDef): String
-}
-
-object HttpClientType {
-
-  def predefinedClients: Seq[HttpClientType] =
-    Seq(
-      AsyncClient,
-      SyncClient,
-      ScalaJSClient,
-      GrpcClient
-    )
-
-  def findClient(name: String): Option[HttpClientType] = {
-    predefinedClients.find(_.name == name)
-  }
+@RPC
+trait Greeter {
+  def sayHello(message: String): String
 }

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/codegen/GrpcClientGeneratorTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/codegen/GrpcClientGeneratorTest.scala
@@ -21,7 +21,6 @@ import wvlet.airspec.AirSpec
 class GrpcClientGeneratorTest extends AirSpec {
 
   test("generate sync gRPC client") {
-    pending()
     val code = HttpCodeGenerator.generate(
       RouteScanner.buildRouter(Seq(classOf[RPCExample])),
       HttpClientGeneratorConfig("example.api:grpc:example.api.client")

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/codegen/GrpcClientGeneratorTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/codegen/GrpcClientGeneratorTest.scala
@@ -12,20 +12,29 @@
  * limitations under the License.
  */
 package wvlet.airframe.http.codegen
+import example.grpc.Greeter
 import example.rpc.RPCExample
 import wvlet.airspec.AirSpec
 
 /**
   */
 class GrpcClientGeneratorTest extends AirSpec {
-  private val router =
-    RouteScanner.buildRouter(Seq(classOf[RPCExample]))
 
   test("generate sync gRPC client") {
+    pending()
     val code = HttpCodeGenerator.generate(
-      router,
-      HttpClientGeneratorConfig("example.api:grpc-sync:example.api.client")
+      RouteScanner.buildRouter(Seq(classOf[RPCExample])),
+      HttpClientGeneratorConfig("example.api:grpc:example.api.client")
     )
     debug(code)
   }
+
+  test("generate gRPC client") {
+    val code = HttpCodeGenerator.generate(
+      RouteScanner.buildRouter(Seq(classOf[Greeter])),
+      HttpClientGeneratorConfig("example.grpc:grpc")
+    )
+    debug(code)
+  }
+
 }

--- a/docs/airframe-rpc.md
+++ b/docs/airframe-rpc.md
@@ -210,7 +210,7 @@ Supported client types are:
 - __sync__: Create a sync HTTP client (ServiceSyncClient) for Scala (JVM)
 - __async__: Create an async HTTP client (ServiceClient) for Scala (JVM) using Future abstraction (`F`). The `F` can be `scala.concurrent.Future` or twitter-util's Future. 
 - __scalajs__:  Create an RPC client (ServiceClientJS)
-- __grpc__: Create a gRPC blocking client (ServiceGrpcClient)
+- __grpc__: Create a gRPC client (ServiceGrpcClient)
 
 To support other types of clients, see the examples of [HTTP code generators](https://github.com/wvlet/airframe/blob/master/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/codegen/client/ScalaHttpClient.scala). This code reads a Router definition of RPC interfaces, and generate client code for calling RPC endpoints. Currently, we only supports generating HTTP clients for Scala. In near future, we would like to add Open API spec generator so that many programming languages can be used with Airframe RPC.
 
@@ -439,16 +439,27 @@ gRPC.server
   .withPort(8080)
   .start { server =>
     // gRPC server (based on Netty) starts at localhost:8080
-
-    // Create a client channel
-    val channel = ManagedChannel.forTaget(server.localAddress).usePlaintext().build()
-
-    // Call gRPC server
-    val client = new ServiceGrpcSyncClient(channel)
-    val ret = client.GreeterApi.sayHello("Airframe gRPC") // Hello Airframe gRPC!     
-     
-    client.close()    
+    server.awaitTermination
   }
+```
+
+### gRPC Client
+
+```scala
+import example.api.ServiceClient
+
+// Create a client channel
+val channel = ManagedChannel.forTaget("localhost:8080").usePlaintext().build()
+
+// Create a gRPC blocking client (SyncClient)
+val client = ServiceGrpcClient.newSyncClient(channel)
+try {
+  // Call gRPC server
+  val ret = client.GreeterApi.sayHello("Airframe gRPC") // Hello Airframe gRPC!     
+}
+finally {
+  client.close()    
+}
 ```
 
 

--- a/docs/airframe-rpc.md
+++ b/docs/airframe-rpc.md
@@ -210,7 +210,7 @@ Supported client types are:
 - __sync__: Create a sync HTTP client (ServiceSyncClient) for Scala (JVM)
 - __async__: Create an async HTTP client (ServiceClient) for Scala (JVM) using Future abstraction (`F`). The `F` can be `scala.concurrent.Future` or twitter-util's Future. 
 - __scalajs__:  Create an RPC client (ServiceClientJS)
-- __grpc-sync__: Create a gRPC blocking client (ServiceGrpcSyncClient)
+- __grpc__: Create a gRPC blocking client (ServiceGrpcClient)
 
 To support other types of clients, see the examples of [HTTP code generators](https://github.com/wvlet/airframe/blob/master/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/codegen/client/ScalaHttpClient.scala). This code reads a Router definition of RPC interfaces, and generate client code for calling RPC endpoints. Currently, we only supports generating HTTP clients for Scala. In near future, we would like to add Open API spec generator so that many programming languages can be used with Airframe RPC.
 

--- a/docs/airframe-rpc.md
+++ b/docs/airframe-rpc.md
@@ -445,6 +445,10 @@ gRPC.server
 
 ### gRPC Client
 
+sbt-airframe generates ServiceGrpcClient class to the target API package. You can create sync (blocking) or async (non-blocking) gRPC clients using this class. 
+
+
+#### gRPC Sync Client
 ```scala
 import example.api.ServiceClient
 
@@ -462,6 +466,27 @@ finally {
 }
 ```
 
+#### gRPC Async Client
+```scala
+import example.api.ServiceClient
+import io.grpc.stub.StreamObserver
+
+// Create an async gRPC client
+val client = ServiceGrpcClient.newAsyncClient(channel)
+
+// Call gRPC server
+client.GreeterApi.sayHello("Airframe gRPC", new StreamObserver[String] { 
+  def onNext(v: String): Unit = {
+    // v == Hello Airframe gRPC!        
+  }
+  def onError(t: Throwable): Unit = {
+    // report the error
+  }
+  def onCompleted(): Unit = {
+    // RPC call completion 
+  }
+})
+```
 
 ## RPC Internals 
 

--- a/sbt-airframe/src/sbt-test/sbt-airframe/grpc/build.sbt
+++ b/sbt-airframe/src/sbt-test/sbt-airframe/grpc/build.sbt
@@ -27,7 +27,7 @@ lazy val server =
       fork in Test := true,
       airframeHttpGeneratorOption := "-l trace",
       airframeHttpClients := Seq(
-        "example.api:grpc-sync"
+        "example.api:grpc"
       ),
       libraryDependencies ++= Seq(
         "org.wvlet.airframe" %% "airframe-http-grpc" % sys.props("plugin.version")

--- a/sbt-airframe/src/sbt-test/sbt-airframe/grpc/server/src/test/scala/example/api/GreeterApiTest.scala
+++ b/sbt-airframe/src/sbt-test/sbt-airframe/grpc/server/src/test/scala/example/api/GreeterApiTest.scala
@@ -15,7 +15,7 @@ object GreeterApiTest extends AirSpec {
   test("test grpc server") {
     gRPC.server.withRouter(router).start { server =>
       val channel = ManagedChannelBuilder.forTarget(server.localAddress).usePlaintext().build()
-      val client  = new ServiceGrpcSyncClient(channel)
+      val client  = ServiceGrpcClient.newSyncClient(channel)
 
       val ret = client.GreeterApi.sayHello("Airframe gRPC")
       info(ret)

--- a/sbt-airframe/src/sbt-test/sbt-airframe/grpc/server/src/test/scala/example/api/GreeterApiTest.scala
+++ b/sbt-airframe/src/sbt-test/sbt-airframe/grpc/server/src/test/scala/example/api/GreeterApiTest.scala
@@ -1,27 +1,49 @@
 package example.api
 
 import wvlet.airspec._
+import wvlet.airframe._
 import wvlet.airframe.http._
 import wvlet.airframe.http.grpc.gRPC
+import wvlet.airframe.http.grpc.GrpcServer
 import io.grpc.ManagedChannelBuilder
+import io.grpc.ManagedChannel
+import io.grpc.stub.StreamObserver
 
 object GreeterApiTest extends AirSpec {
   class GreeterApiImpl extends GreeterApi {
     def sayHello(message: String): String = s"Hello ${message}!"
   }
-
   private val router = Router.of[GreeterApiImpl]
 
-  test("test grpc server") {
-    gRPC.server.withRouter(router).start { server =>
-      val channel = ManagedChannelBuilder.forTarget(server.localAddress).usePlaintext().build()
-      val client  = ServiceGrpcClient.newSyncClient(channel)
+  protected override def design = {
+    gRPC.server
+      .withRouter(router).design
+      .bind[ManagedChannel].toProvider { server: GrpcServer =>
+        ManagedChannelBuilder.forTarget(server.localAddress).usePlaintext().build()
+      }
+      .onShutdown(_.shutdownNow)
+  }
 
-      val ret = client.GreeterApi.sayHello("Airframe gRPC")
-      info(ret)
-      ret shouldBe "Hello Airframe gRPC!"
+  test("test grpc server") { channel: ManagedChannel =>
+    val syncClient = ServiceGrpcClient.newSyncClient(channel)
+    val ret        = syncClient.GreeterApi.sayHello("Airframe gRPC")
+    info(s"sync response: ${ret}")
+    ret shouldBe "Hello Airframe gRPC!"
 
-      client.close()
-    }
+    val asyncClient = ServiceGrpcClient.newAsyncClient(channel)
+    asyncClient.GreeterApi.sayHello(
+      "Airframe gRPC",
+      new StreamObserver[String] {
+        def onNext(v: String): Unit = {
+          logger.info(s"async response: ${v}")
+        }
+        def onError(t: Throwable): Unit = {
+          logger.error(t)
+        }
+        def onCompleted(): Unit = {
+          logger.info("completed")
+        }
+      }
+    )
   }
 }


### PR DESCRIPTION
Reorganized the generated gRPC client code to have a room for adding both sync and async client within the same class.

From this RPC interface definition:
```scala
package example.grpc
import wvlet.airframe.http.RPC
@RPC
trait Greeter {
  def sayHello(message: String): String
}
```

This PR generates the following code:
```scala
/**
 * === DO NOT EDIT THIS FILE ===
 * This code is generated by sbt-airframe plugin.
 */
package example.grpc

import wvlet.airframe.http._
import scala.collection.immutable.Map

object ServiceGrpcClient {
  import wvlet.airframe.msgpack.spi.MsgPack
  import wvlet.airframe.codec.{MessageCodec, MessageCodecFactory}
  import wvlet.airframe.http.grpc.GrpcServiceBuilder.{RPCRequestMarshaller, RPCResponseMarshaller}

  private def newDescriptorBuilder(fullMethodName:String) : io.grpc.MethodDescriptor.Builder[MsgPack, Any] = {
    io.grpc.MethodDescriptor.newBuilder[MsgPack, Any]()
      .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
      .setFullMethodName(fullMethodName)
      .setRequestMarshaller(RPCRequestMarshaller)
  }

  class GreeterDescriptors(codecFactory: MessageCodecFactory) {
    val sayHelloDescriptor: io.grpc.MethodDescriptor[MsgPack, Any] = {
      newDescriptorBuilder("example.grpc.Greeter/sayHello")
        .setResponseMarshaller(new RPCResponseMarshaller[Any](
          codecFactory.of[java.lang.String].asInstanceOf[MessageCodec[Any]]
        )).build()
    }
  }

  object GreeterModels {

  }

  def newSyncClient(
    channel: io.grpc.Channel,
    callOptions: io.grpc.CallOptions = io.grpc.CallOptions.DEFAULT,
    codecFactory: MessageCodecFactory = MessageCodecFactory.defaultFactoryForJSON
  ): SyncClient = new SyncClient(channel, callOptions, codecFactory)

  class SyncClient(
    val channel: io.grpc.Channel,
    callOptions: io.grpc.CallOptions = io.grpc.CallOptions.DEFAULT,
    codecFactory: MessageCodecFactory = MessageCodecFactory.defaultFactoryForJSON
  ) extends io.grpc.stub.AbstractBlockingStub[SyncClient](channel, callOptions) with java.lang.AutoCloseable {

    override protected def build(channel: io.grpc.Channel, callOptions: io.grpc.CallOptions): SyncClient = {
      new SyncClient(channel, callOptions, codecFactory)
    }

    override def close(): Unit = {
      channel match {
        case m: io.grpc.ManagedChannel => m.shutdownNow()
        case _ =>
      }
    }

    object Greeter {
      private val descriptors = new GreeterDescriptors(codecFactory)

      import io.grpc.stub.ClientCalls
      import GreeterModels._

      def sayHello(message: String): String = {
        val __m = Map("message" -> message)
        val codec = codecFactory.of[Map[String, Any]]
        ClientCalls
          .blockingUnaryCall(getChannel, descriptors.sayHelloDescriptor, getCallOptions, codec.toMsgPack(__m))
          .asInstanceOf[String]
      }
    }
  }

  def newAsyncClient(
    channel: io.grpc.Channel,
    callOptions: io.grpc.CallOptions = io.grpc.CallOptions.DEFAULT,
    codecFactory: MessageCodecFactory = MessageCodecFactory.defaultFactoryForJSON
  ): AsyncClient = new AsyncClient(channel, callOptions, codecFactory)

  class AsyncClient(
    val channel: io.grpc.Channel,
    callOptions: io.grpc.CallOptions = io.grpc.CallOptions.DEFAULT,
    codecFactory: MessageCodecFactory = MessageCodecFactory.defaultFactoryForJSON
  ) extends io.grpc.stub.AbstractAsyncStub[AsyncClient](channel, callOptions) with java.lang.AutoCloseable {

    override protected def build(channel: io.grpc.Channel, callOptions: io.grpc.CallOptions): AsyncClient = {
      new AsyncClient(channel, callOptions, codecFactory)
    }

    override def close(): Unit = {
      channel match {
        case m: io.grpc.ManagedChannel => m.shutdownNow()
        case _ =>
      }
    }

    object Greeter {
      private val descriptors = new GreeterDescriptors(codecFactory)

      import io.grpc.stub.ClientCalls
      import GreeterModels._

      def sayHello(message: String, responseObserver: io.grpc.stub.StreamObserver[String]): Unit = {
        val __m = Map("message" -> message)
        val codec = codecFactory.of[Map[String, Any]]
        ClientCalls
          .asyncUnaryCall(getChannel.newCall(descriptors.sayHelloDescriptor, getCallOptions), codec.toMsgPack(__m), responseObserver)
      }
    }
  }
}
```
