### PR TITLE
Replace a body's source with a byte array in memory

### DIFF
--- a/airframe-http-okhttp/src/main/scala/wvlet/airframe/http/okhttp/OkHttpRetryInterceptor.scala
+++ b/airframe-http-okhttp/src/main/scala/wvlet/airframe/http/okhttp/OkHttpRetryInterceptor.scala
@@ -1,6 +1,6 @@
 package wvlet.airframe.http.okhttp
 
-import okhttp3.{Interceptor, Response}
+import okhttp3.{Interceptor, Response, ResponseBody}
 import wvlet.airframe.control.ResultClass
 import wvlet.airframe.control.Retry.RetryContext
 import wvlet.airframe.http.HttpClientMaxRetryException
@@ -13,17 +13,17 @@ class OkHttpRetryInterceptor(retry: RetryContext) extends Interceptor {
   private def dispatch(retryContext: RetryContext, chain: Interceptor.Chain): Response = {
     val request = chain.request()
 
-    val response = Try(chain.proceed(request))
-    val resultClass = response match {
+    val (resultClass, response) = Try(chain.proceed(request)) match {
       case Success(r) =>
+        val res = inMemoryResponse(r)
         try {
-          retryContext.resultClassifier(r)
+          retryContext.resultClassifier(res) -> Some(res)
         } catch {
           case NonFatal(e) =>
-            retryContext.errorClassifier(e)
+            retryContext.errorClassifier(e) -> Some(res)
         }
       case Failure(e) =>
-        retryContext.errorClassifier(e)
+        retryContext.errorClassifier(e) -> None
     }
 
     resultClass match {
@@ -32,7 +32,7 @@ class OkHttpRetryInterceptor(retry: RetryContext) extends Interceptor {
       case ResultClass.Failed(isRetryable, cause, extraWait) =>
         if (!retryContext.canContinue) {
           // Reached the max retry
-          throw HttpClientMaxRetryException(OkHttpResponseWrapper(response.toOption.orNull), retryContext, cause)
+          throw HttpClientMaxRetryException(OkHttpResponseWrapper(response.orNull), retryContext, cause)
         } else if (!isRetryable) {
           // Non-retryable failure
           throw cause
@@ -45,6 +45,21 @@ class OkHttpRetryInterceptor(retry: RetryContext) extends Interceptor {
           dispatch(nextRetryContext, chain)
         }
     }
+  }
+
+  private def inMemoryResponse(response: Response) = {
+    Option(response.body)
+      .map { body =>
+        // The only stateful object is a body's source, which is a one-shot value and then must be closed.
+        // Replace it with a byte array in memory so that we can pass the response along.
+        val r = response
+          .newBuilder().body(ResponseBody.create(body.contentType, Try(body.bytes).getOrElse(Array.empty))).build()
+        body.close()
+        r
+      }.getOrElse {
+        // Response is not eligible for a body, which means it must not be closed
+        response
+      }
   }
 
   override def intercept(chain: Interceptor.Chain): Response = {


### PR DESCRIPTION
okhttp has modeled responses to be one-shot. They expect us to stream the response, decode it from JSON or another format, and use the result as a model object. This PR is to replace the streaming one with the in-memory one so that we can pass the response along, which is one of the options.

How about this solution?

Closes #1212