### PR TITLE
Scala 2.11 deprecation

### DIFF
--- a/.github/workflows/release-js.yml
+++ b/.github/workflows/release-js.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - v*
+  workflow_dispatch:
 
 jobs:
   publish_js:
@@ -31,9 +32,9 @@ jobs:
       - name: Build for Scala.js 1.0.x
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-        run: SCALAJS_VERSION=1.3.0 ./sbt publishJSSigned
+        run: ./sbt publishJSSigned
       - name: Release to Sonatype
         env:
           SONATYPE_USERNAME: '${{ secrets.SONATYPE_USER }}'
           SONATYPE_PASSWORD: '${{ secrets.SONATYPE_PASS }}'
-        run: SCALAJS_VERSION=1.3.0 ./sbt sonatypeBundleRelease
+        run: ./sbt sonatypeBundleRelease

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - v*
+  workflow_dispatch:
 
 jobs:
   publish_jvm:
@@ -32,7 +33,7 @@ jobs:
       - name: Build bundle
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-        run: ./sbt "; + projectJVM2_13/publishSigned; + projectJVM2_12/publishSigned; sbtAirframe/publishSigned;"
+        run: ./sbt "; + projectJVM/publishSigned; sbtAirframe/publishSigned;"
       - name: Release to Sonatype
         env:
           SONATYPE_USERNAME: '${{ secrets.SONATYPE_USER }}'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
           key: ${{ runner.os }}-scala-2.13-${{ hashFiles('**/*.sbt') }}
           restore-keys: ${{ runner.os }}-scala-2.13-
       - name: Scala 2.13 test
-        run: ./sbt ++2.13.2 projectJVM2_13/test
+        run: ./sbt ++2.13.3 projectJVM/test
   test_js:
     name: Scala.js / Scala 2.12
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,21 +55,6 @@ jobs:
           restore-keys: ${{ runner.os }}-scala-2.13-
       - name: Scala 2.13 test
         run: ./sbt ++2.13.2 projectJVM2_13/test
-  test_2_11:
-    name: Scala 2.11
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: olafurpg/setup-scala@v5
-        with:
-          java-version: adopt@1.11
-      - uses: actions/cache@v1
-        with:
-          path: ~/.cache
-          key: ${{ runner.os }}-scala-2.11-${{ hashFiles('**/*.sbt') }}
-          restore-keys: ${{ runner.os }}-scala-2.11-
-      - name: Scala 2.11 test
-        run: ./sbt ++2.11.12 projectJVM/test
   test_js:
     name: Scala.js / Scala 2.12
     runs-on: ubuntu-latest

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,6 @@ import xerial.sbt.pack.PackPlugin.publishPackArchiveTgz
 val SCALA_2_12 = "2.12.12"
 val SCALA_2_13 = "2.13.3"
 
-val untilScala2_12      = SCALA_2_12 :: Nil
 val targetScalaVersions = SCALA_2_13 :: SCALA_2_12 :: Nil
 
 val SCALATEST_VERSION               = "3.0.8"
@@ -164,6 +163,7 @@ lazy val jvmProjects: Seq[ProjectReference] = communityBuildProjects ++ Seq[Proj
   finagle,
   okhttp,
   httpRecorder,
+  benchmark,
   sql,
   examples
 )


### PR DESCRIPTION
- We no longer need to maintain Spark 2.4.x with Scala 2.11 as Spark 3.0.x is stable to use
- This PR drops Scala 2.11 configurations and merges project settings for Scala 2.12 and Scala 2.13 for simplicity
  - Added minor fixes for passing compilation with Scala 2.13