### PR TITLE
airframe-di: #586 Fixes constructor injection to use Singleton 

### DIFF
--- a/airframe/src/main/scala/wvlet/airframe/AirframeSession.scala
+++ b/airframe/src/main/scala/wvlet/airframe/AirframeSession.scala
@@ -33,7 +33,8 @@ private[airframe] class AirframeSession(
     val design: Design,
     stage: Stage,
     val lifeCycleManager: LifeCycleManager,
-    private val singletonHolder: collection.mutable.Map[Surface, Any] = new ConcurrentHashMap[Surface, Any]().asScala
+    private
+    val singletonHolder: collection.mutable.Map[Surface, Any] = new ConcurrentHashMap[Surface, Any]().asScala
 ) extends Session
     with AirframeSessionImpl
     with LogSupport {
@@ -325,12 +326,14 @@ private[airframe] class AirframeSession(
                 )
               case p @ ProviderBinding(factory, provideSingleton, eager, sourceCode) =>
                 trace(s"[${name}] Found a provider for ${p.from}: ${p}, defined at ${sourceCode}")
+
                 def buildWithProvider: Any = {
                   val dependencies = for (d <- factory.dependencyTypes) yield {
                     contextSession.getInstance(d, d, sourceCode, contextSession, false, tpe :: seen)
                   }
                   factory.create(dependencies)
                 }
+
                 if (provideSingleton) {
                   singletonHolder.getOrElseUpdate(p.from, registerInjectee(p.from, p.from, buildWithProvider))
                 } else {
@@ -424,7 +427,8 @@ private[airframe] class AirframeSession(
               p.surface,
               sourceCode,
               contextSession,
-              create = true,
+              // If the default value for the parameter is given, do not register the instance as a singleton
+              create = p.getDefaultValue.nonEmpty,
               seen,
               p.getDefaultValue.map(x => () => x)
             )

--- a/airframe/src/test/scala/wvlet/airframe/ConstructorInjectionTest.scala
+++ b/airframe/src/test/scala/wvlet/airframe/ConstructorInjectionTest.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe
+
+import wvlet.airspec.AirSpec
+
+import scala.util.Random
+
+/**
+  */
+object ConstructorInjectionTest extends AirSpec {
+
+  case class D(x: Int = 1)
+
+  case class C(d1: D, d2: D)
+
+  test("constructor injection should bind singleton instances") {
+    val d = newDesign
+    d.build[C] { c =>
+      c.d1 shouldBeTheSameInstanceAs c.d2
+    }
+  }
+
+}

--- a/airframe/src/test/scala/wvlet/airframe/ConstructorInjectionTest.scala
+++ b/airframe/src/test/scala/wvlet/airframe/ConstructorInjectionTest.scala
@@ -21,15 +21,14 @@ import scala.util.Random
   */
 object ConstructorInjectionTest extends AirSpec {
 
-  case class D(x: Int = 1)
+  case class D(x: Int = Random.nextInt(1000))
 
   case class C(d1: D, d2: D)
 
   test("constructor injection should bind singleton instances") {
-    val d = newDesign
+    val d = newSilentDesign
     d.build[C] { c =>
       c.d1 shouldBeTheSameInstanceAs c.d2
     }
   }
-
 }

--- a/airframe/src/test/scala/wvlet/airframe/ConstructorInjectionTest.scala
+++ b/airframe/src/test/scala/wvlet/airframe/ConstructorInjectionTest.scala
@@ -17,18 +17,31 @@ import wvlet.airspec.AirSpec
 
 import scala.util.Random
 
+object ConstructorInjectionTest {
+
+  case class Dep1(x: Int = Random.nextInt(1000))
+
+  case class Rep(d1: Dep1, d2: Dep1)
+
+  case class Config(port: Int = 8080, timeoutMillis: Int = 100000)
+
+}
+
 /**
   */
-object ConstructorInjectionTest extends AirSpec {
+class ConstructorInjectionTest extends AirSpec {
 
-  case class D(x: Int = Random.nextInt(1000))
+  import ConstructorInjectionTest._
 
-  case class C(d1: D, d2: D)
+  test("constructor injection should bind singleton to the same type") {
+    newSilentDesign.build[Rep] { r =>
+      r.d1 shouldBeTheSameInstanceAs r.d2
+    }
+  }
 
-  test("constructor injection should bind singleton instances") {
-    val d = newSilentDesign
-    d.build[C] { c =>
-      c.d1 shouldBeTheSameInstanceAs c.d2
+  test("properly populate default values") {
+    newSilentDesign.build[Config] { config =>
+      config shouldBe Config()
     }
   }
 }

--- a/airframe/src/test/scala/wvlet/airframe/DefaultValueTest.scala
+++ b/airframe/src/test/scala/wvlet/airframe/DefaultValueTest.scala
@@ -16,6 +16,7 @@ package wvlet.airframe
 import wvlet.airspec.AirSpec
 
 object DefaultValueTest {
+  // This type of default values often used in configuration classes
   case class A(a: Long = 10, b: Long = 100, c: Long = 1000)
 
   case class B(a: A)


### PR DESCRIPTION
This is a corner case bug fix when no default value is present for the constructor parameters.