### PR TITLE
airframe-http-rx: Represent Rx values with OnNext, OnError, and OnCompletion

### DIFF
--- a/airframe-http-rx/.js/src/main/scala/wvlet/airframe/http/rx/html/DOMRenderer.scala
+++ b/airframe-http-rx/.js/src/main/scala/wvlet/airframe/http/rx/html/DOMRenderer.scala
@@ -14,10 +14,11 @@
 package wvlet.airframe.http.rx.html
 
 import org.scalajs.dom
-import wvlet.airframe.http.rx.{Cancelable, Rx}
+import wvlet.airframe.http.rx.{Cancelable, OnCompletion, OnError, OnNext, Rx, RxRunner}
 import wvlet.log.LogSupport
 
 import scala.scalajs.js
+import scala.util.Try
 
 /**
   * Convert HtmlNodes into DOM elements for Scala.js
@@ -87,7 +88,7 @@ object DOMRenderer extends LogSupport {
             c1.cancel
             c1 = traverse(value, Some(start))
           }
-          Cancelable.merge(c1, c2)
+          Cancelable { () => Try(c1.cancel); Try(c2.cancel) }
         case a: HtmlAttribute =>
           addAttribute(node, a)
         case n: dom.Node =>
@@ -100,7 +101,7 @@ object DOMRenderer extends LogSupport {
           val elem = node.lastChild
           val c2   = rx.traverseModifiers(m => renderTo(elem, m))
           node.mountHere(elem, anchor)
-          Cancelable.merge(c1, c2)
+          Cancelable { () => Try(c1.cancel); Try(c2.cancel) }
         case s: String =>
           val textNode = newTextNode(s)
           node.mountHere(textNode, anchor)

--- a/airframe-http/src/main/scala/wvlet/airframe/http/rx/Rx.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/rx/Rx.scala
@@ -51,12 +51,14 @@ trait Rx[+A] extends LogSupport {
   def toOption[X, A1 >: A](implicit ev: A1 <:< Option[X]): RxOption[X] = RxOptionOp(this.asInstanceOf[Rx[Option[X]]])
 
   /**
-    * Recover a known error to
-    * @param f
-    * @tparam U
-    * @return
+    * Recover from a known error and emit a replacement value
     */
   def recover[U](f: PartialFunction[Throwable, U]): Rx[U] = RecoverOp(this, f)
+
+  /**
+    * Recover from a known error and emit replacement values from a given Rx
+    */
+  def recoverWith[U](f: PartialFunction[Throwable, Rx[U]]): Rx[U] = RecoverWithOp(this, f)
 
   /**
     * Subscribe any change in the upstream, and if a change is detected,
@@ -145,5 +147,6 @@ object Rx extends LogSupport {
   case class NamedOp[A](input: Rx[A], name: String) extends UnaryRx[A, A] {
     override def toString: String = s"${name}:${input}"
   }
-  case class RecoverOp[A, U](input: Rx[A], f: PartialFunction[Throwable, U]) extends UnaryRx[A, U]
+  case class RecoverOp[A, U](input: Rx[A], f: PartialFunction[Throwable, U])         extends UnaryRx[A, U]
+  case class RecoverWithOp[A, U](input: Rx[A], f: PartialFunction[Throwable, Rx[U]]) extends UnaryRx[A, U]
 }

--- a/airframe-http/src/main/scala/wvlet/airframe/http/rx/Rx.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/rx/Rx.scala
@@ -87,7 +87,7 @@ trait Rx[+A] extends LogSupport {
     }
 
   private[rx] def runInternal[U](effect: RxEvent => U): Cancelable = {
-    RxRunner.runInternal(this)(effect)
+    RxRunner.run(this)(effect)
   }
 }
 

--- a/airframe-http/src/main/scala/wvlet/airframe/http/rx/Rx.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/rx/Rx.scala
@@ -88,7 +88,7 @@ object Rx extends LogSupport {
   /**
     * Create a sequence of values from Seq[A]
     */
-  def fromSeq[A](lst: Seq[A]): Rx[A] = SeqOp(LazyF0(lst))
+  def fromSeq[A](lst: => Seq[A]): Rx[A] = SeqOp(LazyF0(lst))
 
   /**
     * Create a sequence of values

--- a/airframe-http/src/main/scala/wvlet/airframe/http/rx/Rx.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/rx/Rx.scala
@@ -48,8 +48,9 @@ trait Rx[+A] extends LogSupport {
     * Using joins will be more intuitive than nesting multiple Rx operators
     * like Rx[A].map { x => ... Rx[B].map { ...} }.
     */
-  def join[B](other: Rx[B]): Rx[(A, B)]             = JoinOp(this, other)
-  def join[B, C](b: Rx[B], c: Rx[C]): Rx[(A, B, C)] = Join3Op(this, b, c)
+  def join[B](other: Rx[B]): Rx[(A, B)]                             = JoinOp(this, other)
+  def join[B, C](b: Rx[B], c: Rx[C]): Rx[(A, B, C)]                 = Join3Op(this, b, c)
+  def join[B, C, D](b: Rx[B], c: Rx[C], d: Rx[D]): Rx[(A, B, C, D)] = Join4Op(this, b, c, d)
 
   def concat[A1 >: A](other: Rx[A1]): Rx[A1] = ConcatOp(this, other)
   def lastOption: RxOption[A]                = LastOp(this).toOption
