### PR TITLE
airframe-http: Fixes #1546 by adding path prefixes to disambiguate NFA nodes

### DIFF
--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/Automaton.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/Automaton.scala
@@ -26,6 +26,15 @@ object Automaton {
   class Automaton[Node, Token](val nodes: Set[Node], val edges: Set[Edge[Node, Token]]) {
     type NodeSet = Set[Node]
 
+    override def toString: String = {
+      s"""[nodes]
+         |${nodes.mkString("\n")}
+         |
+         |[edges]
+         |${edges.mkString("\n")}
+         |""".stripMargin
+    }
+
     def addNode(n: Node): Automaton[Node, Token] = {
       new Automaton(nodes + n, edges)
     }

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/RouterTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/RouterTest.scala
@@ -59,6 +59,17 @@ class RouterTest extends AirSpec {
     r.routes.find(_.path == "/v1/hello") shouldBe defined
   }
 
+  def `support nested prefixed paths`: Unit = {
+    val r = Router
+      .add[NextedPathsExample]
+
+    val r1 = r.findRoute(Http.GET("/v1/hello/world"))
+    r1 shouldBe defined
+
+    val r2 = r.findRoute(Http.GET("/v2/hello/world"))
+    r2 shouldBe defined
+  }
+
   trait RouteA
   trait RouteB
   trait RouteC

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/example/ControllerExample.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/example/ControllerExample.scala
@@ -98,3 +98,14 @@ trait PrefixExample {
     "hello"
   }
 }
+
+trait NextedPathsExample {
+  @Endpoint(path = "/v1/hello/world")
+  def hello: String = {
+    "hello"
+  }
+  @Endpoint(path = "/v2/hello/world")
+  def helloV1: String = {
+    "hello"
+  }
+}


### PR DESCRIPTION
The problem was intermediate nodes were wrongly merged when building Automaton 
```
[OK]
v1 -> hello -> world (match)
v2 -> hello -> world (match) 

[Bug] 
v1 -> hello -> world (match)
v2 -/       \- world (match)
```

To solve this, added path prefixes to automaton nodes so that nodes belonging to different path prefixes will not be merged:
```
[With this PR]
v1 -> v1/hello -> v1/hello/world (match)
v2 -> v2/hello -> v2/hello/world (match)
```