### PR TITLE
Add a simple finagle/grpc benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,6 @@ website/node_modules
 website/i18n/*
 
 log/*
+airframe-benchmark/log/*
 .vscode/launch.json
 project/metals.sbt

--- a/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/http/Greeter.scala
+++ b/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/http/Greeter.scala
@@ -28,6 +28,8 @@ object Greeter {
 
   def finagleClient =
     HttpCodeGenerator.generate(router, HttpClientGeneratorConfig("wvlet.airframe.benchmark.http:sync"))
+  def finagleAsyncClient =
+    HttpCodeGenerator.generate(router, HttpClientGeneratorConfig("wvlet.airframe.benchmark.http:async"))
   def grpcClient =
     HttpCodeGenerator.generate(router, HttpClientGeneratorConfig("wvlet.airframe.benchmark.http:grpc"))
 }

--- a/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/http/Greeter.scala
+++ b/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/http/Greeter.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.benchmark.http
+
+import wvlet.airframe.http.codegen.{HttpClientGeneratorConfig, HttpCodeGenerator}
+import wvlet.airframe.http.{HttpClientConfig, RPC, Router}
+
+/**
+  */
+@RPC
+class Greeter {
+  def hello(name: String) = s"Hello ${name}!"
+}
+
+object Greeter {
+  def router = Router.of[Greeter]
+
+  def finagleClient =
+    HttpCodeGenerator.generate(router, HttpClientGeneratorConfig("wvlet.airframe.benchmark.http:sync"))
+  def grpcClient =
+    HttpCodeGenerator.generate(router, HttpClientGeneratorConfig("wvlet.airframe.benchmark.http:grpc"))
+}

--- a/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/http/HttpBenchmark.scala
+++ b/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/http/HttpBenchmark.scala
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.benchmark.http
+import java.util.concurrent.TimeUnit
+
+import io.grpc.Channel
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+import wvlet.airframe.Session
+import wvlet.airframe.http.finagle.{Finagle, FinagleSyncClient}
+import wvlet.airframe.http.grpc.gRPC
+import wvlet.log.LogSupport
+import com.twitter.finagle.http.{Request, Response}
+
+/**
+  */
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class FinagleBenchmark extends LogSupport {
+
+  private val design                                       = Finagle.server.withRouter(Greeter.router).designWithSyncClient.withProductionMode
+  private var session: Option[Session]                     = None
+  private var client: ServiceSyncClient[Request, Response] = null
+
+  @Setup
+  def setup: Unit = {
+    val s = design.newSession
+    s.start
+    session = Some(s)
+    client = new ServiceSyncClient(s.build[FinagleSyncClient])
+  }
+
+  @TearDown
+  def teardown: Unit = {
+    session.foreach(_.shutdown)
+  }
+
+  @Benchmark
+  def rpc(blackhole: Blackhole): Unit = {
+    blackhole.consume(client.Greeter.hello("RPC"))
+  }
+}
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class GrpcBenchmark extends LogSupport {
+
+  private val design =
+    gRPC.server.withRouter(Greeter.router).designWithChannel.withProductionMode
+  private var session: Option[Session]       = None
+  private var client: ServiceGrpc.SyncClient = null
+
+  @Setup
+  def setup: Unit = {
+    val s = design.newSession
+    s.start
+    val channel = s.build[Channel]
+    session = Some(s)
+    client = ServiceGrpc.newSyncClient(channel)
+  }
+
+  @TearDown
+  def teardown: Unit = {
+    session.foreach(_.shutdown)
+  }
+
+  @Benchmark
+  def rpc(blackhole: Blackhole): Unit = {
+    blackhole.consume(client.Greeter.hello("RPC"))
+  }
+}

--- a/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/http/ServiceAsyncClient.scala
+++ b/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/http/ServiceAsyncClient.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.benchmark.http
+
+/**
+  */
+import wvlet.airframe.http._
+import scala.language.higherKinds
+import scala.collection.immutable.Map
+
+class ServiceClient[F[_], Req, Resp](private val client: HttpClient[F, Req, Resp]) extends AutoCloseable {
+  override def close(): Unit = { client.close() }
+  def getClient: HttpClient[F, Req, Resp] = client
+  object Greeter {
+    def hello(name: String, requestFilter: Req => Req = identity): F[String] = {
+      client.postOps[Map[String, Any], String](
+        resourcePath = s"/wvlet.airframe.benchmark.http.Greeter/hello",
+        Map("name" -> name),
+        requestFilter = requestFilter
+      )
+    }
+  }
+}