@@ -175,6 +176,9 @@ object Rx extends LogSupport {
   }
   case class Join3Op[A, B, C](a: Rx[A], b: Rx[B], c: Rx[C]) extends Rx[(A, B, C)] {
     override def parents: Seq[Rx[_]] = Seq(a, b, c)
+  }
+  case class Join4Op[A, B, C, D](a: Rx[A], b: Rx[B], c: Rx[C], d: Rx[D]) extends Rx[(A, B, C, D)] {
+    override def parents: Seq[Rx[_]] = Seq(a, b, c, d)
   }
 
   case class ConcatOp[A](first: Rx[A], next: Rx[A]) extends Rx[A] {

--- a/airframe-http/src/main/scala/wvlet/airframe/http/rx/Rx.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/rx/Rx.scala
@@ -54,9 +54,9 @@ trait Rx[+A] extends LogSupport {
     * @return
     */
   def subscribe[U](subscriber: A => U): Cancelable = {
-    Rx.run(this)(subscriber)
+    RxRunner.run(this)(subscriber)
   }
-  def run(effect: A => Unit): Cancelable = Rx.run(this)(effect)
+  def run(effect: A => Unit): Cancelable = RxRunner.run(this)(effect)
 }
 
 object Rx extends LogSupport {
@@ -79,104 +79,6 @@ object Rx extends LogSupport {
     val v = Rx.variable[Option[A]](None)
     f.foreach { x => v := Some(x) }
     v
-  }
-
-  /**
-    * Build a executable chain of Rx operators, and the resulting chain
-    * will be registered to the root node (e.g. RxVar). If the root value changes,
-    * the effect code block will be executed.
-    *
-    * @param rx
-    * @param effect
-    * @tparam A
-    * @tparam U
-    * @return
-    */
-  private def run[A, U](rx: Rx[A])(effect: A => U): Cancelable = {
-    rx match {
-      case MapOp(in, f) =>
-        run(in)(x => effect(f.asInstanceOf[Any => A](x)))
-      case FlatMapOp(in, f) =>
-        // This var is a placeholder to remember the preceding Cancelable operator, which will be updated later
-        var c1 = Cancelable.empty
-        val c2 = run(in) { x =>
-          val rxb = f.asInstanceOf[Any => Rx[A]](x)
-          // This code is necessary to properly cancel the effect if this operator is evaluated before
-          c1.cancel
-          c1 = run(rxb)(effect)
-        }
-        Cancelable { () => c1.cancel; c2.cancel }
-      case FilterOp(in, cond) =>
-        run(in) { x =>
-          if (cond.asInstanceOf[A => Boolean](x)) {
-            effect(x)
-          }
-        }
-      case ZipOp(left, right) =>
-        var allReady: Boolean = false
-        var v1: Any           = null
-        var v2: Any           = null
-        val c1 = run(left) { x =>
-          v1 = x
-          if (allReady) {
-            effect((v1, v2).asInstanceOf[A])
-          }
-        }
-        val c2 = run(right) { x =>
-          v2 = x
-          if (allReady) {
-            effect((v1, v2).asInstanceOf[A])
-          }
-        }
-        allReady = true
-        effect((v1, v2).asInstanceOf[A])
-        Cancelable { () => c1.cancel; c2.cancel }
-      case Zip3Op(r1, r2, r3) =>
-        var allReady: Boolean = false
-        var v1: Any           = null
-        var v2: Any           = null
-        var v3: Any           = null
-        val c1 = run(r1) { x =>
-          v1 = x
-          if (allReady) {
-            effect((v1, v2, v3).asInstanceOf[A])
-          }
-        }
-        val c2 = run(r2) { x =>
-          v2 = x
-          if (allReady) {
-            effect((v1, v2, v3).asInstanceOf[A])
-          }
-        }
-        val c3 = run(r3) { x =>
-          v3 = x
-          if (allReady) {
-            effect((v1, v2, v3).asInstanceOf[A])
-          }
-        }
-        allReady = true
-        effect((v1, v2, v3).asInstanceOf[A])
-        Cancelable { () => c1.cancel; c2.cancel }
-      case RxOptionOp(in) =>
-        run(in) {
-          case Some(v) => effect(v)
-          case None    =>
-          // Do nothing
-        }
-      case NamedOp(input, name) =>
-        run(input)(effect)
-      case SingleOp(v) =>
-        effect(v)
-        Cancelable.empty
-      case o: RxOptionVar[_] =>
-        o.asInstanceOf[RxOptionVar[A]].foreach {
-          case Some(v) => effect(v)
-          case None    =>
-          // Do nothing
-        }
-      case v: RxVar[_] =>
-        v.asInstanceOf[RxVar[A]].foreach(effect)
-    }
   }
 
   abstract class UnaryRx[I, A] extends Rx[A] {

--- a/airframe-http/src/main/scala/wvlet/airframe/http/rx/RxEvent.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/rx/RxEvent.scala
@@ -14,20 +14,10 @@
 package wvlet.airframe.http.rx
 
 /**
+  * Observable event types. http://reactivex.io/documentation/observable.html
   */
-sealed trait RxEvent {
-  def isLastEvent: Boolean
-  def isError: Boolean
-}
-case class OnNext(v: Any) extends RxEvent {
-  override def isLastEvent: Boolean = false
-  override def isError: Boolean     = false
-}
-case class OnError(e: Throwable) extends RxEvent {
-  override def isLastEvent: Boolean = true
-  override def isError: Boolean     = true
-}
-case object OnCompletion extends RxEvent {
-  override def isLastEvent: Boolean = true
-  override def isError: Boolean     = false
-}
+sealed trait RxEvent
+
+case class OnNext(v: Any)        extends RxEvent
+case class OnError(e: Throwable) extends RxEvent
+case object OnCompletion         extends RxEvent

--- a/airframe-http/src/main/scala/wvlet/airframe/http/rx/RxEvent.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/rx/RxEvent.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.http.rx
+
+/**
+  */
+sealed trait RxEvent {
+  def isLastEvent: Boolean
+  def isError: Boolean
+}
+case class OnNext(v: Any) extends RxEvent {
+  override def isLastEvent: Boolean = false
+  override def isError: Boolean     = false
+}
+case class OnError(e: Throwable) extends RxEvent {
+  override def isLastEvent: Boolean = true
+  override def isError: Boolean     = true
+}
+case object OnCompletion extends RxEvent {
+  override def isLastEvent: Boolean = true
+  override def isError: Boolean     = false
+}

--- a/airframe-http/src/main/scala/wvlet/airframe/http/rx/RxRunner.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/rx/RxRunner.scala
@@ -16,8 +16,29 @@ object RxRunner extends LogSupport {
   // Used for continuous RxVar evaluation (e.g., RxVar -> DOM rendering)
   private val continuousRunner = new RxRunner(continuous = true)
 
-  def run[A, U](rx: Rx[A])(effect: RxEvent => U): Cancelable             = defaultRunner.run(rx)(effect)
-  def runContinuously[A, U](rx: Rx[A])(effect: RxEvent => U): Cancelable = continuousRunner.run(rx)(effect)
+  def run[A, U](rx: Rx[A])(effect: RxEvent => U): Cancelable =
+    defaultRunner.run(rx) { ev =>
+      ev match {
+        case v @ OnNext(_) =>
+          effect(v)
+          true
+        case other =>
+          effect(other)
+          false
+      }
+    }
+
+  def runContinuously[A, U](rx: Rx[A])(effect: RxEvent => U): Cancelable =
+    continuousRunner.run(rx) { ev =>
+      ev match {
+        case v @ OnNext(_) =>
+          effect(v)
+          true
+        case other =>
+          effect(other)
+          false
+      }
+    }
 }
 
 class RxRunner(
@@ -31,125 +52,11 @@ class RxRunner(
     * the effect code block will be executed.
     *
     * @param rx
-    * @param effect
+    * @param effect toContinue
     * @tparam A
-    * @tparam U
     */
-  def run[A, U](rx: Rx[A])(effect: RxEvent => U): Cancelable = {
+  def run[A](rx: Rx[A])(effect: RxEvent => Boolean): Cancelable = {
     rx match {
-      case MapOp(in, f) =>
-        var toContinue = true
-        run(in) { ev =>
-          if (continuous || toContinue) {
-            ev match {
-              case OnNext(v) =>
-                Try(f.asInstanceOf[Any => A](v)) match {
-                  case Success(x) => effect(OnNext(x))
-                  case Failure(e) =>
-                    toContinue = false
-                    effect(OnError(e))
-                }
-              case other =>
-                toContinue = false
-                effect(other)
-            }
-          }
-        }
-      case fm @ FlatMapOp(in, f) =>
-        var toContinue = true
-        // This var is a placeholder to remember the preceding Cancelable operator, which will be updated later
-        var c1 = Cancelable.empty
-        val c2 = run(fm.input) { ev =>
-          if (continuous || toContinue) {
-            ev match {
-              case OnNext(x) =>
-                Try(fm.f.asInstanceOf[Any => Rx[A]](x)) match {
-                  case Success(rxb) =>
-                    // This code is necessary to properly cancel the effect if this operator is evaluated before
-                    c1.cancel
-                    c1 = run(rxb.asInstanceOf[Rx[A]]) {
-                      case n @ OnNext(x) => effect(n)
-                      case OnCompletion  => // skip the end of flatMap body stream
-                      case ev @ OnError(e) =>
-                        toContinue = false
-                        effect(ev)
-                    }
-                  case Failure(e) =>
-                    toContinue = false
-                    effect(OnError(e))
-                }
-              case other =>
-                toContinue = false
-                effect(other)
-            }
-          }
-        }
-        Cancelable { () => c1.cancel; c2.cancel }
-      case FilterOp(in, cond) =>
-        var toContinue = true
-        run(in) { ev =>
-          if (continuous || toContinue) {
-            ev match {
-              case OnNext(x) =>
-                Try(cond.asInstanceOf[A => Boolean](x.asInstanceOf[A])) match {
-                  case Success(true) =>
-                    effect(OnNext(x))
-                  case Success(false) =>
-                  // Skip unmatched element
-                  case Failure(e) =>
-                    toContinue = false
-                    effect(OnError(e))
-                }
-              case other =>
-                toContinue = false
-                effect(other)
-            }
-          }
-        }
-      case ConcatOp(first, next) =>
-        var c1 = Cancelable.empty
-        val c2 = run(first) {
-          case OnCompletion =>
-            // Properly cancel the effect if this operator is evaluated before
-            c1.cancel
-            c1 = run(next)(effect)
-            c1
-          case other =>
-            effect(other)
-        }
-        Cancelable { () => c1.cancel; c2.cancel }
-      case LastOp(in) =>
-        var last: Option[A] = None
-        run(in) {
-          case OnNext(v) =>
-            last = Some(v.asInstanceOf[A])
-          case err @ OnError(e) =>
-            effect(err)
-          case OnCompletion =>
-            Try(effect(OnNext(last))) match {
-              case Success(v) => effect(OnCompletion)
-              case Failure(e) => effect(OnError(e))
-            }
-        }
-      case z @ ZipOp(r1, r2) =>
-        zip(z)(effect)
-      case z @ Zip3Op(r1, r2, r3) =>
-        zip(z)(effect)
-      case j @ JoinOp(r1, r2) =>
-        join(j)(effect)
-      case j @ Join3Op(r1, r2, r3) =>
-        join(j)(effect)
-      case j @ Join4Op(r1, r2, r3, r4) =>
-        join(j)(effect)
-      case RxOptionOp(in) =>
-        run(in) {
-          case OnNext(Some(v)) => effect(OnNext(v))
-          case OnNext(None)    =>
-          // do nothing for empty values
-          case other => effect(other)
-        }
-      case NamedOp(input, name) =>
-        run(input)(effect)
       case SingleOp(v) =>
         Try(effect(OnNext(v.eval))) match {
           case Success(c) => effect(OnCompletion)
@@ -163,13 +70,10 @@ class RxRunner(
           if (continuous || toContinue) {
             lst match {
               case Nil =>
-                effect(OnCompletion)
+                toContinue = effect(OnCompletion)
               case head :: tail =>
-                Try(effect(OnNext(head))) match {
-                  case Success(x) => loop(tail)
-                  case Failure(e) =>
-                    effect(OnError(e))
-                }
+                toContinue = effect(OnNext(head))
+                loop(tail)
             }
           }
         }
@@ -178,6 +82,116 @@ class RxRunner(
         Cancelable { () =>
           toContinue = false
         }
+      case MapOp(in, f) =>
+        run(in) {
+          case OnNext(v) =>
+            Try(f.asInstanceOf[Any => A](v)) match {
+              case Success(x) =>
+                effect(OnNext(x))
+              case Failure(e) =>
+                effect(OnError(e))
+            }
+          case other =>
+            effect(other)
+        }
+      case fm @ FlatMapOp(in, f) =>
+        // This var is a placeholder to remember the preceding Cancelable operator, which will be updated later
+        var c1 = Cancelable.empty
+        val c2 = run(fm.input) {
+          case OnNext(x) =>
+            var toContinue = true
+            Try(fm.f(x)) match {
+              case Success(rxb) =>
+                // This code is necessary to properly cancel the effect if this operator is evaluated before
+                c1.cancel
+                c1 = run(rxb.asInstanceOf[Rx[A]]) {
+                  case n @ OnNext(x) =>
+                    toContinue = effect(n)
+                    toContinue
+                  case OnCompletion =>
+                    // skip the end of the nested flatMap body stream
+                    true
+                  case ev @ OnError(e) =>
+                    toContinue = effect(ev)
+                    toContinue
+                }
+                toContinue
+              case Failure(e) =>
+                effect(OnError(e))
+            }
+          case other =>
+            effect(other)
+        }
+        Cancelable { () => c1.cancel; c2.cancel }
+//      case FilterOp(in, cond) =>
+//        var toContinue = true
+//        run(in) { ev =>
+//          if (continuous || toContinue) {
+//            ev match {
+//              case OnNext(x) =>
+//                Try(cond.asInstanceOf[A => Boolean](x.asInstanceOf[A])) match {
+//                  case Success(true) =>
+//                    effect(OnNext(x))
+//                  case Success(false) =>
+//                  // Skip unmatched element
+//                  case Failure(e) =>
+//                    toContinue = false
+//                    effect(OnError(e))
+//                }
+//              case other =>
+//                toContinue = false
+//                effect(other)
+//            }
+//          }
+//        }
+      case ConcatOp(first, next) =>
+        var c1 = Cancelable.empty
+        val c2 = run(first) {
+          case OnCompletion =>
+            var toContinue = true
+            // Properly cancel the effect if this operator is evaluated before
+            c1.cancel
+            c1 = run(next) { ev =>
+              toContinue = effect(ev)
+              toContinue
+            }
+            toContinue
+          case other =>
+            effect(other)
+        }
+        Cancelable { () => c1.cancel; c2.cancel }
+//      case LastOp(in) =>
+//        var last: Option[A] = None
+//        run(in) {
+//          case OnNext(v) =>
+//            last = Some(v.asInstanceOf[A])
+//          case err @ OnError(e) =>
+//            effect(err)
+//          case OnCompletion =>
+//            Try(effect(OnNext(last))) match {
+//              case Success(v) => effect(OnCompletion)
+//              case Failure(e) => effect(OnError(e))
+//            }
+//        }
+//      case z @ ZipOp(r1, r2) =>
+//        zip(z)(effect)
+//      case z @ Zip3Op(r1, r2, r3) =>
+//        zip(z)(effect)
+//      case j @ JoinOp(r1, r2) =>
+//        join(j)(effect)
+//      case j @ Join3Op(r1, r2, r3) =>
+//        join(j)(effect)
+//      case j @ Join4Op(r1, r2, r3, r4) =>
+//        join(j)(effect)
+//      case RxOptionOp(in) =>
+//        run(in) {
+//          case OnNext(Some(v)) => effect(OnNext(v))
+//          case OnNext(None)    =>
+//          // do nothing for empty values
+//          case other => effect(other)
+//        }
+//      case NamedOp(input, name) =>
+//        run(input)(effect)
       case TryOp(e) =>
         e match {
           case Success(x) =>
@@ -186,182 +200,198 @@ class RxRunner(
             effect(OnError(e))
         }
         Cancelable.empty
-      case o: RxOptionVar[_] =>
-        o.asInstanceOf[RxOptionVar[A]].foreach {
-          case Some(v) => effect(OnNext(v))
-          case None    =>
-          // Do nothing
-        }
-      case v: RxVar[_] =>
-        v.asInstanceOf[RxVar[A]].foreach { x => effect(OnNext(x)) }
-      case RecoverOp(in, f) =>
-        run(in) {
-          case OnError(e) if f.isDefinedAt(e) =>
-            Try(effect(OnNext(f(e)))) match {
-              case Success(x) => effect(OnCompletion)
-              case Failure(e) => effect(OnError(e))
-            }
-          case other =>
-            effect(other)
-        }
-      case RecoverWithOp(in, f) =>
-        var completed = false
-        var c1        = Cancelable.empty
-        val c2 = run(in) {
-          case OnError(e) if f.isDefinedAt(e) =>
-            c1.cancel
-            Try(f(e)) match {
-              case Success(recoverySource) =>
-                c1 = run(recoverySource)(effect)
-              case Failure(e) =>
-                completed = true
-                effect(OnError(e))
-            }
-          case e if e.isLastEvent && completed =>
-          // Skip reporting the completion event
-          case other =>
-            effect(other)
-        }
-        Cancelable { () => c1.cancel; c2.cancel }
+//      case o: RxOptionVar[_] =>
+//        o.asInstanceOf[RxOptionVar[A]].foreach {
+//          case Some(v) => effect(OnNext(v))
+//          case None    =>
+//          // Do nothing
+//        }
+//      case v: RxVar[_] =>
+//        v.asInstanceOf[RxVar[A]].foreach { x => effect(OnNext(x)) }
+//      case RecoverOp(in, f) =>
+//        var toContinue = true
+//        run(in) { ev =>
+//          warn(ev)
+//          if (continuous || toContinue) {
+//            ev match {
+//              case OnNext(v) =>
+//                effect(ev)
+//              case OnError(e) if f.isDefinedAt(e) =>
+//                Try(effect(OnNext(f(e)))) match {
+//                  case Success(x) =>
+//                  // recovery succeeded
+//                  case Failure(e) =>
+//                    toContinue = false
+//                    effect(OnError(e))
+//                }
+//              case other =>
+//                toContinue = false
+//                effect(other)
+//            }
+//          }
+//        }
+//      case RecoverWithOp(in, f) =>
+//        var toContinue = true
+//        var c1         = Cancelable.empty
+//        val c2 = run(in) { ev =>
+//          if (continuous || toContinue) {
+//            ev match {
+//              case OnError(e) if f.isDefinedAt(e) =>
+//                c1.cancel
+//                Try(f(e)) match {
+//                  case Success(recoverySource) =>
+//                    c1 = run(recoverySource)(effect)
+//                  case Failure(e) =>
+//                    toContinue = false
+//                    effect(OnError(e))
+//                }
+//              case e if e.isLastEvent && !toContinue =>
+//              // Skip reporting the completion event
+//              case other =>
+//                effect(other)
+//            }
+//          }
+//        }
+//        Cancelable { () => c1.cancel; c2.cancel }
     }
   }
-
-  /**
-    * A base implementation for merging streams and generating tuples
-    * @param input
-    * @tparam A
-    */
-  private[rx] abstract class CombinedStream[A](input: Rx[A]) extends LogSupport {
-    protected val size = input.parents.size
-
-    protected val lastEvent: Array[Option[RxEvent]] = Array.fill(size)(None)
-    private val c: Array[Cancelable]                = Array.fill(size)(Cancelable.empty)
-    private val completed: AtomicBoolean            = new AtomicBoolean(false)
-
-    protected def nextValue: Option[Seq[Any]]
-
-    protected def update(index: Int, v: A): Unit
-
-    protected def isCompleted: Boolean
-
-    def run[U](effect: RxEvent => U): Cancelable = {
-      def emit: Unit = {
-        // Emit the tuple result.
-        nextValue match {
-          case None =>
-          // Nothing to emit
-          case Some(values) =>
-            // Generate tuples from last values.
-            // This code is a bit ad-hoc because there is no way to produce tuples from Seq[X] of lastValues
-            values.size match {
-              case 2 =>
-                effect(OnNext((values(0), values(1)).asInstanceOf[A]))
-              case 3 =>
-                effect(OnNext((values(0), values(1), values(2)).asInstanceOf[A]))
-              case 4 =>
-                effect(OnNext((values(0), values(1), values(2), values(3)).asInstanceOf[A]))
-              case _ => ???
-            }
-        }
-      }
-
-      // Scan the last events and emit the next value or a completion event
-      def processEvents(doEmit: Boolean) = {
-        val errors = lastEvent.collect { case Some(e @ OnError(ex)) => ex }
-        if (errors.isEmpty) {
-          if (doEmit) {
-            emit
-          } else {
-            if (isCompleted && completed.compareAndSet(false, true)) {
-              trace(s"emit OnCompletion")
-              effect(OnCompletion)
-            }
-          }
-        } else {
-          // Report the completion event only once
-          if (continuous || completed.compareAndSet(false, true)) {
-            if (errors.size == 1) {
-              effect(OnError(errors(0)))
-            } else {
-              effect(OnError(MultipleExceptions(errors.toSeq)))
-            }
-          }
-        }
-      }
-
-      for (i <- 0 until size) {
-        c(i) = runner.run(input.parents(i)) { e =>
-          lastEvent(i) = Some(e)
-          trace(s"c(${i}) ${e}")
-          e match {
-            case OnNext(v) =>
-              update(i, v.asInstanceOf[A])
-              processEvents(true)
-            case _ =>
-              processEvents(false)
-          }
-        }
-      }
-
-      processEvents(false)
-      Cancelable { () => c.foreach(_.cancel) }
-    }
-  }
-
-  private class ZipStream[A](input: Rx[A]) extends CombinedStream(input) {
-    private val lastValueBuffer: Array[Queue[A]] = Array.fill(size)(Queue.empty[A])
-
-    override protected def nextValue: Option[Seq[Any]] = {
-      if (lastValueBuffer.forall(_.nonEmpty)) {
-        val values = for (i <- 0 until lastValueBuffer.size) yield {
-          val (v, newQueue) = lastValueBuffer(i).dequeue
-          lastValueBuffer(i) = newQueue
-          v
-        }
-        Some(values)
-      } else {
-        None
-      }
-    }
-
-    override protected def update(index: Int, v: A): Unit = {
-      lastValueBuffer(index) = lastValueBuffer(index).enqueue(v)
-    }
-
-    override protected def isCompleted: Boolean = {
-      !continuous && lastEvent.forall(_.isDefined)
-    }
-  }
-
-  private def zip[A, U](input: Rx[A])(effect: RxEvent => U): Cancelable = {
-    new ZipStream(input).run(effect)
-  }
-
-  private class JoinStream[A](input: Rx[A]) extends CombinedStream(input) {
-    private val lastValue: Array[Option[A]] = Array.fill(size)(None)
-
-    override protected def nextValue: Option[Seq[Any]] = {
-      if (lastValue.forall(_.nonEmpty)) {
-        val values = for (i <- 0 until lastValue.size) yield {
-          lastValue(i).get
-        }
-        Some(values)
-      } else {
-        None
-      }
-    }
-
-    override protected def update(index: Int, v: A): Unit = {
-      lastValue(index) = Some(v)
-    }
-
-    override protected def isCompleted: Boolean = {
-      !continuous && lastEvent.forall(x => x.isDefined && x.get == OnCompletion)
-    }
-  }
-
-  private def join[A, U](input: Rx[A])(effect: RxEvent => U): Cancelable = {
-    new JoinStream(input).run(effect)
-  }
+//
+//  /**
+//    * A base implementation for merging streams and generating tuples
+//    * @param input
+//    * @tparam A
+//    */
+//  private[rx] abstract class CombinedStream[A](input: Rx[A]) extends LogSupport {
+//    protected val size = input.parents.size
+//
+//    protected val lastEvent: Array[Option[RxEvent]] = Array.fill(size)(None)
+//    private val c: Array[Cancelable]                = Array.fill(size)(Cancelable.empty)
+//    private val completed: AtomicBoolean            = new AtomicBoolean(false)
+//
+//    protected def nextValue: Option[Seq[Any]]
+//
+//    protected def update(index: Int, v: A): Unit
+//
+//    protected def isCompleted: Boolean
+//
+//    def run[U](effect: RxEvent => U): Cancelable = {
+//      def emit: Unit = {
+//        // Emit the tuple result.
+//        nextValue match {
+//          case None =>
+//          // Nothing to emit
+//          case Some(values) =>
+//            // Generate tuples from last values.
+//            // This code is a bit ad-hoc because there is no way to produce tuples from Seq[X] of lastValues
+//            values.size match {
+//              case 2 =>
+//                effect(OnNext((values(0), values(1)).asInstanceOf[A]))
+//              case 3 =>
+//                effect(OnNext((values(0), values(1), values(2)).asInstanceOf[A]))
+//              case 4 =>
+//                effect(OnNext((values(0), values(1), values(2), values(3)).asInstanceOf[A]))
+//              case _ => ???
+//            }
+//        }
+//      }
+//
+//      // Scan the last events and emit the next value or a completion event
+//      def processEvents(doEmit: Boolean) = {
+//        val errors = lastEvent.collect { case Some(e @ OnError(ex)) => ex }
+//        if (errors.isEmpty) {
+//          if (doEmit) {
+//            emit
+//          } else {
+//            if (isCompleted && completed.compareAndSet(false, true)) {
+//              trace(s"emit OnCompletion")
+//              effect(OnCompletion)
+//            }
+//          }
+//        } else {
+//          // Report the completion event only once
+//          if (continuous || completed.compareAndSet(false, true)) {
+//            if (errors.size == 1) {
+//              effect(OnError(errors(0)))
+//            } else {
+//              effect(OnError(MultipleExceptions(errors.toSeq)))
+//            }
+//          }
+//        }
+//      }
+//
+//      for (i <- 0 until size) {
+//        c(i) = runner.run(input.parents(i)) { e =>
+//          lastEvent(i) = Some(e)
+//          trace(s"c(${i}) ${e}")
+//          e match {
+//            case OnNext(v) =>
+//              update(i, v.asInstanceOf[A])
+//              processEvents(true)
+//            case _ =>
+//              processEvents(false)
+//          }
+//        }
+//      }
+//
+//      processEvents(false)
+//      Cancelable { () => c.foreach(_.cancel) }
+//    }
+//  }
+//
+//  private class ZipStream[A](input: Rx[A]) extends CombinedStream(input) {
+//    private val lastValueBuffer: Array[Queue[A]] = Array.fill(size)(Queue.empty[A])
+//
+//    override protected def nextValue: Option[Seq[Any]] = {
+//      if (lastValueBuffer.forall(_.nonEmpty)) {
+//        val values = for (i <- 0 until lastValueBuffer.size) yield {
+//          val (v, newQueue) = lastValueBuffer(i).dequeue
+//          lastValueBuffer(i) = newQueue
+//          v
+//        }
+//        Some(values)
+//      } else {
+//        None
+//      }
+//    }
+//
+//    override protected def update(index: Int, v: A): Unit = {
+//      lastValueBuffer(index) = lastValueBuffer(index).enqueue(v)
+//    }
+//
+//    override protected def isCompleted: Boolean = {
+//      !continuous && lastEvent.forall(_.isDefined)
+//    }
+//  }
+//
+//  private def zip[A, U](input: Rx[A])(effect: RxEvent => U): Cancelable = {
+//    new ZipStream(input).run(effect)
+//  }
+//
+//  private class JoinStream[A](input: Rx[A]) extends CombinedStream(input) {
+//    private val lastValue: Array[Option[A]] = Array.fill(size)(None)
+//
+//    override protected def nextValue: Option[Seq[Any]] = {
+//      if (lastValue.forall(_.nonEmpty)) {
+//        val values = for (i <- 0 until lastValue.size) yield {
+//          lastValue(i).get
+//        }
+//        Some(values)
+//      } else {
+//        None
+//      }
+//    }
+//
+//    override protected def update(index: Int, v: A): Unit = {
+//      lastValue(index) = Some(v)
+//    }
+//
+//    override protected def isCompleted: Boolean = {
+//      !continuous && lastEvent.forall(x => x.isDefined && x.get == OnCompletion)
+//    }
+//  }
+//
+//  private def join[A, U](input: Rx[A])(effect: RxEvent => U): Cancelable = {
+//    new JoinStream(input).run(effect)
+//  }
 
 }

--- a/airframe-http/src/main/scala/wvlet/airframe/http/rx/RxRunner.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/rx/RxRunner.scala
@@ -52,7 +52,8 @@ class RxRunner(
     * the effect code block will be executed.
     *
     * @param rx
-    * @param effect toContinue
+    * @param effect a function to process the generated RxEvent. This function must return true when the downstream operator can
+    *               receive further events (OnNext). If the leaf sink operator issued OnError or OnCompletion event, this must return false.
     * @tparam A
     */
   def run[A](rx: Rx[A])(effect: RxEvent => Boolean): Cancelable = {

--- a/airframe-http/src/main/scala/wvlet/airframe/http/rx/RxRunner.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/rx/RxRunner.scala
@@ -240,7 +240,7 @@ class RxRunner(
         lastValueBuffer.size match {
           case 2 =>
             // For zip2
-            trace(s"emit :${lastValueBuffer.mkString(", ")}")
+            trace(s"emit :${lastValueBuffer.map(_.headOption).mkString(", ")}")
             effect(OnNext((values(0), values(1)).asInstanceOf[A]))
           case 3 =>
             // For zip3
@@ -288,7 +288,7 @@ class RxRunner(
       }
     }
 
-    processEvents(false)
+    processEvents(true)
     Cancelable { () => c.foreach(_.cancel) }
   }
 

--- a/airframe-http/src/main/scala/wvlet/airframe/http/rx/RxRunner.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/rx/RxRunner.scala
@@ -10,16 +10,17 @@ import scala.collection.immutable.Queue
 import scala.util.{Failure, Success, Try}
 import Rx._
 
-private[rx] object RxRunner extends LogSupport {
+object RxRunner extends LogSupport {
 
-  val defaultRunner = new RxRunner(continuous = false)
+  private val defaultRunner = new RxRunner(continuous = false)
   // Used for continuous RxVar evaluation (e.g., RxVar -> DOM rendering)
-  val continuousRunner = new RxRunner(continuous = true)
+  private val continuousRunner = new RxRunner(continuous = true)
 
-  private[rx] def run[A, U](rx: Rx[A])(effect: RxEvent => U): Cancelable = defaultRunner.run(rx)(effect)
+  def run[A, U](rx: Rx[A])(effect: RxEvent => U): Cancelable             = defaultRunner.run(rx)(effect)
+  def runContinuously[A, U](rx: Rx[A])(effect: RxEvent => U): Cancelable = continuousRunner.run(rx)(effect)
 }
 
-private[rx] class RxRunner(
+class RxRunner(
     // If this value is true, evaluating Rx keeps reporting events after OnError or OnCompletion is observed
     continuous: Boolean
 ) extends LogSupport {

--- a/airframe-http/src/main/scala/wvlet/airframe/http/rx/RxRunner.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/rx/RxRunner.scala
@@ -23,7 +23,7 @@ object RxRunner extends LogSupport {
 class RxRunner(
     // If this value is true, evaluating Rx keeps reporting events after OnError or OnCompletion is observed
     continuous: Boolean
-) extends LogSupport {
+) extends LogSupport { runner =>
 
   /**
     * Build an executable chain of Rx operators. The resulting chain
@@ -139,6 +139,8 @@ class RxRunner(
         join(j)(effect)
       case j @ Join3Op(r1, r2, r3) =>
         join(j)(effect)
+      case j @ Join4Op(r1, r2, r3, r4) =>
+        join(j)(effect)
       case RxOptionOp(in) =>
         run(in) {
           case OnNext(Some(v)) => effect(OnNext(v))
@@ -224,150 +226,142 @@ class RxRunner(
     }
   }
 
-  private def zip[A, U](input: Rx[A])(effect: RxEvent => U): Cancelable = {
-    val size                              = input.parents.size
-    val lastValueBuffer: Array[Queue[A]]  = Array.fill(size)(Queue.empty[A])
-    val lastEvent: Array[Option[RxEvent]] = Array.fill(size)(None)
-    val c: Array[Cancelable]              = Array.fill(size)(Cancelable.empty)
+  /**
+    * A base implementation for merging streams and generating tuples
+    * @param input
+    * @tparam A
+    */
+  private[rx] abstract class CombinedStream[A](input: Rx[A]) extends LogSupport {
+    protected val size = input.parents.size
 
-    val completed: AtomicBoolean = new AtomicBoolean(false)
-    def emit: Unit = {
-      // Emit the tuple result.
+    protected val lastEvent: Array[Option[RxEvent]] = Array.fill(size)(None)
+    private val c: Array[Cancelable]                = Array.fill(size)(Cancelable.empty)
+    private val completed: AtomicBoolean            = new AtomicBoolean(false)
+
+    protected def nextValue: Option[Seq[Any]]
+
+    protected def update(index: Int, v: A): Unit
+
+    protected def isCompleted: Boolean
+
+    def run[U](effect: RxEvent => U): Cancelable = {
+      def emit: Unit = {
+        // Emit the tuple result.
+        nextValue match {
+          case None =>
+          // Nothing to emit
+          case Some(values) =>
+            // Generate tuples from last values.
+            // This code is a bit ad-hoc because there is no way to produce tuples from Seq[X] of lastValues
+            values.size match {
+              case 2 =>
+                effect(OnNext((values(0), values(1)).asInstanceOf[A]))
+              case 3 =>
+                effect(OnNext((values(0), values(1), values(2)).asInstanceOf[A]))
+              case 4 =>
+                effect(OnNext((values(0), values(1), values(2), values(3)).asInstanceOf[A]))
+              case _ => ???
+            }
+        }
+      }
+
+      // Scan the last events and emit the next value or a completion event
+      def processEvents(doEmit: Boolean) = {
+        val errors = lastEvent.collect { case Some(e @ OnError(ex)) => ex }
+        if (errors.isEmpty) {
+          if (doEmit) {
+            emit
+          } else {
+            if (isCompleted && completed.compareAndSet(false, true)) {
+              trace(s"emit OnCompletion")
+              effect(OnCompletion)
+            }
+          }
+        } else {
+          // Report the completion event only once
+          if (continuous || completed.compareAndSet(false, true)) {
+            if (errors.size == 1) {
+              effect(OnError(errors(0)))
+            } else {
+              effect(OnError(MultipleExceptions(errors.toSeq)))
+            }
+          }
+        }
+      }
+
+      for (i <- 0 until size) {
+        c(i) = runner.run(input.parents(i)) { e =>
+          lastEvent(i) = Some(e)
+          trace(s"c(${i}) ${e}")
+          e match {
+            case OnNext(v) =>
+              update(i, v.asInstanceOf[A])
+              processEvents(true)
+            case _ =>
+              processEvents(false)
+          }
+        }
+      }
+
+      processEvents(false)
+      Cancelable { () => c.foreach(_.cancel) }
+    }
+  }
+
+  private class ZipStream[A](input: Rx[A]) extends CombinedStream(input) {
+    private val lastValueBuffer: Array[Queue[A]] = Array.fill(size)(Queue.empty[A])
+
+    override protected def nextValue: Option[Seq[Any]] = {
       if (lastValueBuffer.forall(_.nonEmpty)) {
         val values = for (i <- 0 until lastValueBuffer.size) yield {
           val (v, newQueue) = lastValueBuffer(i).dequeue
           lastValueBuffer(i) = newQueue
           v
         }
-        // Generate tuples from last values.
-        // This code is a bit ad-hoc because there is no way to produce tuples from Seq[X] of lastValues
-        lastValueBuffer.size match {
-          case 2 =>
-            // For zip2
-            trace(s"emit :${lastValueBuffer.map(_.headOption).mkString(", ")}")
-            effect(OnNext((values(0), values(1)).asInstanceOf[A]))
-          case 3 =>
-            // For zip3
-            effect(OnNext((values(0), values(1), values(2)).asInstanceOf[A]))
-          case _ => ???
-        }
-      }
-    }
-
-    // Scan the last events and emit the next value or a completion event
-    def processEvents(doEmit: Boolean) = {
-      val errors = lastEvent.collect { case Some(e @ OnError(ex)) => ex }
-      if (errors.isEmpty) {
-        if (doEmit) {
-          emit
-        } else {
-          if (!continuous && lastEvent.forall(_.isDefined) && completed.compareAndSet(false, true)) {
-            trace(s"emit OnCompletion")
-            effect(OnCompletion)
-          }
-        }
+        Some(values)
       } else {
-        // Report the completion event only once
-        if (continuous || completed.compareAndSet(false, true)) {
-          if (errors.size == 1) {
-            effect(OnError(errors(0)))
-          } else {
-            effect(OnError(MultipleExceptions(errors.toSeq)))
-          }
-        }
+        None
       }
     }
 
-    for (i <- 0 until size) {
-      c(i) = run(input.parents(i)) { e =>
-        lastEvent(i) = Some(e)
-        trace(s"c(${i}) ${e}")
-        e match {
-          case OnNext(v) =>
-            lastValueBuffer(i) = lastValueBuffer(i).enqueue(v.asInstanceOf[A])
-            processEvents(true)
-          case _ =>
-            processEvents(false)
-        }
-      }
+    override protected def update(index: Int, v: A): Unit = {
+      lastValueBuffer(index) = lastValueBuffer(index).enqueue(v)
     }
 
-    processEvents(false)
-    Cancelable { () => c.foreach(_.cancel) }
+    override protected def isCompleted: Boolean = {
+      !continuous && lastEvent.forall(_.isDefined)
+    }
   }
 
-  private def join[A, U](input: Rx[A])(effect: RxEvent => U): Cancelable = {
-    val size                              = input.parents.size
-    val lastValue: Array[Option[A]]       = Array.fill(size)(None)
-    val lastEvent: Array[Option[RxEvent]] = Array.fill(size)(None)
-    val c: Array[Cancelable]              = Array.fill(size)(Cancelable.empty)
+  private def zip[A, U](input: Rx[A])(effect: RxEvent => U): Cancelable = {
+    new ZipStream(input).run(effect)
+  }
 
-    val completed: AtomicBoolean = new AtomicBoolean(false)
-    def emit: Unit = {
-      // Emit the tuple result.
+  private class JoinStream[A](input: Rx[A]) extends CombinedStream(input) {
+    private val lastValue: Array[Option[A]] = Array.fill(size)(None)
+
+    override protected def nextValue: Option[Seq[Any]] = {
       if (lastValue.forall(_.nonEmpty)) {
         val values = for (i <- 0 until lastValue.size) yield {
           lastValue(i).get
         }
-        // Generate tuples from last values.
-        // This code is a bit ad-hoc because there is no way to produce tuples from Seq[X] of lastValues
-        lastValue.size match {
-          case 2 =>
-            // For join2
-            trace(s"emit :${lastValue.mkString(", ")}")
-            effect(OnNext((values(0), values(1)).asInstanceOf[A]))
-          case 3 =>
-            // For join3
-            effect(OnNext((values(0), values(1), values(2)).asInstanceOf[A]))
-          case _ => ???
-        }
+        Some(values)
+      } else {
+        None
       }
     }
 
-    def hasNoMoreData: Boolean = {
+    override protected def update(index: Int, v: A): Unit = {
+      lastValue(index) = Some(v)
+    }
+
+    override protected def isCompleted: Boolean = {
       !continuous && lastEvent.forall(x => x.isDefined && x.get == OnCompletion)
     }
+  }
 
-    // Scan the last events and emit the next value or a completion event
-    def processEvents(doEmit: Boolean) = {
-      val errors = lastEvent.collect { case Some(e @ OnError(ex)) => ex }
-      if (errors.isEmpty) {
-        if (doEmit) {
-          emit
-        } else {
-          if (hasNoMoreData && completed.compareAndSet(false, true)) {
-            trace(s"emit OnCompletion")
-            effect(OnCompletion)
-          }
-        }
-      } else {
-        // Report the completion event only once
-        if (continuous || completed.compareAndSet(false, true)) {
-          if (errors.size == 1) {
-            effect(OnError(errors(0)))
-          } else {
-            effect(OnError(MultipleExceptions(errors.toSeq)))
-          }
-        }
-      }
-    }
-
-    for (i <- 0 until size) {
-      c(i) = run(input.parents(i)) { e =>
-        lastEvent(i) = Some(e)
-        trace(s"c(${i}) ${e}")
-        e match {
-          case OnNext(v) =>
-            lastValue(i) = Some(v.asInstanceOf[A])
-            processEvents(true)
-          case _ =>
-            processEvents(false)
-        }
-      }
-    }
-
-    processEvents(false)
-    Cancelable { () => c.foreach(_.cancel) }
+  private def join[A, U](input: Rx[A])(effect: RxEvent => U): Cancelable = {
+    new JoinStream(input).run(effect)
   }
 
 }

--- a/airframe-http/src/main/scala/wvlet/airframe/http/rx/RxRunner.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/rx/RxRunner.scala
@@ -1,0 +1,103 @@
+package wvlet.airframe.http.rx
+
+object RxRunner {
+
+  /**
+    * Build a executable chain of Rx operators, and the resulting chain
+    * will be registered to the root node (e.g. RxVar). If the root value changes,
+    * the effect code block will be executed.
+    *
+    * @param rx
+    * @param effect
+    * @tparam A
+    * @tparam U
+    * @return
+    */
+  private[rx] def run[A, U](rx: Rx[A])(effect: A => U): Cancelable = {
+    rx match {
+      case MapOp(in, f) =>
+        run(in)(x => effect(f.asInstanceOf[Any => A](x)))
+      case FlatMapOp(in, f) =>
+        // This var is a placeholder to remember the preceding Cancelable operator, which will be updated later
+        var c1 = Cancelable.empty
+        val c2 = run(in) { x =>
+          val rxb = f.asInstanceOf[Any => Rx[A]](x)
+          // This code is necessary to properly cancel the effect if this operator is evaluated before
+          c1.cancel
+          c1 = run(rxb)(effect)
+        }
+        Cancelable { () => c1.cancel; c2.cancel }
+      case FilterOp(in, cond) =>
+        run(in) { x =>
+          if (cond.asInstanceOf[A => Boolean](x)) {
+            effect(x)
+          }
+        }
+      case ZipOp(left, right) =>
+        var allReady: Boolean = false
+        var v1: Any           = null
+        var v2: Any           = null
+        val c1 = run(left) { x =>
+          v1 = x
+          if (allReady) {
+            effect((v1, v2).asInstanceOf[A])
+          }
+        }
+        val c2 = run(right) { x =>
+          v2 = x
+          if (allReady) {
+            effect((v1, v2).asInstanceOf[A])
+          }
+        }
+        allReady = true
+        effect((v1, v2).asInstanceOf[A])
+        Cancelable { () => c1.cancel; c2.cancel }
+      case Zip3Op(r1, r2, r3) =>
+        var allReady: Boolean = false
+        var v1: Any           = null
+        var v2: Any           = null
+        var v3: Any           = null
+        val c1 = run(r1) { x =>
+          v1 = x
+          if (allReady) {
+            effect((v1, v2, v3).asInstanceOf[A])
+          }
+        }
+        val c2 = run(r2) { x =>
+          v2 = x
+          if (allReady) {
+            effect((v1, v2, v3).asInstanceOf[A])
+          }
+        }
+        val c3 = run(r3) { x =>
+          v3 = x
+          if (allReady) {
+            effect((v1, v2, v3).asInstanceOf[A])
+          }
+        }
+        allReady = true
+        effect((v1, v2, v3).asInstanceOf[A])
+        Cancelable { () => c1.cancel; c2.cancel }
+      case RxOptionOp(in) =>
+        run(in) {
+          case Some(v) => effect(v)
+          case None    =>
+          // Do nothing
+        }
+      case NamedOp(input, name) =>
+        run(input)(effect)
+      case SingleOp(v) =>
+        effect(v)
+        Cancelable.empty
+      case o: RxOptionVar[_] =>
+        o.asInstanceOf[RxOptionVar[A]].foreach {
+          case Some(v) => effect(v)
+          case None    =>
+          // Do nothing
+        }
+      case v: RxVar[_] =>
+        v.asInstanceOf[RxVar[A]].foreach(effect)
+    }
+  }
+
+}

--- a/airframe-http/src/main/scala/wvlet/airframe/http/rx/RxRunner.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/rx/RxRunner.scala
@@ -57,31 +57,6 @@ class RxRunner(
     */
   def run[A](rx: Rx[A])(effect: RxEvent => Boolean): Cancelable = {
     rx match {
-      case SingleOp(v) =>
-        Try(effect(OnNext(v.eval))) match {
-          case Success(c) => effect(OnCompletion)
-          case Failure(e) => effect(OnError(e))
-        }
-        Cancelable.empty
-      case SeqOp(inputList) =>
-        var toContinue = true
-        @tailrec
-        def loop(lst: List[A]): Unit = {
-          if (continuous || toContinue) {
-            lst match {
-              case Nil =>
-                toContinue = effect(OnCompletion)
-              case head :: tail =>
-                toContinue = effect(OnNext(head))
-                loop(tail)
-            }
-          }
-        }
-        loop(inputList.eval.toList)
-        // Stop reading the next element if cancelled
-        Cancelable { () =>
-          toContinue = false
-        }
       case MapOp(in, f) =>
         run(in) {
           case OnNext(v) =>
@@ -123,27 +98,24 @@ class RxRunner(
             effect(other)
         }
         Cancelable { () => c1.cancel; c2.cancel }
-//      case FilterOp(in, cond) =>
-//        var toContinue = true
-//        run(in) { ev =>
-//          if (continuous || toContinue) {
-//            ev match {
-//              case OnNext(x) =>
-//                Try(cond.asInstanceOf[A => Boolean](x.asInstanceOf[A])) match {
-//                  case Success(true) =>
-//                    effect(OnNext(x))
-//                  case Success(false) =>
-//                  // Skip unmatched element
-//                  case Failure(e) =>
-//                    toContinue = false
-//                    effect(OnError(e))
-//                }
-//              case other =>
-//                toContinue = false
-//                effect(other)
-//            }
-//          }
-//        }
+      case FilterOp(in, cond) =>
+        var toContinue = true
+        run(in) { ev =>
+          ev match {
+            case OnNext(x) =>
+              Try(cond.asInstanceOf[A => Boolean](x.asInstanceOf[A])) match {
+                case Success(true) =>
+                  effect(OnNext(x))
+                case Success(false) =>
+                  // Skip unmatched element
+                  true
+                case Failure(e) =>
+                  effect(OnError(e))
+              }
+            case other =>
+              effect(other)
+          }
+        }
       case ConcatOp(first, next) =>
         var c1 = Cancelable.empty
         val c2 = run(first) {
@@ -160,38 +132,42 @@ class RxRunner(
             effect(other)
         }
         Cancelable { () => c1.cancel; c2.cancel }
-//      case LastOp(in) =>
-//        var last: Option[A] = None
-//        run(in) {
-//          case OnNext(v) =>
-//            last = Some(v.asInstanceOf[A])
-//          case err @ OnError(e) =>
-//            effect(err)
-//          case OnCompletion =>
-//            Try(effect(OnNext(last))) match {
-//              case Success(v) => effect(OnCompletion)
-//              case Failure(e) => effect(OnError(e))
-//            }
-//        }
-//      case z @ ZipOp(r1, r2) =>
-//        zip(z)(effect)
-//      case z @ Zip3Op(r1, r2, r3) =>
-//        zip(z)(effect)
-//      case j @ JoinOp(r1, r2) =>
-//        join(j)(effect)
-//      case j @ Join3Op(r1, r2, r3) =>
-//        join(j)(effect)
-//      case j @ Join4Op(r1, r2, r3, r4) =>
-//        join(j)(effect)
-//      case RxOptionOp(in) =>
-//        run(in) {
-//          case OnNext(Some(v)) => effect(OnNext(v))
-//          case OnNext(None)    =>
-//          // do nothing for empty values
-//          case other => effect(other)
-//        }
-//      case NamedOp(input, name) =>
-//        run(input)(effect)
+      case LastOp(in) =>
+        var last: Option[A] = None
+        run(in) {
+          case OnNext(v) =>
+            last = Some(v.asInstanceOf[A])
+            true
+          case err @ OnError(e) =>
+            effect(err)
+          case OnCompletion =>
+            Try(effect(OnNext(last))) match {
+              case Success(v) => effect(OnCompletion)
+              case Failure(e) => effect(OnError(e))
+            }
+        }
+      case z @ ZipOp(r1, r2) =>
+        zip(z)(effect)
+      case z @ Zip3Op(r1, r2, r3) =>
+        zip(z)(effect)
+      case j @ JoinOp(r1, r2) =>
+        join(j)(effect)
+      case j @ Join3Op(r1, r2, r3) =>
+        join(j)(effect)
+      case j @ Join4Op(r1, r2, r3, r4) =>
+        join(j)(effect)
+      case RxOptionOp(in) =>
+        run(in) {
+          case OnNext(Some(v)) =>
+            effect(OnNext(v))
+          case OnNext(None) =>
+            // do nothing for empty values
+            true
+          case other =>
+            effect(other)
+        }
+      case NamedOp(input, name) =>
+        run(input)(effect)
       case TryOp(e) =>
         e match {
           case Success(x) =>
@@ -200,198 +176,225 @@ class RxRunner(
             effect(OnError(e))
         }
         Cancelable.empty
-//      case o: RxOptionVar[_] =>
-//        o.asInstanceOf[RxOptionVar[A]].foreach {
-//          case Some(v) => effect(OnNext(v))
-//          case None    =>
-//          // Do nothing
-//        }
-//      case v: RxVar[_] =>
-//        v.asInstanceOf[RxVar[A]].foreach { x => effect(OnNext(x)) }
-//      case RecoverOp(in, f) =>
-//        var toContinue = true
-//        run(in) { ev =>
-//          warn(ev)
-//          if (continuous || toContinue) {
-//            ev match {
-//              case OnNext(v) =>
-//                effect(ev)
-//              case OnError(e) if f.isDefinedAt(e) =>
-//                Try(effect(OnNext(f(e)))) match {
-//                  case Success(x) =>
-//                  // recovery succeeded
-//                  case Failure(e) =>
-//                    toContinue = false
-//                    effect(OnError(e))
-//                }
-//              case other =>
-//                toContinue = false
-//                effect(other)
-//            }
-//          }
-//        }
-//      case RecoverWithOp(in, f) =>
-//        var toContinue = true
-//        var c1         = Cancelable.empty
-//        val c2 = run(in) { ev =>
-//          if (continuous || toContinue) {
-//            ev match {
-//              case OnError(e) if f.isDefinedAt(e) =>
-//                c1.cancel
-//                Try(f(e)) match {
-//                  case Success(recoverySource) =>
-//                    c1 = run(recoverySource)(effect)
-//                  case Failure(e) =>
-//                    toContinue = false
-//                    effect(OnError(e))
-//                }
-//              case e if e.isLastEvent && !toContinue =>
-//              // Skip reporting the completion event
-//              case other =>
-//                effect(other)
-//            }
-//          }
-//        }
-//        Cancelable { () => c1.cancel; c2.cancel }
+      case o: RxOptionVar[_] =>
+        o.asInstanceOf[RxOptionVar[A]].foreach {
+          case Some(v) =>
+            effect(OnNext(v))
+          case None =>
+          // Do nothing
+        }
+      case v: RxVar[_] =>
+        v.asInstanceOf[RxVar[A]].foreach { x => effect(OnNext(x)) }
+      case RecoverOp(in, f) =>
+        run(in) { ev =>
+          ev match {
+            case OnNext(v) =>
+              effect(ev)
+            case OnError(e) if f.isDefinedAt(e) =>
+              Try(effect(OnNext(f(e)))) match {
+                case Success(x) =>
+                  // recovery succeeded
+                  true
+                case Failure(e) =>
+                  effect(OnError(e))
+              }
+            case other =>
+              effect(other)
+          }
+        }
+      case RecoverWithOp(in, f) =>
+        var toContinue = true
+        var c1         = Cancelable.empty
+        val c2 = run(in) { ev =>
+          ev match {
+            case OnError(e) if f.isDefinedAt(e) =>
+              c1.cancel
+              Try(f(e)) match {
+                case Success(recoverySource) =>
+                  c1 = run(recoverySource) { ev =>
+                    toContinue = effect(ev)
+                    toContinue
+                  }
+                  toContinue
+                case Failure(e) =>
+                  effect(OnError(e))
+              }
+            case other =>
+              effect(other)
+          }
+        }
+        Cancelable { () => c1.cancel; c2.cancel }
+      case SingleOp(v) =>
+        Try(effect(OnNext(v.eval))) match {
+          case Success(c) => effect(OnCompletion)
+          case Failure(e) => effect(OnError(e))
+        }
+        Cancelable.empty
+      case SeqOp(inputList) =>
+        var toContinue = true
+        @tailrec
+        def loop(lst: List[A]): Unit = {
+          if (continuous || toContinue) {
+            lst match {
+              case Nil =>
+                toContinue = effect(OnCompletion)
+              case head :: tail =>
+                toContinue = effect(OnNext(head))
+                loop(tail)
+            }
+          }
+        }
+        loop(inputList.eval.toList)
+        // Stop reading the next element if cancelled
+        Cancelable { () =>
+          toContinue = false
+        }
     }
   }
-//
-//  /**
-//    * A base implementation for merging streams and generating tuples
-//    * @param input
-//    * @tparam A
-//    */
-//  private[rx] abstract class CombinedStream[A](input: Rx[A]) extends LogSupport {
-//    protected val size = input.parents.size
-//
-//    protected val lastEvent: Array[Option[RxEvent]] = Array.fill(size)(None)
-//    private val c: Array[Cancelable]                = Array.fill(size)(Cancelable.empty)
-//    private val completed: AtomicBoolean            = new AtomicBoolean(false)
-//
-//    protected def nextValue: Option[Seq[Any]]
-//
-//    protected def update(index: Int, v: A): Unit
-//
-//    protected def isCompleted: Boolean
-//
-//    def run[U](effect: RxEvent => U): Cancelable = {
-//      def emit: Unit = {
-//        // Emit the tuple result.
-//        nextValue match {
-//          case None =>
-//          // Nothing to emit
-//          case Some(values) =>
-//            // Generate tuples from last values.
-//            // This code is a bit ad-hoc because there is no way to produce tuples from Seq[X] of lastValues
-//            values.size match {
-//              case 2 =>
-//                effect(OnNext((values(0), values(1)).asInstanceOf[A]))
-//              case 3 =>
-//                effect(OnNext((values(0), values(1), values(2)).asInstanceOf[A]))
-//              case 4 =>
-//                effect(OnNext((values(0), values(1), values(2), values(3)).asInstanceOf[A]))
-//              case _ => ???
-//            }
-//        }
-//      }
-//
-//      // Scan the last events and emit the next value or a completion event
-//      def processEvents(doEmit: Boolean) = {
-//        val errors = lastEvent.collect { case Some(e @ OnError(ex)) => ex }
-//        if (errors.isEmpty) {
-//          if (doEmit) {
-//            emit
-//          } else {
-//            if (isCompleted && completed.compareAndSet(false, true)) {
-//              trace(s"emit OnCompletion")
-//              effect(OnCompletion)
-//            }
-//          }
-//        } else {
-//          // Report the completion event only once
-//          if (continuous || completed.compareAndSet(false, true)) {
-//            if (errors.size == 1) {
-//              effect(OnError(errors(0)))
-//            } else {
-//              effect(OnError(MultipleExceptions(errors.toSeq)))
-//            }
-//          }
-//        }
-//      }
-//
-//      for (i <- 0 until size) {
-//        c(i) = runner.run(input.parents(i)) { e =>
-//          lastEvent(i) = Some(e)
-//          trace(s"c(${i}) ${e}")
-//          e match {
-//            case OnNext(v) =>
-//              update(i, v.asInstanceOf[A])
-//              processEvents(true)
-//            case _ =>
-//              processEvents(false)
-//          }
-//        }
-//      }
-//
-//      processEvents(false)
-//      Cancelable { () => c.foreach(_.cancel) }
-//    }
-//  }
-//
-//  private class ZipStream[A](input: Rx[A]) extends CombinedStream(input) {
-//    private val lastValueBuffer: Array[Queue[A]] = Array.fill(size)(Queue.empty[A])
-//
-//    override protected def nextValue: Option[Seq[Any]] = {
-//      if (lastValueBuffer.forall(_.nonEmpty)) {
-//        val values = for (i <- 0 until lastValueBuffer.size) yield {
-//          val (v, newQueue) = lastValueBuffer(i).dequeue
-//          lastValueBuffer(i) = newQueue
-//          v
-//        }
-//        Some(values)
-//      } else {
-//        None
-//      }
-//    }
-//
-//    override protected def update(index: Int, v: A): Unit = {
-//      lastValueBuffer(index) = lastValueBuffer(index).enqueue(v)
-//    }
-//
-//    override protected def isCompleted: Boolean = {
-//      !continuous && lastEvent.forall(_.isDefined)
-//    }
-//  }
-//
-//  private def zip[A, U](input: Rx[A])(effect: RxEvent => U): Cancelable = {
-//    new ZipStream(input).run(effect)
-//  }
-//
-//  private class JoinStream[A](input: Rx[A]) extends CombinedStream(input) {
-//    private val lastValue: Array[Option[A]] = Array.fill(size)(None)
-//
-//    override protected def nextValue: Option[Seq[Any]] = {
-//      if (lastValue.forall(_.nonEmpty)) {
-//        val values = for (i <- 0 until lastValue.size) yield {
-//          lastValue(i).get
-//        }
-//        Some(values)
-//      } else {
-//        None
-//      }
-//    }
-//
-//    override protected def update(index: Int, v: A): Unit = {
-//      lastValue(index) = Some(v)
-//    }
-//
-//    override protected def isCompleted: Boolean = {
-//      !continuous && lastEvent.forall(x => x.isDefined && x.get == OnCompletion)
-//    }
-//  }
-//
-//  private def join[A, U](input: Rx[A])(effect: RxEvent => U): Cancelable = {
-//    new JoinStream(input).run(effect)
-//  }
+
+  /**
+    * A base implementation for merging streams and generating tuples
+    * @param input
+    * @tparam A
+    */
+  private[rx] abstract class CombinedStream[A](input: Rx[A]) extends LogSupport {
+    protected val size = input.parents.size
+
+    protected val lastEvent: Array[Option[RxEvent]] = Array.fill(size)(None)
+    private val c: Array[Cancelable]                = Array.fill(size)(Cancelable.empty)
+    private val completed: AtomicBoolean            = new AtomicBoolean(false)
+
+    protected def nextValue: Option[Seq[Any]]
+
+    protected def update(index: Int, v: A): Unit
+
+    protected def isCompleted: Boolean
+
+    def run(effect: RxEvent => Boolean): Cancelable = {
+      def emit: Boolean = {
+        // Emit the tuple result.
+        val toContinue = nextValue match {
+          case None =>
+            // Nothing to emit
+            true
+          case Some(values) =>
+            // Generate tuples from last values.
+            // This code is a bit ad-hoc because there is no way to produce tuples from Seq[X] of lastValues
+            values.size match {
+              case 2 =>
+                effect(OnNext((values(0), values(1)).asInstanceOf[A]))
+              case 3 =>
+                effect(OnNext((values(0), values(1), values(2)).asInstanceOf[A]))
+              case 4 =>
+                effect(OnNext((values(0), values(1), values(2), values(3)).asInstanceOf[A]))
+              case _ =>
+                ???
+            }
+        }
+        toContinue
+      }
+
+      // Scan the last events and emit the next value or a completion event
+      def processEvents(doEmit: Boolean): Boolean = {
+        val errors = lastEvent.collect { case Some(e @ OnError(ex)) => ex }
+        if (errors.isEmpty) {
+          if (doEmit) {
+            emit
+          } else {
+            if (isCompleted && completed.compareAndSet(false, true)) {
+              trace(s"emit OnCompletion")
+              effect(OnCompletion)
+            } else {
+              true
+            }
+          }
+        } else {
+          // Report the completion event only once
+          if (continuous || completed.compareAndSet(false, true)) {
+            if (errors.size == 1) {
+              effect(OnError(errors(0)))
+            } else {
+              effect(OnError(MultipleExceptions(errors.toSeq)))
+            }
+          } else {
+            true
+          }
+        }
+      }
+
+      for (i <- 0 until size) {
+        c(i) = runner.run(input.parents(i)) { e =>
+          lastEvent(i) = Some(e)
+          trace(s"c(${i}) ${e}")
+          e match {
+            case OnNext(v) =>
+              update(i, v.asInstanceOf[A])
+              processEvents(true)
+            case _ =>
+              processEvents(false)
+          }
+        }
+      }
+
+      processEvents(false)
+      Cancelable { () => c.foreach(_.cancel) }
+    }
+  }
+
+  private class ZipStream[A](input: Rx[A]) extends CombinedStream(input) {
+    private val lastValueBuffer: Array[Queue[A]] = Array.fill(size)(Queue.empty[A])
+
+    override protected def nextValue: Option[Seq[Any]] = {
+      if (lastValueBuffer.forall(_.nonEmpty)) {
+        val values = for (i <- 0 until lastValueBuffer.size) yield {
+          val (v, newQueue) = lastValueBuffer(i).dequeue
+          lastValueBuffer(i) = newQueue
+          v
+        }
+        Some(values)
+      } else {
+        None
+      }
+    }
+
+    override protected def update(index: Int, v: A): Unit = {
+      lastValueBuffer(index) = lastValueBuffer(index).enqueue(v)
+    }
+
+    override protected def isCompleted: Boolean = {
+      !continuous && lastEvent.forall(_.isDefined)
+    }
+  }
+
+  private def zip[A](input: Rx[A])(effect: RxEvent => Boolean): Cancelable = {
+    new ZipStream(input).run(effect)
+  }
+
+  private class JoinStream[A](input: Rx[A]) extends CombinedStream(input) {
+    private val lastValue: Array[Option[A]] = Array.fill(size)(None)
+
+    override protected def nextValue: Option[Seq[Any]] = {
+      if (lastValue.forall(_.nonEmpty)) {
+        val values = for (i <- 0 until lastValue.size) yield {
+          lastValue(i).get
+        }
+        Some(values)
+      } else {
+        None
+      }
+    }
+
+    override protected def update(index: Int, v: A): Unit = {
+      lastValue(index) = Some(v)
+    }
+
+    override protected def isCompleted: Boolean = {
+      !continuous && lastEvent.forall(x => x.isDefined && x.get == OnCompletion)
+    }
+  }
+
+  private def join[A](input: Rx[A])(effect: RxEvent => Boolean): Cancelable = {
+    new JoinStream(input).run(effect)
+  }
 
 }

--- a/airframe-http/src/test/scala/wvlet/airframe/http/rx/BackPropagationTest.scala
+++ b/airframe-http/src/test/scala/wvlet/airframe/http/rx/BackPropagationTest.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.http.rx
+import wvlet.airspec.AirSpec
+
+/**
+  */
+class BackPropagationTest extends AirSpec {
+  val ex = new IllegalArgumentException("dummy")
+
+  private def eval[A](rx: Rx[A]): Seq[RxEvent] = {
+    val b = Seq.newBuilder[RxEvent]
+    RxRunner.run(rx)(b += _)
+    val events = b.result()
+    debug(events)
+    events
+  }
+
+  test("map") {
+    val rx = Rx
+      .sequence(1, 2, 3)
+      .map {
+        case 2     => throw ex
+        case other => other
+      }
+
+    eval(rx) shouldBe Seq(
+      OnNext(1),
+      OnError(ex)
+    )
+  }
+
+  test("flatMap") {
+    val rx = Rx
+      .sequence(1, 2, 3)
+      .flatMap {
+        case 2     => Rx.single(2).concat(Rx.exception(ex))
+        case other => Rx.sequence(other, other)
+      }
+
+    eval(rx) shouldBe Seq(
+      OnNext(1),
+      OnNext(1),
+      OnNext(2),
+      OnError(ex)
+    )
+  }
+
+  test("concat") {
+    val rx = Rx.single(2).concat(Rx.exception(ex))
+    eval(rx) shouldBe Seq(
+      OnNext(2),
+      OnError(ex)
+    )
+  }
+
+}

--- a/airframe-http/src/test/scala/wvlet/airframe/http/rx/RxTest.scala
+++ b/airframe-http/src/test/scala/wvlet/airframe/http/rx/RxTest.scala
@@ -219,6 +219,57 @@ object RxTest extends AirSpec {
     e.cancel
   }
 
+  test("join") {
+    val x  = Rx.variable(1)
+    val y  = Rx.variable("a")
+    val rx = x.join(y)
+
+    val b = Seq.newBuilder[RxEvent]
+    RxRunner.run(rx)(b += _)
+
+    y := "b"
+    y := "c"
+    x := 2
+    y := "d"
+
+    val events = b.result()
+    debug(events)
+    events shouldBe Seq(
+      OnNext(1, "a"),
+      OnNext(1, "b"),
+      OnNext(1, "c"),
+      OnNext(2, "c"),
+      OnNext(2, "d")
+    )
+  }
+
+  test("join3") {
+    val x  = Rx.variable(1)
+    val y  = Rx.variable("a")
+    val z  = Rx.variable(true)
+    val rx = x.join(y, z)
+
+    val b = Seq.newBuilder[RxEvent]
+    RxRunner.run(rx)(b += _)
+
+    y := "b"
+    y := "c"
+    z := false
+    x := 2
+    y := "d"
+
+    val events = b.result()
+    debug(events)
+    events shouldBe Seq(
+      OnNext(1, "a", true),
+      OnNext(1, "b", true),
+      OnNext(1, "c", true),
+      OnNext(1, "c", false),
+      OnNext(2, "c", false),
+      OnNext(2, "d", false)
+    )
+  }
+
   implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global
 
   test("from Future[X]") {

--- a/airframe-http/src/test/scala/wvlet/airframe/http/rx/RxTest.scala
+++ b/airframe-http/src/test/scala/wvlet/airframe/http/rx/RxTest.scala
@@ -226,4 +226,11 @@ object RxTest extends AirSpec {
     }
   }
 
+  test("lastOption") {
+    val rx = Rx.const(1).lastOption
+    rx.run { x =>
+      info(s"last: ${x}")
+    }
+  }
+
 }

--- a/airframe-http/src/test/scala/wvlet/airframe/http/rx/RxTest.scala
+++ b/airframe-http/src/test/scala/wvlet/airframe/http/rx/RxTest.scala
@@ -180,6 +180,10 @@ object RxTest extends AirSpec {
     a.zip(b).run(r += _)
 
     r.result shouldBe Seq((1, "a"), (2, "b"))
+
+    val r2 = Seq.newBuilder[(String, Int)]
+    b.zip(a).run(r2 += _)
+    r2.result shouldBe Seq(("a", 1), ("b", 2))
   }
 
   test("zip3") {

--- a/airframe-http/src/test/scala/wvlet/airframe/http/rx/RxTest.scala
+++ b/airframe-http/src/test/scala/wvlet/airframe/http/rx/RxTest.scala
@@ -414,6 +414,43 @@ object RxTest extends AirSpec {
     }
   }
 
+  test("recover in the middle") {
+    val rx = Rx
+      .sequence(1, 2, 3)
+      .map {
+        case 2     => throw new IllegalArgumentException("test error")
+        case other => other
+      }
+      .recover {
+        case e: IllegalArgumentException => -1
+      }
+    debug(rx)
+    eval(rx) shouldBe Seq(
+      OnNext(1),
+      OnNext(-1),
+      OnNext(3),
+      OnCompletion
+    )
+  }
+
+  test("recover in the middle failed") {
+    val ex = new IllegalArgumentException("test error")
+    val rx = Rx
+      .sequence(1, 2, 3)
+      .map {
+        case 2     => throw ex
+        case other => other
+      }
+      .recover {
+        case e: IllegalStateException => -1
+      }
+    debug(rx)
+    eval(rx) shouldBe Seq(
+      OnNext(1),
+      OnError(ex)
+    )
+  }
+
   test("Rx.exception") {
     val ex = new IllegalArgumentException("test error")
 

--- a/airframe-http/src/test/scala/wvlet/airframe/http/rx/RxTest.scala
+++ b/airframe-http/src/test/scala/wvlet/airframe/http/rx/RxTest.scala
@@ -201,7 +201,6 @@ object RxTest extends AirSpec {
     var count = 0
 
     val e = x.run { v =>
-      info(s"${v}, count:${count}")
       count match {
         case 0 =>
           v shouldBe (1, "a", true)

--- a/airframe-http/src/test/scala/wvlet/airframe/http/rx/RxTest.scala
+++ b/airframe-http/src/test/scala/wvlet/airframe/http/rx/RxTest.scala
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 package wvlet.airframe.http.rx
-import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicReference}
 
 import wvlet.airspec.AirSpec
 
@@ -227,10 +227,28 @@ object RxTest extends AirSpec {
   }
 
   test("lastOption") {
-    val rx = Rx.const(1).lastOption
+    val rx      = Rx.single(1).lastOption
+    var counter = 0
     rx.run { x =>
-      info(s"last: ${x}")
+      counter += 1
+      x shouldBe 1
     }
+    counter shouldBe 1
   }
 
+  test("concat") {
+    val rx = Rx.single(1).concat(Rx.single(2)).map(_ * 2)
+    val b  = Seq.newBuilder[Int]
+    rx.run {
+      b += _
+    }
+    b.result() shouldBe Seq(2, 4)
+  }
+
+  test("sequence") {
+    val rx = Rx.sequence(Seq(1, 2, 3)).map(_ * 2)
+    val b  = Seq.newBuilder[Int]
+    rx.run(b += _)
+    b.result() shouldBe Seq(2, 4, 6)
+  }
 }

--- a/airframe-http/src/test/scala/wvlet/airframe/http/rx/RxTest.scala
+++ b/airframe-http/src/test/scala/wvlet/airframe/http/rx/RxTest.scala
@@ -172,6 +172,16 @@ object RxTest extends AirSpec {
     c.cancel
   }
 
+  test("zip sequences") {
+    val a = Rx.sequence(1, 2, 3)
+    val b = Rx.sequence("a", "b")
+
+    val r = Seq.newBuilder[(Int, String)]
+    a.zip(b).run(r += _)
+
+    r.result shouldBe Seq((1, "a"), (2, "b"))
+  }
+
   test("zip3") {
     val a = Rx.variable(1)
     val b = Rx.variable("a")

--- a/airframe-http/src/test/scala/wvlet/airframe/http/rx/RxTest.scala
+++ b/airframe-http/src/test/scala/wvlet/airframe/http/rx/RxTest.scala
@@ -270,6 +270,36 @@ object RxTest extends AirSpec {
     )
   }
 
+  test("join4") {
+    val x  = Rx.variable(1)
+    val y  = Rx.variable("a")
+    val z  = Rx.variable(true)
+    val w  = Rx.variable(10)
+    val rx = x.join(y, z, w)
+
+    val b = Seq.newBuilder[RxEvent]
+    RxRunner.run(rx)(b += _)
+
+    y := "b"
+    y := "c"
+    w := 20
+    z := false
+    x := 2
+    y := "d"
+
+    val events = b.result()
+    debug(events)
+    events shouldBe Seq(
+      OnNext(1, "a", true, 10),
+      OnNext(1, "b", true, 10),
+      OnNext(1, "c", true, 10),
+      OnNext(1, "c", true, 20),
+      OnNext(1, "c", false, 20),
+      OnNext(2, "c", false, 20),
+      OnNext(2, "d", false, 20)
+    )
+  }
+
   implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global
 
   test("from Future[X]") {

--- a/airframe-http/src/test/scala/wvlet/airframe/http/rx/RxTest.scala
+++ b/airframe-http/src/test/scala/wvlet/airframe/http/rx/RxTest.scala
@@ -283,7 +283,8 @@ object RxTest extends AirSpec {
         ("filter", rx.filter(_ => true), Seq(1)),
         ("zip", rx.zip(Rx.single(2)), Seq((1, 2))),
         ("zip3", rx.zip(Rx.single(2), Rx.single(3)), Seq((1, 2, 3))),
-        ("concat", rx.concat(Rx.single(2)), Seq(1, 2))
+        ("concat", rx.concat(Rx.single(2)), Seq(1, 2)),
+        ("lastOption", rx.lastOption, Seq(1))
       ).map { x =>
         (x._1, x._2.recover(recoveryFunction), x._3)
       }


### PR DESCRIPTION
This change will be necessary for supporting gRPC streaming #1234 

In this PR, Rx values will be represented with three states: OnNext(v), OnError(Throwable), and OnCompletion. Especially OnCompletion event is important to implement Rx.lastOption, Rx.concat, Rx.sequence. Without OnCompletion event, we don't know the end of stream (lastOption), so we can't concatenate two or more streams. 

With this change, Rx can be used as a reactive programming interface http://reactivex.io/

