### PR TITLE
airframe-rx: Add Rx.cache

### DIFF
--- a/airframe-rx/src/main/scala/wvlet/airframe/rx/Rx.scala
+++ b/airframe-rx/src/main/scala/wvlet/airframe/rx/Rx.scala
@@ -136,6 +136,8 @@ trait RxStream[+A] extends Rx[A] with LogSupport {
   def concat[A1 >: A](other: Rx[A1]): RxStream[A1] = Rx.concat(this, other)
   def lastOption: RxOption[A]                      = LastOp(this).toOption
 
+  def cache: RxStream[A] = CacheOp(this)
+
   /**
     * Take an event up to <i>n</i> elements. This may receive fewer events than n if the upstream operator
     * completes before generating <i>n</i> elements.
@@ -292,4 +294,6 @@ object Rx extends LogSupport {
   }
   case class ThrottleFirstOp[A](input: Rx[A], interval: Long, unit: TimeUnit) extends UnaryRx[A, A]
   case class ThrottleLastOp[A](input: Rx[A], interval: Long, unit: TimeUnit)  extends UnaryRx[A, A]
+
+  case class CacheOp[A](input: Rx[A], private[rx] var lastValue: Option[A] = None) extends UnaryRx[A, A]
 }

--- a/airframe-rx/src/main/scala/wvlet/airframe/rx/Rx.scala
+++ b/airframe-rx/src/main/scala/wvlet/airframe/rx/Rx.scala
@@ -136,6 +136,18 @@ trait RxStream[+A] extends Rx[A] with LogSupport {
   def concat[A1 >: A](other: Rx[A1]): RxStream[A1] = Rx.concat(this, other)
   def lastOption: RxOption[A]                      = LastOp(this).toOption
 
+  /**
+    * Cache the last item, and emit the cached value if available.
+    *
+    * The cached value will be preserved to the operatror itself even after cancelling the subscription.
+    * Re-subscription of this opreator will immediately return the cached
+    * value to the downstream operators.
+    *
+    * This operator is useful if we need to involve time-consuming operator, and want to reuse the last result:
+    * <code>
+    * Rx.intervalMillis(1000).map(i => (heavy process)).cache
+    * </code>
+    */
   def cache: RxStream[A] = CacheOp(this)
 
   /**

--- a/airframe-rx/src/main/scala/wvlet/airframe/rx/RxRunner.scala
+++ b/airframe-rx/src/main/scala/wvlet/airframe/rx/RxRunner.scala
@@ -175,6 +175,19 @@ class RxRunner(
               case Failure(e) => effect(OnError(e))
             }
         }
+      case cache @ CacheOp(in, _) =>
+        cache.lastValue match {
+          case Some(v) =>
+            effect(OnNext(v))
+          case None =>
+        }
+        run(in) { 
+          case OnNext(v) =>
+            cache.asInstanceOf[CacheOp[A]].lastValue = Some(v.asInstanceOf[A])
+            effect(OnNext(v))
+          case other =>
+            effect(other)
+        }
       case TakeOp(in, n) =>
         var count = 0
         run(in) {

--- a/airframe-rx/src/main/scala/wvlet/airframe/rx/RxRunner.scala
+++ b/airframe-rx/src/main/scala/wvlet/airframe/rx/RxRunner.scala
@@ -181,7 +181,7 @@ class RxRunner(
             effect(OnNext(v))
           case None =>
         }
-        run(in) { 
+        run(in) {
           case OnNext(v) =>
             cache.asInstanceOf[CacheOp[A]].lastValue = Some(v.asInstanceOf[A])
             effect(OnNext(v))

--- a/airframe-rx/src/test/scala/wvlet/airframe/rx/RxTest.scala
+++ b/airframe-rx/src/test/scala/wvlet/airframe/rx/RxTest.scala
@@ -714,4 +714,28 @@ object RxTest extends AirSpec {
       )
     }
   }
+
+  test("cache") {
+    val v           = Rx.variable(1)
+    val rx: Rx[Int] = v.map(x => x * 10).cache
+    val c0          = RxRunner.runContinuously(rx) { e => e shouldBe OnNext(10) }
+    c0.cancel
+
+    val events = Seq.newBuilder[RxEvent]
+    v := 2
+    val c1 = RxRunner.runContinuously(rx)(events += _)
+    c1.cancel
+    events.result() shouldBe Seq(
+      OnNext(10),
+      OnNext(20)
+    )
+    val events2 = Seq.newBuilder[RxEvent]
+    v := 3
+    val c2 = RxRunner.runContinuously(rx)(events2 += _)
+    c2.cancel
+    events2.result() shouldBe Seq(
+      OnNext(20),
+      OnNext(30)
+    )
+  }
 }

--- a/airframe-rx/src/test/scala/wvlet/airframe/rx/RxTest.scala
+++ b/airframe-rx/src/test/scala/wvlet/airframe/rx/RxTest.scala
@@ -732,10 +732,12 @@ object RxTest extends AirSpec {
     val events2 = Seq.newBuilder[RxEvent]
     v := 3
     val c2 = RxRunner.runContinuously(rx)(events2 += _)
+    v := 4
     c2.cancel
     events2.result() shouldBe Seq(
       OnNext(20),
-      OnNext(30)
+      OnNext(30),
+      OnNext(40)
     )
   }
 }


### PR DESCRIPTION
This PR will add a handy method for caching the last event. 

This will simplify the code that needs to read RPC results periodically while reusing the last result when re-rendering the page. For example, we can write a page listing the remote worker nodes like this: 
```scala
private val nodeList = Rx.intervalMillis(1000).andThen(i => (rpc call to get a node list)).cache

def render = nodeList.map { list =>
   ... // If the cached data is available, it will be rendered quickly
}

// Rx.intervalMillis(1000) will stop properly when this DOM is unmounted
// via Rx operator update (e.g., Rx.variable.update ...)
```

@shimamoto Could your review this new operator? cc: @takezoe 