### PR TITLE
airframe-rx: #1505 Add Rx.andThen(Future[X]) and Rx.future[X]

### DIFF
--- a/airframe-rx/src/test/scala/wvlet/airframe/rx/RxTest.scala
+++ b/airframe-rx/src/test/scala/wvlet/airframe/rx/RxTest.scala
@@ -13,11 +13,11 @@
  */
 package wvlet.airframe.rx
 import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
-
 import wvlet.airframe.Design
 import wvlet.airspec.AirSpec
 
-import scala.concurrent.Future
+import scala.concurrent.{Future, Promise}
+import scala.util.Try
 
 /**
   */
@@ -341,6 +341,20 @@ object RxTest extends AirSpec {
         case _    => fail()
       }
     }
+  }
+
+  test("Future response") {
+    val p  = Promise[Int]()
+    val rx = Rx.future(p.future).map { x => x * 2 }
+    p.complete(Try(10))
+    rx.run(x => x shouldBe 20)
+  }
+
+  test("andThen(Future[X])") {
+    val p  = Promise[Int]()
+    val rx = Rx.const(1).andThen(x => p.future).map(_ * 2)
+    p.complete(Try(10))
+    rx.run(x => x shouldBe 20)
   }
 
   test("lastOption") {


### PR DESCRIPTION
This PR adds a handy method for calling RPC that returns Future respones while rendering RxElements. cc: @shimamoto @takezoe 