### PR TITLE
airframe-rx: Add Rx.startWith

### DIFF
--- a/airframe-rx/src/main/scala/wvlet/airframe/rx/Rx.scala
+++ b/airframe-rx/src/main/scala/wvlet/airframe/rx/Rx.scala
@@ -177,6 +177,16 @@ trait RxStream[+A] extends Rx[A] with LogSupport {
     */
   def sample(timeWindow: Long, unit: TimeUnit = TimeUnit.MILLISECONDS): RxStream[A] =
     ThrottleLastOp[A](this, timeWindow, unit)
+
+  /**
+    * Emit the given item first before returning the items from the source.
+    */
+  def startWith[A1 >: A](a: A1): RxStream[A1] = Rx.concat(Rx.single(a), this)
+
+  /**
+    * Emit the given items first before returning the items from the source.
+    */
+  def startWith[A1 >: A](lst: Seq[A1]): RxStream[A1] = Rx.concat(Rx.fromSeq(lst), this)
 }
 
 /**

--- a/airframe-rx/src/test/scala/wvlet/airframe/rx/RxTest.scala
+++ b/airframe-rx/src/test/scala/wvlet/airframe/rx/RxTest.scala
@@ -412,6 +412,16 @@ object RxTest extends AirSpec {
     b.result() shouldBe Seq(2, 4)
   }
 
+  test("startWith(single)") {
+    val rx = Rx.single(1).startWith(0)
+    eval(rx) shouldBe Seq(OnNext(0), OnNext(1), OnCompletion)
+  }
+
+  test("startWith(Seq)") {
+    val rx = Rx.single(1).startWith(Seq(0, 0))
+    eval(rx) shouldBe Seq(OnNext(0), OnNext(0), OnNext(1), OnCompletion)
+  }
+
   test("sequence") {
     val rx = Rx.fromSeq(Seq(1, 2, 3)).map(_ * 2)
     val b  = Seq.newBuilder[Int]


### PR DESCRIPTION
http://reactivex.io/documentation/operators/startwith.html

We can use this operator to render the loading state while waiting for RPC responses:
```scala
rpcCall.map( x => div(...))
.startWith(div("loading ..."))

// This is equivalent to
Rx.concat(Rx.single(div("loading ...")), rpcCall.map(x => div(...)) 
```