### PR TITLE
Improve empty JSON array and object formatting

### DIFF
--- a/airframe-json/src/main/scala/wvlet/airframe/json/JSON.scala
+++ b/airframe-json/src/main/scala/wvlet/airframe/json/JSON.scala
@@ -73,31 +73,39 @@ object JSON extends LogSupport {
       val s = new StringBuilder()
       v match {
         case x: JSONObject =>
-          s.append("{\n")
-          s.append {
-            x.v
-              .map { case (k, v: JSONValue) =>
-                val ss = new StringBuilder
-                ss.append("  " * (level + 1))
-                ss.append("\"")
-                ss.append(quoteJSONString(k))
-                ss.append("\": ")
-                ss.append(formatInternal(v, level + 1))
-                ss.result()
-              }.mkString("", ",\n", "\n")
+          if (x.v.isEmpty) {
+            s.append("{}")
+          } else {
+            s.append("{\n")
+            s.append {
+              x.v
+                .map { case (k, v: JSONValue) =>
+                  val ss = new StringBuilder
+                  ss.append("  " * (level + 1))
+                  ss.append("\"")
+                  ss.append(quoteJSONString(k))
+                  ss.append("\": ")
+                  ss.append(formatInternal(v, level + 1))
+                  ss.result()
+                }.mkString("", ",\n", "\n")
+            }
+            s.append("  " * level)
+            s.append("}")
           }
-          s.append("  " * level)
-          s.append("}")
         case x: JSONArray =>
-          s.append("[\n")
-          s.append(
-            x.v
-              .map { x =>
-                ("  " * (level + 1)) + formatInternal(x, level + 1)
-              }.mkString("", ",\n", "\n")
-          )
-          s.append("  " * level)
-          s.append("]")
+          if (x.v.isEmpty) {
+            s.append("[]")
+          } else {
+            s.append("[\n")
+            s.append(
+              x.v
+                .map { x =>
+                  ("  " * (level + 1)) + formatInternal(x, level + 1)
+                }.mkString("", ",\n", "\n")
+            )
+            s.append("  " * level)
+            s.append("]")
+          }
         case x => s.append(x.toJSON)
       }
       s.result()

--- a/airframe-json/src/test/scala/wvlet/airframe/json/JSONTest.scala
+++ b/airframe-json/src/test/scala/wvlet/airframe/json/JSONTest.scala
@@ -80,7 +80,9 @@ class JSONTest extends AirSpec {
   }
 
   def `format JSON value`: Unit = {
-    val json = JSON.parse("""{"user": [{ "values": {"value": "a"} }, { "values": {"value": "b"} }]}""")
+    val json = JSON.parse(
+      """{"user": [{ "values": {"value": "a"} }, { "values": {"value": "b"} }, {"values": []}, {"values": {}}]}"""
+    )
     JSON.format(json) shouldBe """{
                                  |  "user": [
                                  |    {
@@ -92,6 +94,12 @@ class JSONTest extends AirSpec {
                                  |      "values": {
                                  |        "value": "b"
                                  |      }
+                                 |    },
+                                 |    {
+                                 |      "values": []
+                                 |    },
+                                 |    {
+                                 |      "values": {}
                                  |    }
                                  |  ]
                                  |}""".stripMargin


### PR DESCRIPTION
Before:
```json
"empty_array": [

],
"empty_object": {

}
```

After:
```json
"empty_array": [],
"empty_object": {}
```