--- a/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/http/ServiceGrpc.scala
+++ b/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/http/ServiceGrpc.scala
@@ -1,0 +1,129 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.benchmark.http
+
+import scala.collection.immutable.Map
+
+object ServiceGrpc {
+  import wvlet.airframe.msgpack.spi.MsgPack
+  import wvlet.airframe.codec.{MessageCodec, MessageCodecFactory}
+  import wvlet.airframe.http.grpc.GrpcServiceBuilder.{RPCRequestMarshaller, RPCResponseMarshaller}
+
+  private def newDescriptorBuilder(
+      fullMethodName: String,
+      methodType: io.grpc.MethodDescriptor.MethodType
+  ): io.grpc.MethodDescriptor.Builder[MsgPack, Any] = {
+    io.grpc.MethodDescriptor
+      .newBuilder[MsgPack, Any]()
+      .setType(methodType)
+      .setFullMethodName(fullMethodName)
+      .setRequestMarshaller(RPCRequestMarshaller)
+  }
+
+  class GreeterDescriptors(codecFactory: MessageCodecFactory) {
+    val helloDescriptor: io.grpc.MethodDescriptor[MsgPack, Any] = {
+      newDescriptorBuilder("wvlet.airframe.benchmark.http.Greeter/hello", io.grpc.MethodDescriptor.MethodType.UNARY)
+        .setResponseMarshaller(
+          new RPCResponseMarshaller[Any](
+            codecFactory.of[java.lang.String].asInstanceOf[MessageCodec[Any]]
+          )
+        ).build()
+    }
+  }
+
+  object GreeterModels {}
+
+  def newSyncClient(
+      channel: io.grpc.Channel,
+      callOptions: io.grpc.CallOptions = io.grpc.CallOptions.DEFAULT,
+      codecFactory: MessageCodecFactory = MessageCodecFactory.defaultFactoryForJSON
+  ): SyncClient = new SyncClient(channel, callOptions, codecFactory)
+
+  class SyncClient(
+      val channel: io.grpc.Channel,
+      callOptions: io.grpc.CallOptions = io.grpc.CallOptions.DEFAULT,
+      codecFactory: MessageCodecFactory = MessageCodecFactory.defaultFactoryForJSON
+  ) extends io.grpc.stub.AbstractBlockingStub[SyncClient](channel, callOptions)
+      with java.lang.AutoCloseable {
+
+    override protected def build(channel: io.grpc.Channel, callOptions: io.grpc.CallOptions): SyncClient = {
+      new SyncClient(channel, callOptions, codecFactory)
+    }
+
+    override def close(): Unit = {
+      channel match {
+        case m: io.grpc.ManagedChannel => m.shutdownNow()
+        case _                         =>
+      }
+    }
+
+    object Greeter {
+      private val descriptors = new GreeterDescriptors(codecFactory)
+
+      import io.grpc.stub.ClientCalls
+      import GreeterModels._
+
+      def hello(name: String): String = {
+        val __m   = Map("name" -> name)
+        val codec = codecFactory.of[Map[String, Any]]
+        ClientCalls
+          .blockingUnaryCall(getChannel, descriptors.helloDescriptor, getCallOptions, codec.toMsgPack(__m))
+          .asInstanceOf[String]
+      }
+    }
+  }
+
+  def newAsyncClient(
+      channel: io.grpc.Channel,
+      callOptions: io.grpc.CallOptions = io.grpc.CallOptions.DEFAULT,
+      codecFactory: MessageCodecFactory = MessageCodecFactory.defaultFactoryForJSON
+  ): AsyncClient = new AsyncClient(channel, callOptions, codecFactory)
+
+  class AsyncClient(
+      val channel: io.grpc.Channel,
+      callOptions: io.grpc.CallOptions = io.grpc.CallOptions.DEFAULT,
+      codecFactory: MessageCodecFactory = MessageCodecFactory.defaultFactoryForJSON
+  ) extends io.grpc.stub.AbstractAsyncStub[AsyncClient](channel, callOptions)
+      with java.lang.AutoCloseable {
+
+    override protected def build(channel: io.grpc.Channel, callOptions: io.grpc.CallOptions): AsyncClient = {
+      new AsyncClient(channel, callOptions, codecFactory)
+    }
+
+    override def close(): Unit = {
+      channel match {
+        case m: io.grpc.ManagedChannel => m.shutdownNow()
+        case _                         =>
+      }
+    }
+
+    object Greeter {
+      private val descriptors = new GreeterDescriptors(codecFactory)
+
+      import io.grpc.stub.ClientCalls
+      import GreeterModels._
+
+      def hello(name: String, responseObserver: io.grpc.stub.StreamObserver[String]): Unit = {
+        val __m   = Map("name" -> name)
+        val codec = codecFactory.of[Map[String, Any]]
+        ClientCalls
+          .asyncUnaryCall[MsgPack, Any](
+            getChannel.newCall(descriptors.helloDescriptor, getCallOptions),
+            codec.toMsgPack(__m),
+            responseObserver.asInstanceOf[io.grpc.stub.StreamObserver[Any]]
+          )
+      }
+    }
+  }
+}

