### PR TITLE
Path prefix versioning doesn't work in airframe-http

### DIFF
--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/RouterTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/RouterTest.scala
@@ -59,6 +59,17 @@ class RouterTest extends AirSpec {
     r.routes.find(_.path == "/v1/hello") shouldBe defined
   }
 
+  def `support nested prefixed paths`: Unit = {
+    val r = Router
+      .add[NextedPathsExample]
+
+    val r1 = r.findRoute(Http.GET("/v1/hello/world"))
+    r1 shouldBe defined
+
+    val r2 = r.findRoute(Http.GET("/v2/hello/world"))
+    r2 shouldBe defined
+  }
+
   trait RouteA
   trait RouteB
   trait RouteC

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/example/ControllerExample.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/example/ControllerExample.scala
@@ -98,3 +98,14 @@ trait PrefixExample {
     "hello"
   }
 }
+
+trait NextedPathsExample {
+  @Endpoint(path = "/v1/hello/world")
+  def hello: String = {
+    "hello"
+  }
+  @Endpoint(path = "/v2/hello/world")
+  def helloV1: String = {
+    "hello"
+  }
+}


### PR DESCRIPTION
If airframe-http based web application has paths that are versioned by prefix and are nested as follows:

- `/v1/hello/world`
- `/v2/hello/world`

`RouteMatcher` yields an exception like this:

```
java.lang.IllegalArgumentException: Found multiple matching routes: /v1/hello/world, /v2/hello/world 
```

Looks like this check is affecting, but I'm not sure how we can fix it properly.
https://github.com/wvlet/airframe/blob/2c610f2acdfa50eb67a11631e630558dd193d81b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/RouteMatcher.scala#L70-L77

I think this issue is critical for airframe-http based applications because this means path prefix-based versioning is almost unavailable in airframe-http.