### PR TITLE
sbt-airframe: Generate ServiceJSClientRx for Scala.js + RPC + Rx

### DIFF
--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/codegen/client/ScalaHttpClientGenerator.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/codegen/client/ScalaHttpClientGenerator.scala
@@ -179,6 +179,7 @@ object ScalaJSClientGenerator extends HttpClientGenerator {
          |import wvlet.airframe.surface.Surface
          |import wvlet.airframe.http.js.JSHttpClient
          |import wvlet.airframe.http.HttpMessage.Request
+         |import wvlet.airframe.rx.RxStream
          |
          |${jsClientCls}
          |
@@ -206,8 +207,8 @@ object ScalaJSClientGenerator extends HttpClientGenerator {
          |  /**
          |    * Override this method to add a common error handling
          |    */
-         |  protected def toRx[A](future:Future[A]): wvlet.airframe.rx.RxStream[A] = {
-         |    client.config.rxConverter(future).asInstanceOf[wvlet.airframe.rx.RxStream[A]]
+         |  protected def toRx[A](future:Future[A]): RxStream[A] = {
+         |    client.config.rxConverter(future).asInstanceOf[RxStream[A]]
          |  }
          |
          |${indent(rpcClientBody)}

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/codegen/client/ScalaHttpClientGenerator.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/codegen/client/ScalaHttpClientGenerator.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.http.codegen.client
 
-import wvlet.airframe.http.codegen.HttpClientIR.{ClientServiceDef, ClientSourceDef}
+import wvlet.airframe.http.codegen.HttpClientIR.{ClientMethodDef, ClientServiceDef, ClientSourceDef}
 
 /**
   */
@@ -172,7 +172,7 @@ object ScalaJSClientGenerator extends HttpClientGenerator {
   override def defaultFileName: String  = "ServiceJSClient.scala"
   override def defaultClassName: String = "ServiceJSClient"
   override def generate(src: ClientSourceDef): String = {
-    def code =
+    def code: String =
       s"""${header(src.destPackageName)}
          |
          |import scala.concurrent.Future
@@ -180,44 +180,86 @@ object ScalaJSClientGenerator extends HttpClientGenerator {
          |import wvlet.airframe.http.js.JSHttpClient
          |import wvlet.airframe.http.HttpMessage.Request
          |
-         |${cls}""".stripMargin
+         |${jsClientCls}
+         |
+         |${rpcClientCls}""".stripMargin
 
-    def cls: String =
+    def jsClientCls: String =
       s"""class ${src.classDef.clsName}(private val client: JSHttpClient = JSHttpClient.defaultClient) {
          |  def getClient: JSHttpClient = client
          |
          |${indent(clsBody)}
-         |}
-         |""".stripMargin
+         |}""".stripMargin
 
     def clsBody: String = {
       generateNestedStub(src) { svc =>
         s"""object ${svc.serviceName} {
-           |${indent(serviceBody(svc))}
+           |${indent(serviceBodyForFuture(svc))}
            |}""".stripMargin
       }
     }
 
-    def serviceBody(svc: ClientServiceDef): String = {
+    def rpcClientCls: String =
+      s"""class ${src.classDef.clsName}Rx(private val client: JSHttpClient = JSHttpClient.defaultClient) {
+         |  def getClient: JSHttpClient = client
+         |
+         |  /**
+         |    * Override this method to add a common error handling
+         |    */
+         |  protected def toRx[A](future:Future[A]): wvlet.airframe.rx.RxStream[A] = {
+         |    client.config.rxConverter(future).asInstanceOf[wvlet.airframe.rx.RxStream[A]]
+         |  }
+         |
+         |${indent(rpcClientBody)}
+         |}""".stripMargin
+
+    def rpcClientBody: String = {
+      generateNestedStub(src) { svc =>
+        s"""object ${svc.serviceName} {
+           |${indent(serviceBodyForRPC(svc))}
+           |}""".stripMargin
+      }
+    }
+
+    def inputArgs(m: ClientMethodDef): String = {
+      val args = m.inputParameters.map(x => s"${x.name}: ${x.surface.fullTypeName}") ++
+        Seq("requestFilter: Request => Request = identity")
+      args.mkString(", ")
+    }
+
+    def sendRequestArgs(m: ClientMethodDef): String = {
+      val args = Seq.newBuilder[String]
+      args += s"""resourcePath = s"${m.path}""""
+      args ++= m.clientCallParameters
+      args ++= m.typeArgs.map(s => s"Surface.of[${s.fullTypeName}]")
+      args += "requestFilter = requestFilter"
+      args.result().mkString(", ")
+    }
+
+    def serviceBodyForFuture(svc: ClientServiceDef): String = {
       svc.methods
         .map { m =>
-          val inputArgs = {
-            m.inputParameters.map(x => s"${x.name}: ${x.surface.fullTypeName}") ++
-              Seq("requestFilter: Request => Request = identity")
-          }
-
-          val sendRequestArgs = Seq.newBuilder[String]
-          sendRequestArgs += s"""resourcePath = s"${m.path}""""
-          sendRequestArgs ++= m.clientCallParameters
-          sendRequestArgs ++= m.typeArgs.map(s => s"Surface.of[${s.fullTypeName}]")
-          sendRequestArgs += "requestFilter = requestFilter"
-
           val lines = Seq.newBuilder[String]
           m.requestModelClassDef.foreach { x =>
             lines += x.code()
           }
-          lines += s"def ${m.name}(${inputArgs.mkString(", ")}): Future[${m.returnType.fullTypeName}] = {"
-          lines += s"  client.${m.clientMethodName}[${m.typeArgString}](${sendRequestArgs.result().mkString(", ")})"
+          lines += s"def ${m.name}(${inputArgs(m)}): Future[${m.returnType.fullTypeName}] = {"
+          lines += s"  client.${m.clientMethodName}[${m.typeArgString}](${sendRequestArgs(m)})"
+          lines += s"}"
+          lines.result().mkString("\n")
+        }
+        .mkString("\n")
+    }
+
+    def serviceBodyForRPC(svc: ClientServiceDef): String = {
+      svc.methods
+        .map { m =>
+          val lines = Seq.newBuilder[String]
+          m.requestModelClassDef.foreach { x =>
+            lines += x.code()
+          }
+          lines += s"def ${m.name}(${inputArgs(m)}): RxStream[${m.returnType.fullTypeName}] = {"
+          lines += s"  toRx(client.${m.clientMethodName}[${m.typeArgString}](${sendRequestArgs(m)}))"
           lines += s"}"
           lines.result().mkString("\n")
         }

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/codegen/HttpClientGeneratorTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/codegen/HttpClientGeneratorTest.scala
@@ -74,6 +74,11 @@ class HttpClientGeneratorTest extends AirSpec {
       code.contains("""Map("limit" -> limit, "sort" -> sort)""") shouldBe true
     }
     code.contains("import java.lang.Object") shouldBe false
+
+    test("generate ServiceJSClientRx") {
+      code.contains("class ServiceJSClientRx") shouldBe true
+      code.contains(": RxStream[scala.collection.Seq[example.Book]] = ")
+    }
   }
 
   test("scan classes") {

--- a/airframe-rx/src/main/scala/wvlet/airframe/rx/Rx.scala
+++ b/airframe-rx/src/main/scala/wvlet/airframe/rx/Rx.scala
@@ -81,6 +81,8 @@ trait Rx[+A] {
 }
 
 /**
+  * The base reactive stream interface that can receive events from upstream operators and chain
+  * next actions using Scala-collection like operators (e.g., map, filter, etc.)
   */
 trait RxStream[+A] extends Rx[A] with LogSupport {
   import Rx._

--- a/docs/airframe-rpc.md
+++ b/docs/airframe-rpc.md
@@ -250,7 +250,7 @@ lazy val ui =
     .enablePlugins(ScalaJSPlugin, AirframeHttpPlugin)
     .settings(
       buildSettings,
-      // sbt-airframe generates Scala.js HTTP client: ServiceJSClient with this setting:
+      // sbt-airframe generates Scala.js HTTP client: ServiceJSClient(Rx) with this setting:
       airframeHttpClients := Seq("myapp.app.v1:scalajs"),
       // Enable debug logging of sbt-airframe
       airframeHttpGeneratorOption := "-l debug"

--- a/sbt-airframe/src/sbt-test/sbt-airframe/js-client/client/src/main/scala/myspp/client/Main.scala
+++ b/sbt-airframe/src/sbt-test/sbt-airframe/js-client/client/src/main/scala/myspp/client/Main.scala
@@ -1,0 +1,17 @@
+package myapp.client
+
+import myapp.spi._
+
+object Main {
+
+  val jsClient = new ServiceJSClient()
+  val rpcClient = new ServiceJSClientRx()
+
+  import MyRPC._
+
+  // JS client
+  jsClient.MyRPC.hello(System.currentTimeMillis(), HelloRequest())
+
+  // RPC client that returns Rx[X] type
+  rpcClient.MyRPC.hello(System.currentTimeMillis(), HelloRequest())
+}


### PR DESCRIPTION
With this PR, sbt-airframe will generate an RPC client (ServcieJSClientRx) for Scala.js that returns Rx[X] return type, instead of Future[X].

This client will simplify RPC calls from Scala.js like this:
```scala
val rpcClient = bind[ServiceJSClientRx]

rpcClient.ServiceApi.apiMethod(...).map { x =>
  div(s"result: ${x}")
}
```

Previously, we always needed to wrap Future with Rx:
```scala
val jsClient = bind[ServiceJSClient]

// We always need to import ExecutionContext for Scala.js
implicit val queue = scala.scalajs.concurrent.JSExecutionContext.queue

Rx.future(jsClient.ServiceApi.apiMethod(...)).map { x =>
  div(s"result: ${x}")
}
```

cc: @shimamoto @takezoe 