### PR TITLE
Add setThreadLocal method for the pre-defined key TLS_KEY_SERVER_EXCEPTION

### DIFF
--- a/airframe-http/src/main/scala/wvlet/airframe/http/HttpBackend.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/HttpBackend.scala
@@ -65,6 +65,9 @@ trait HttpBackend[Req, Resp, F[_]] { self =>
   // Prepare a thread-local holder for passing parameter values
   def withThreadLocalStore(request: => F[Resp]): F[Resp]
 
+  // Set a thread-local context parameter value for a pre-defined key
+  def setThreadLocalToServerException[A](value: A): Unit = setThreadLocal(HttpBackend.TLS_KEY_SERVER_EXCEPTION, value)
+
   // Set a thread-local context parameter value
   def setThreadLocal[A](key: String, value: A): Unit
 

--- a/airframe-http/src/main/scala/wvlet/airframe/http/HttpBackend.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/HttpBackend.scala
@@ -66,7 +66,7 @@ trait HttpBackend[Req, Resp, F[_]] { self =>
   def withThreadLocalStore(request: => F[Resp]): F[Resp]
 
   // Set a thread-local context parameter value for a pre-defined key
-  def setThreadLocalToServerException[A](value: A): Unit = setThreadLocal(HttpBackend.TLS_KEY_SERVER_EXCEPTION, value)
+  def setThreadLocalServerException[A](value: A): Unit = setThreadLocal(HttpBackend.TLS_KEY_SERVER_EXCEPTION, value)
 
   // Set a thread-local context parameter value
   def setThreadLocal[A](key: String, value: A): Unit


### PR DESCRIPTION
Like FinagleServer.defaultErrorFilter, I sometimes want to rescue specific exceptions in an own Filter but to record them in an access log. The exceptions rescued convert into a new Future.value, meaning no exceptions are recorded by HttpAccessLogFilter. To record them, this PR is to add a method to set an exception.