### PR TITLE
airframe-grpc: Add async grpc client for streaming

### DIFF
--- a/airframe-http-grpc/src/main/scala/wvlet/airframe/http/grpc/GrpcClientCalls.scala
+++ b/airframe-http-grpc/src/main/scala/wvlet/airframe/http/grpc/GrpcClientCalls.scala
@@ -64,4 +64,19 @@ object GrpcClientCalls extends LogSupport {
     }
   }
 
+  def translate[A, B](observer: StreamObserver[A], f: B => A): StreamObserver[B] =
+    new StreamObserver[B] {
+      override def onNext(value: B): Unit = {
+        Try(f(value)) match {
+          case Success(a) => observer.onNext(a)
+          case Failure(e) => observer.onError(e)
+        }
+      }
+      override def onError(t: Throwable): Unit = {
+        observer.onError(t)
+      }
+      override def onCompleted(): Unit = {
+        observer.onCompleted()
+      }
+    }
 }

--- a/docs/airframe-rpc.md
+++ b/docs/airframe-rpc.md
@@ -386,7 +386,7 @@ Airframe gRPC is a gRPC and HTTP2-based implementation of Airframe RPC, which ca
 - Roadmap
   - [x] Create a gRPC server from Airframe RPC router
   - [x] Generate gRPC client stub with sbt-airframe plugin.
-  - [ ] Support client, server-side, and bidirectional streaming
+  - [x] Support client, server-side, and bidirectional streaming
   - [ ] Add a gRPC server proxy with airframe-http-finagle for supporting HTTP1
 
 __build.sbt__
@@ -523,6 +523,6 @@ case class HelloResponse(message:String)
 ```json
 {"message":"..."}
 ```
--__Http Status__
+- __Http Status__
   - 200 (Ok) for successful responses.
   - 400 (Bad Request) if some request parameters are invalid.

--- a/sbt-airframe/src/sbt-test/sbt-airframe/grpc/server/src/test/scala/example/api/GreeterApiTest.scala
+++ b/sbt-airframe/src/sbt-test/sbt-airframe/grpc/server/src/test/scala/example/api/GreeterApiTest.scala
@@ -35,6 +35,9 @@ object GreeterApiTest extends AirSpec {
       .bind[ServiceGrpc.SyncClient].toProvider { channel: ManagedChannel =>
         ServiceGrpc.newSyncClient(channel)
       }
+      .bind[ServiceGrpc.AsyncClient].toProvider { channel: ManagedChannel =>
+        ServiceGrpc.newAsyncClient(channel)
+      }
   }
 
   test("test unary RPC") { syncClient: ServiceGrpc.SyncClient =>
@@ -43,23 +46,77 @@ object GreeterApiTest extends AirSpec {
     ret shouldBe "Hello Airframe gRPC!"
   }
 
-//  test("test async RPC") { channel: ManagedChannel =>
-//    val asyncClient = ServiceGrpcClient.newAsyncClient(channel)
-//    asyncClient.GreeterApi.sayHello(
-//      "Airframe gRPC",
-//      new StreamObserver[String] {
-//        def onNext(v: String): Unit = {
-//          logger.info(s"async response: ${v}")
-//        }
-//        def onError(t: Throwable): Unit = {
-//          logger.error(t)
-//        }
-//        def onCompleted(): Unit = {
-//          logger.info("completed")
-//        }
-//      }
-//    )
-// }
+  test("test async unary RPC") { asyncClient: ServiceGrpc.AsyncClient =>
+    asyncClient.GreeterApi.sayHello(
+      "Airframe gRPC",
+      new StreamObserver[String] {
+        def onNext(v: String): Unit = {
+          logger.info(s"async response: ${v}")
+        }
+        def onError(t: Throwable): Unit = {
+          logger.error(t)
+        }
+        def onCompleted(): Unit = {
+          logger.info("completed")
+        }
+      }
+    )
+  }
+
+  test("test async server-streaming RPC") { asyncClient: ServiceGrpc.AsyncClient =>
+    asyncClient.GreeterApi.serverStreaming(
+      "Airframe gRPC",
+      new StreamObserver[String] {
+        def onNext(v: String): Unit = {
+          logger.info(s"async response: ${v}")
+        }
+        def onError(t: Throwable): Unit = {
+          logger.error(t)
+        }
+        def onCompleted(): Unit = {
+          logger.info("completed")
+        }
+      }
+    )
+  }
+
+  test("test async client-streaming RPC") { asyncClient: ServiceGrpc.AsyncClient =>
+    val requestObserver = asyncClient.GreeterApi.clientStreaming(
+      new StreamObserver[String] {
+        def onNext(v: String): Unit = {
+          logger.info(s"async response: ${v}")
+        }
+        def onError(t: Throwable): Unit = {
+          logger.error(t)
+        }
+        def onCompleted(): Unit = {
+          logger.info("completed")
+        }
+      }
+    )
+    requestObserver.onNext("airframe")
+    requestObserver.onNext("rpc")
+    requestObserver.onCompleted()
+  }
+
+  test("test async bidi-streaming RPC") { asyncClient: ServiceGrpc.AsyncClient =>
+    val requestObserver = asyncClient.GreeterApi.bidiStreaming(
+      new StreamObserver[String] {
+        def onNext(v: String): Unit = {
+          logger.info(s"async response: ${v}")
+        }
+        def onError(t: Throwable): Unit = {
+          logger.error(t)
+        }
+        def onCompleted(): Unit = {
+          logger.info("completed")
+        }
+      }
+    )
+    requestObserver.onNext("airframe")
+    requestObserver.onNext("rpc")
+    requestObserver.onCompleted()
+  }
 
   test("test streaming") { syncClient: ServiceGrpc.SyncClient =>
     val r1 = syncClient.GreeterApi.serverStreaming("gRPC")


### PR DESCRIPTION
While grpc sync client uses Rx[X], async client supports StreamObserver based streaming