--- a/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/http/ServiceSyncClient.scala
+++ b/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/http/ServiceSyncClient.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.benchmark.http
+
+/**
+  */
+import wvlet.airframe.http._
+import scala.collection.immutable.Map
+
+class ServiceSyncClient[Req, Resp](private val client: HttpSyncClient[Req, Resp]) extends AutoCloseable {
+  override def close(): Unit = { client.close() }
+  def getClient: HttpSyncClient[Req, Resp] = client
+  object Greeter {
+    def hello(name: String, requestFilter: Req => Req = identity): String = {
+      client.postOps[Map[String, Any], String](
+        resourcePath = s"/wvlet.airframe.benchmark.http.Greeter/hello",
+        Map("name" -> name),
+        requestFilter = requestFilter
+      )
+    }
+  }
+}

--- a/airframe-benchmark/src/test/scala/wvlet/airframe/benchmark/BenchmarkMainTest.scala
+++ b/airframe-benchmark/src/test/scala/wvlet/airframe/benchmark/BenchmarkMainTest.scala
@@ -48,6 +48,6 @@ class BenchmarkMainTest extends AirSpec {
   }
 
   def `run http benchmark`: Unit = {
-    BenchmarkMain.main("bench-quick -F 0 -mt 2s http")
+    BenchmarkMain.main("bench-quick -F 0 -mt 1s http")
   }
 }

--- a/airframe-benchmark/src/test/scala/wvlet/airframe/benchmark/BenchmarkMainTest.scala
+++ b/airframe-benchmark/src/test/scala/wvlet/airframe/benchmark/BenchmarkMainTest.scala
@@ -46,4 +46,8 @@ class BenchmarkMainTest extends AirSpec {
   def `run json perf benchmark`: Unit = {
     BenchmarkMain.main(s"json-perf -n ${iteration} -b ${iteration}")
   }
+
+  def `run http benchmark`: Unit = {
+    BenchmarkMain.main("bench-quick -F 0 -mt 2s http")
+  }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -726,7 +726,7 @@ lazy val benchmark =
       ),
       publishPackArchiveTgz
     )
-    .dependsOn(msgpackJVM, jsonJVM, metricsJVM, launcher, airspecRefJVM % Test)
+    .dependsOn(msgpackJVM, jsonJVM, metricsJVM, launcher, finagle, grpc, airframeMacrosJVMRef, airspecRefJVM % Test)
 
 lazy val fluentd =
   project


### PR DESCRIPTION
Added a simple benchmark to see the performance of gRPC compared to Finagle:

```
> benchmark/pack

$ ./airframe-benchmark/target/pack/bin/airframe-benchmark bench -mt 5s http
Benchmark              Mode  Cnt     Score      Error  Units
FinagleBenchmark.rpc  thrpt   10  3780.651 ± 2274.439  ops/s
GrpcBenchmark.rpc     thrpt   10  6665.655 ± 2034.274  ops/s
```

Generally, gRPC seems 1.5 ~ 2x faster than Finagle. 

## Updates

Added async RPC call results as well:
```
Benchmark                   Mode  Cnt      Score      Error  Units
FinagleBenchmark.rpcAsync  thrpt   10  12540.307 ± 3885.182  ops/s
FinagleBenchmark.rpcSync   thrpt   10   4378.924 ± 1238.384  ops/s
GrpcBenchmark.rpcAsync     thrpt   10  35829.839 ± 3067.464  ops/s
GrpcBenchmark.rpcSync      thrpt   10   6355.409 ± 1586.169  ops/s
````
gRPC is super fast: 35,829 rpc/sec: 5x faster than sync client and 3x faster than finagle-async client!
