### PR TITLE
Properly generate an openapi document for endpoints supporting multiple methods

### DIFF
--- a/airframe-http/.jvm/src/test/scala/example/openapi/OpenAPIExample.scala
+++ b/airframe-http/.jvm/src/test/scala/example/openapi/OpenAPIExample.scala
@@ -101,6 +101,11 @@ trait OpenAPIEndpointExample {
   @Endpoint(method = HttpMethod.TRACE, path = "/v1/trace1")
   def trace1(): Unit
 
+  @Endpoint(method = HttpMethod.POST, path = "/v1/multi_method")
+  def multi1(): Unit
+
+  @Endpoint(method = HttpMethod.OPTIONS, path = "/v1/multi_method")
+  def multi2(): Unit
 }
 
 object OpenAPIEndpointExample {

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/openapi/OpenAPITest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/openapi/OpenAPITest.scala
@@ -480,61 +480,15 @@ class OpenAPITest extends AirSpec {
         |      summary: trace1
         |      description: trace1
         |      operationId: trace1""".stripMargin,
-//      """  /v1/multi_method:
-//        |    post:
-//        |      summary: multi1
-//        |      description: multi1
-//        |      operationId: multi1
-//        |      responses:
-//        |        '200':
-//        |          description: 'RPC response'
-//        |        '400':
-//        |          $ref: '#/components/responses/400'
-//        |        '500':
-//        |          $ref: '#/components/responses/500'
-//        |        '503':
-//        |          $ref: '#/components/responses/503'""".stripMargin,
-//      """  /v1/multi_method:
-//        |    options:
-//        |      summary: multi2
-//        |      description: multi2
-//        |      operationId: multi2
-//        |      responses:
-//        |        '200':
-//        |          description: 'RPC response'
-//        |        '400':
-//        |          $ref: '#/components/responses/400'
-//        |        '500':
-//        |          $ref: '#/components/responses/500'
-//        |        '503':
-//        |          $ref: '#/components/responses/503'""".stripMargin,
-      """  /v1/multi_method:
-        |    post:
+      """  /v1/multi_method:""".stripMargin,
+      """    post:
         |      summary: multi1
         |      description: multi1
-        |      operationId: multi1
-        |      responses:
-        |        '200':
-        |          description: 'RPC response'
-        |        '400':
-        |          $ref: '#/components/responses/400'
-        |        '500':
-        |          $ref: '#/components/responses/500'
-        |        '503':
-        |          $ref: '#/components/responses/503'
-        |    options:
+        |      operationId: multi1""".stripMargin,
+      """    options:
         |      summary: multi2
         |      description: multi2
-        |      operationId: multi2
-        |      responses:
-        |        '200':
-        |          description: 'RPC response'
-        |        '400':
-        |          $ref: '#/components/responses/400'
-        |        '500':
-        |          $ref: '#/components/responses/500'
-        |        '503':
-        |          $ref: '#/components/responses/503'""".stripMargin,
+        |      operationId: multi2""".stripMargin
     )
 
     // For the ease of testing at https://editor.swagger.io/
@@ -542,13 +496,18 @@ class OpenAPITest extends AirSpec {
     //      .setContents(new java.awt.datatransfer.StringSelection(yaml), null)
 
     fragments.foreach { x =>
-      trace(x)
       yaml.contains(x) shouldBe true
     }
 
     // Parsing test
     OpenAPI.parseJson(json)
-    parseOpenAPI(yaml)
+    val oa = parseOpenAPI(yaml)
+
+    test("generate overloaded methods") {
+      val mm = oa.getPaths.get("/v1/multi_method")
+      mm.getOptions shouldNotBe null
+      mm.getPost shouldNotBe null
+    }
   }
 
   private def parseOpenAPI(yamlOrJson: String): io.swagger.v3.oas.models.OpenAPI = {

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/openapi/OpenAPITest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/openapi/OpenAPITest.scala
@@ -479,7 +479,62 @@ class OpenAPITest extends AirSpec {
         |    trace:
         |      summary: trace1
         |      description: trace1
-        |      operationId: trace1""".stripMargin
+        |      operationId: trace1""".stripMargin,
+//      """  /v1/multi_method:
+//        |    post:
+//        |      summary: multi1
+//        |      description: multi1
+//        |      operationId: multi1
+//        |      responses:
+//        |        '200':
+//        |          description: 'RPC response'
+//        |        '400':
+//        |          $ref: '#/components/responses/400'
+//        |        '500':
+//        |          $ref: '#/components/responses/500'
+//        |        '503':
+//        |          $ref: '#/components/responses/503'""".stripMargin,
+//      """  /v1/multi_method:
+//        |    options:
+//        |      summary: multi2
+//        |      description: multi2
+//        |      operationId: multi2
+//        |      responses:
+//        |        '200':
+//        |          description: 'RPC response'
+//        |        '400':
+//        |          $ref: '#/components/responses/400'
+//        |        '500':
+//        |          $ref: '#/components/responses/500'
+//        |        '503':
+//        |          $ref: '#/components/responses/503'""".stripMargin,
+      """  /v1/multi_method:
+        |    post:
+        |      summary: multi1
+        |      description: multi1
+        |      operationId: multi1
+        |      responses:
+        |        '200':
+        |          description: 'RPC response'
+        |        '400':
+        |          $ref: '#/components/responses/400'
+        |        '500':
+        |          $ref: '#/components/responses/500'
+        |        '503':
+        |          $ref: '#/components/responses/503'
+        |    options:
+        |      summary: multi2
+        |      description: multi2
+        |      operationId: multi2
+        |      responses:
+        |        '200':
+        |          description: 'RPC response'
+        |        '400':
+        |          $ref: '#/components/responses/400'
+        |        '500':
+        |          $ref: '#/components/responses/500'
+        |        '503':
+        |          $ref: '#/components/responses/503'""".stripMargin,
     )
 
     // For the ease of testing at https://editor.swagger.io/

--- a/build.sbt
+++ b/build.sbt
@@ -935,7 +935,7 @@ lazy val sbtAirframe =
       // This setting might be unnecessary?
       //crossSbtVersions := Vector("1.3.13"),
       libraryDependencies ++= Seq(
-        "io.get-coursier"   %% "coursier"         % "2.0.13",
+        "io.get-coursier"   %% "coursier"         % "2.0.14",
         "org.apache.commons" % "commons-compress" % "1.20"
       ),
       scriptedLaunchOpts := {


### PR DESCRIPTION
Currently,  airframe-http doesn't properly generate an openapi document for endpoints supporting multiple methods.