### PR TITLE
internal: Upgrade to sbt 1.4.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,8 +55,8 @@ addCommandAlias(
 // Reload build.sbt on changes
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
-// Since sbt-1.4.0-RC2
-ThisBuild / usePipelining := true
+// Disable pipelining available since sbt-1.4.0, it causes compilation failure
+ThisBuild / usePipelining := false
 
 // For using Scala 2.12 in sbt
 scalaVersion in ThisBuild := SCALA_2_12
@@ -1111,7 +1111,7 @@ lazy val sbtAirframe =
       name := "sbt-airframe",
       description := "sbt plugin for helping programming with Airframe",
       scalaVersion := SCALA_2_12,
-//      crossSbtVersions := Vector("1.3.12"),
+      crossSbtVersions := Vector("1.3.13"),
       libraryDependencies ++= Seq(
         "io.get-coursier"   %% "coursier"         % "2.0.0-RC5-6",
         "org.apache.commons" % "commons-compress" % "1.20"

--- a/build.sbt
+++ b/build.sbt
@@ -17,10 +17,11 @@ val SQLITE_JDBC_VERSION             = "3.32.3.2"
 val SLF4J_VERSION                   = "1.7.30"
 val JS_JAVA_LOGGING_VERSION         = "1.0.0"
 val JS_JAVA_TIME_VERSION            = "1.0.0"
+val SCALAJS_DOM_VERSION             = "1.1.0"
 val FINAGLE_VERSION                 = "20.4.1"
 val FLUENCY_VERSION                 = "2.4.1"
-val SCALAJS_DOM_VERSION             = "1.1.0"
 val GRPC_VERSION                    = "1.32.1"
+val JMH_VERSION                     = "1.25.2"
 
 val airSpecFramework = new TestFramework("wvlet.airspec.Framework")
 
@@ -55,7 +56,7 @@ addCommandAlias(
 // Reload build.sbt on changes
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
-// Disable pipelining available since sbt-1.4.0, it causes compilation failure
+// Disable the pipelining available since sbt-1.4.0. It caused compilation failure
 ThisBuild / usePipelining := false
 
 // For using Scala 2.12 in sbt
@@ -499,8 +500,7 @@ lazy val metrics =
     .settings(buildSettings)
     .settings(
       name := "airframe-metrics",
-      description := "Basit metric representations, including duration, size, time window, etc.",
-      libraryDependencies ++= Seq()
+      description := "Basit metric representations, including duration, size, time window, etc."
     )
     .jsSettings(jsBuildSettings)
     .dependsOn(log, surface, airspecRef % Test)
@@ -713,8 +713,6 @@ lazy val json =
 lazy val jsonJVM = json.jvm
 lazy val jsonJS  = json.js
 
-val JMH_VERSION = "1.25.2"
-
 lazy val benchmark =
   project
     .in(file("airframe-benchmark"))
@@ -728,7 +726,6 @@ lazy val benchmark =
       // Turbo mode didn't work with this error:
       // java.lang.RuntimeException: ERROR: Unable to find the resource: /META-INF/BenchmarkList
       turbo := false,
-      exportPipelining := false,
       // Generate JMH benchmark cord before packaging and testing
       pack := pack.dependsOn(compile in Test).value,
       sourceDirectory in Jmh := (sourceDirectory in Compile).value,
@@ -774,7 +771,7 @@ lazy val fluentd =
         "org.slf4j" % "slf4j-jdk14" % SLF4J_VERSION
       )
     )
-    .dependsOn(codecJVM, airframeJVM % Compile, airframeMacrosJVMRef, airspecRefJVM % Test)
+    .dependsOn(codecJVM, airframeJVM, airframeMacrosJVMRef, airspecRefJVM % Test)
 
 lazy val sql =
   project
@@ -1111,7 +1108,8 @@ lazy val sbtAirframe =
       name := "sbt-airframe",
       description := "sbt plugin for helping programming with Airframe",
       scalaVersion := SCALA_2_12,
-      crossSbtVersions := Vector("1.3.13"),
+      // This setting might be unnecessary?
+      //crossSbtVersions := Vector("1.3.13"),
       libraryDependencies ++= Seq(
         "io.get-coursier"   %% "coursier"         % "2.0.0-RC5-6",
         "org.apache.commons" % "commons-compress" % "1.20"

--- a/examples/rpc-examples/hello-rpc/build.sbt
+++ b/examples/rpc-examples/hello-rpc/build.sbt
@@ -1,4 +1,4 @@
-val AIRFRAME_VERSION = "20.8.0"
+val AIRFRAME_VERSION = "20.9.2"
 scalaVersion in ThisBuild := "2.12.12"
 
 // RPC API definition. This project should contain only RPC interfaces

--- a/examples/rpc-examples/hello-rpc/project/build.properties
+++ b/examples/rpc-examples/hello-rpc/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.13
+sbt.version=1.4.0

--- a/project/build.properties
+++ b/project/build.properties
@@ -11,4 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-sbt.version=1.4.0-RC2
+sbt.version=1.4.0

--- a/project/build.properties
+++ b/project/build.properties
@@ -11,4 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-sbt.version=1.3.13
+sbt.version=1.4.0-RC2

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -5,6 +5,8 @@ addSbtPlugin("org.scalameta"      % "sbt-scalafmt"             % "2.4.2")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
 addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"            % "0.10.0")
 
+addDependencyTreePlugin
+
 // For Scala.js
 val SCALAJS_VERSION = sys.env.getOrElse("SCALAJS_VERSION", "1.2.0")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % SCALAJS_VERSION)

--- a/sbt
+++ b/sbt
@@ -35,7 +35,7 @@
 set -o pipefail
 
 declare -r sbt_release_version="1.3.13"
-declare -r sbt_unreleased_version="1.4.0-M1"
+declare -r sbt_unreleased_version="1.4.0-RC1"
 
 declare -r latest_213="2.13.3"
 declare -r latest_212="2.12.12"

--- a/sbt
+++ b/sbt
@@ -34,8 +34,8 @@
 
 set -o pipefail
 
-declare -r sbt_release_version="1.3.13"
-declare -r sbt_unreleased_version="1.4.0-RC1"
+declare -r sbt_release_version="1.4.0"
+declare -r sbt_unreleased_version="1.4.0"
 
 declare -r latest_213="2.13.3"
 declare -r latest_212="2.12.12"


### PR DESCRIPTION
- Upgrade to sbt 1.4.0
- Enable the build-in dependency tree plugin (We can use dependencyTree command)
- Tested build pipelining https://github.com/sbt/sbt/pull/5703 
, but observed many compilation failures especially around macro / JVM projects. Disabled this feature for now (this behavior is the default anyway)
