### PR TITLE
airframe-grpc: Add benchmark for ScalaPB

### DIFF
--- a/airframe-benchmark/src/main/protobuf/greeter.proto
+++ b/airframe-benchmark/src/main/protobuf/greeter.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "wvlet.airframe.benchmark.http.proto";
+
+package proto;
+
+// The greeting service definition.
+service Greeter {
+  rpc Hello (HelloRequest) returns (HelloReply) {}
+}
+
+message HelloRequest {
+  string name = 1;
+}
+
+message HelloReply {
+  string message = 1;
+}

--- a/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/http/ScalaPBGreeter.scala
+++ b/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/http/ScalaPBGreeter.scala
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.benchmark.http
+import wvlet.airframe.benchmark.http.proto.greeter.{GreeterGrpc, HelloReply, HelloRequest}
+
+import scala.concurrent.Future
+
+/**
+  */
+class ScalaPBGreeter extends GreeterGrpc.Greeter {
+
+  override def hello(
+      request: HelloRequest
+  ): Future[HelloReply] = {
+    Future.successful(HelloReply(s"Hello ${request.name}!"))
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -698,8 +698,7 @@ lazy val benchmark =
   project
     .in(file("airframe-benchmark"))
     // Necessary for generating /META-INF/BenchmarkList
-    .enablePlugins(JmhPlugin)
-    .enablePlugins(PackPlugin)
+    .enablePlugins(JmhPlugin, PackPlugin)
     .settings(buildSettings)
     .settings(
       name := "airframe-benchmark",
@@ -721,8 +720,12 @@ lazy val benchmark =
         "org.openjdk.jmh" % "jmh-generator-bytecode"   % JMH_VERSION,
         "org.openjdk.jmh" % "jmh-generator-reflection" % JMH_VERSION,
         // Used only for json benchmark
-        "org.json4s" %% "json4s-jackson" % "3.6.9",
-        "io.circe"   %% "circe-parser"   % "0.11.2"
+        "org.json4s"           %% "json4s-jackson"       % "3.6.9",
+        "io.circe"             %% "circe-parser"         % "0.11.2",
+        "com.thesamet.scalapb" %% "scalapb-runtime-grpc" % scalapb.compiler.Version.scalapbVersion
+      ),
+      PB.targets in Compile := Seq(
+        scalapb.gen() -> (sourceManaged in Compile).value / "scalapb"
       ),
       publishPackArchiveTgz
     )

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -30,3 +30,7 @@ addSbtPlugin("org.xerial.sbt"     % "sbt-pack" % "0.12")
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
 
 scalacOptions ++= Seq("-deprecation", "-feature")
+
+// Only for ScalaPB benchmark
+addSbtPlugin("com.thesamet"                    % "sbt-protoc"     % "0.99.34")
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.10.8"


### PR DESCRIPTION
Add a benchmark for ScalaPB. airframe-grpc seems faster than ScalaPB:
```
$ ./sbt airframe-benchmark/pack
$ ./airframe-benchmark/target/pack/bin/airframe-benchmark bench http -mt 5s

Benchmark                   Mode  Cnt      Score      Error  Units
FinagleBenchmark.rpcAsync  thrpt   10  16873.366 ± 3370.694  ops/s
FinagleBenchmark.rpcSync   thrpt   10   4344.363 ± 1878.053  ops/s
GrpcBenchmark.rpcAsync     thrpt   10  45615.096 ± 8768.244  ops/s
GrpcBenchmark.rpcSync      thrpt   10   7564.656 ± 1729.330  ops/s
ScalaPBBenchmark.rpcAsync  thrpt   10  23550.051 ± 3981.219  ops/s
ScalaPBBenchmark.rpcSync   thrpt   10   6910.494 ± 2075.070  ops/s
```