### PR TITLE
airframe-rx: Add Rx.cache.getCurrent

### DIFF
--- a/airframe-rx/src/main/scala/wvlet/airframe/rx/Rx.scala
+++ b/airframe-rx/src/main/scala/wvlet/airframe/rx/Rx.scala
@@ -196,6 +196,11 @@ trait RxStream[+A] extends Rx[A] with LogSupport {
 trait RxStreamCache[A] extends RxStream[A] {
 
   /**
+    * Get the current cached value if exists
+    */
+  def getCurrent: Option[A]
+
+  /**
     * Discard the cached value after the given duration.
     */
   def expireAfterWrite(time: Long, unit: TimeUnit): RxStreamCache[A]
@@ -350,6 +355,7 @@ object Rx extends LogSupport {
       ticker: Ticker = Ticker.systemTicker
   ) extends UnaryRx[A, A]
       with RxStreamCache[A] {
+    override def getCurrent: Option[A] = lastValue
     override def expireAfterWrite(time: Long, unit: TimeUnit): RxStreamCache[A] = {
       this.copy(expirationAfterWriteNanos = Some(unit.toNanos(time)))
     }

--- a/airframe-rx/src/main/scala/wvlet/airframe/rx/RxOption.scala
+++ b/airframe-rx/src/main/scala/wvlet/airframe/rx/RxOption.scala
@@ -107,6 +107,7 @@ trait RxOption[+A] extends Rx[Option[A]] {
   * @tparam A
   */
 trait RxOptionCache[A] extends RxOption[A] {
+  def getCurrent: Option[A]
   def expireAfterWrite(time: Long, unit: TimeUnit): RxOptionCache[A]
   def withTicker(ticker: Ticker): RxOptionCache[A]
 }
@@ -141,6 +142,7 @@ class RxOptionVar[A](variable: RxVar[Option[A]]) extends RxOption[A] with RxVarO
 }
 
 case class RxOptionCacheOp[A](input: RxStreamCache[Option[A]]) extends RxOptionCache[A] {
+  override def getCurrent: Option[A]             = input.getCurrent.flatten
   override protected def in: RxStream[Option[A]] = input.toRxStream
   override def parents: Seq[Rx[_]]               = input.parents
 


### PR DESCRIPTION
I've found it's necessary to implement components that have some public methods referencing Rx data:

```scala
class Selector extends RxElement { 
   private val list = getList.map(x => ...).cache 

   def selected = list.getCurrent.map(lst => lst(selectedIndex))
}
```