### PR TITLE
airframe-ulid: Performance optimization

### DIFF
--- a/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/ulid/ULIDBenchmark.scala
+++ b/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/ulid/ULIDBenchmark.scala
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.benchmark.ulid
+
+import org.openjdk.jmh.annotations.{Benchmark, BenchmarkMode, Group, Mode, OutputTimeUnit, Scope, State}
+import org.openjdk.jmh.infra.Blackhole
+import wvlet.airframe.ulid.{ULID => AirframeULID}
+import com.chatwork.scala.ulid.{ULID => ChatworkULID}
+import java.util.concurrent.TimeUnit
+
+abstract class ULIDBenchmark {
+
+  protected def newULID: String
+
+  @Benchmark
+  @Group("generate")
+  def generate(blackhole: Blackhole): Unit = {
+    blackhole.consume(newULID)
+  }
+
+}
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class Airframe extends ULIDBenchmark {
+  override protected def newULID: String = {
+    AirframeULID.newULID.toString
+  }
+}
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class Chatwork extends ULIDBenchmark {
+  override protected def newULID: String = {
+    ChatworkULID.generate().asString
+  }
+}

--- a/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/ulid/ULIDBenchmark.scala
+++ b/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/ulid/ULIDBenchmark.scala
@@ -20,22 +20,20 @@ import com.chatwork.scala.ulid.{ULID => ChatworkULID}
 import java.util.concurrent.TimeUnit
 
 abstract class ULIDBenchmark {
-
-  protected def newULID: String
+  protected def newULIDString: String
 
   @Benchmark
-  @Group("generate")
+  @Group("ulid_string")
   def generate(blackhole: Blackhole): Unit = {
-    blackhole.consume(newULID)
+    blackhole.consume(newULIDString)
   }
-
 }
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
 class Airframe extends ULIDBenchmark {
-  override protected def newULID: String = {
+  override protected def newULIDString: String = {
     AirframeULID.newULID.toString
   }
 }
@@ -44,7 +42,7 @@ class Airframe extends ULIDBenchmark {
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
 class Chatwork extends ULIDBenchmark {
-  override protected def newULID: String = {
+  override protected def newULIDString: String = {
     ChatworkULID.generate().asString
   }
 }

--- a/airframe-benchmark/src/test/scala/wvlet/airframe/benchmark/BenchmarkMainTest.scala
+++ b/airframe-benchmark/src/test/scala/wvlet/airframe/benchmark/BenchmarkMainTest.scala
@@ -45,9 +45,17 @@ class BenchmarkMainTest extends AirSpec {
 
   def `run json perf benchmark`: Unit = {
     BenchmarkMain.main(s"json-perf -n ${iteration} -b ${iteration}")
+    warn(s"This is a test run result, and it may not reflect the actual performance")
   }
 
   def `run http benchmark`: Unit = {
     BenchmarkMain.main("bench-quick -F 0 -mt 1s http")
+    warn(s"This is a test run result, and it may not reflect the actual performance")
   }
+
+  def `run ulid benchmark`: Unit = {
+    BenchmarkMain.main("bench-quick -F 0 ulid")
+    warn(s"This is a test run result, and it may not reflect the actual performance")
+  }
+
 }

--- a/airframe-ulid/.js/src/main/scala/wvlet/airframe/ulid/compat.scala
+++ b/airframe-ulid/.js/src/main/scala/wvlet/airframe/ulid/compat.scala
@@ -19,4 +19,8 @@ import scala.util.Random
   */
 object compat {
   val random: Random = scala.util.Random
+
+  def sleep(millis: Int): Unit = {
+    // no-op as Scala.js has no sleep
+  }
 }

--- a/airframe-ulid/.js/src/main/scala/wvlet/airframe/ulid/compat.scala
+++ b/airframe-ulid/.js/src/main/scala/wvlet/airframe/ulid/compat.scala
@@ -13,19 +13,10 @@
  */
 package wvlet.airframe.ulid
 
-import wvlet.airspec.AirSpec
-import wvlet.airspec.spi.PropertyCheck
+import scala.util.Random
 
 /**
   */
-class CrockfordBase32Test extends AirSpec with PropertyCheck {
-  test("Encode long pairs") {
-    forAll { (hi: Long, low: Long) =>
-      val encoded       = CrockfordBase32.encode128bits(hi, low)
-      val (hi_d, low_d) = CrockfordBase32.decode128bits(encoded)
-      info(s"${hi}, ${low}, ${encoded}, ${hi_d}, ${low_d}")
-      (hi, low) shouldBe (hi_d, low_d)
-    }
-  }
-
+object compat {
+  val random: Random = scala.util.Random
 }

--- a/airframe-ulid/.jvm/src/main/scala/wvlet/airframe/ulid/compat.scala
+++ b/airframe-ulid/.jvm/src/main/scala/wvlet/airframe/ulid/compat.scala
@@ -27,4 +27,8 @@ object compat {
         Random
     }
   }
+
+  def sleep(millis: Int): Unit = {
+    Thread.sleep(millis)
+  }
 }

--- a/airframe-ulid/.jvm/src/main/scala/wvlet/airframe/ulid/compat.scala
+++ b/airframe-ulid/.jvm/src/main/scala/wvlet/airframe/ulid/compat.scala
@@ -13,19 +13,18 @@
  */
 package wvlet.airframe.ulid
 
-import wvlet.airspec.AirSpec
-import wvlet.airspec.spi.PropertyCheck
+import java.security.{NoSuchAlgorithmException, SecureRandom}
+import scala.util.Random
 
 /**
   */
-class CrockfordBase32Test extends AirSpec with PropertyCheck {
-  test("Encode long pairs") {
-    forAll { (hi: Long, low: Long) =>
-      val encoded       = CrockfordBase32.encode128bits(hi, low)
-      val (hi_d, low_d) = CrockfordBase32.decode128bits(encoded)
-      info(s"${hi}, ${low}, ${encoded}, ${hi_d}, ${low_d}")
-      (hi, low) shouldBe (hi_d, low_d)
+object compat {
+  val random: Random = {
+    try {
+      SecureRandom.getInstanceStrong
+    } catch {
+      case _: NoSuchAlgorithmException =>
+        Random
     }
   }
-
 }

--- a/airframe-ulid/.jvm/src/test/scala/wvlet/airframe/ulid/ULIDCalendarTest.scala
+++ b/airframe-ulid/.jvm/src/test/scala/wvlet/airframe/ulid/ULIDCalendarTest.scala
@@ -22,7 +22,7 @@ import wvlet.airspec.spi.PropertyCheck
 /**
   */
 class ULIDCalendarTest extends AirSpec with PropertyCheck {
-  private def ulid(timestamp: => Long, random: => Double) = {
+  private def ulid(timestamp: => Long, random: => Int) = {
     new ULIDGenerator(() => timestamp, () => random)
   }
 
@@ -33,7 +33,7 @@ class ULIDCalendarTest extends AirSpec with PropertyCheck {
         cal.getTimeInMillis > ULID.MinTime
         && cal.getTimeInMillis < ULID.MaxTime
       ) {
-        val u = ULID(ulid(cal.getTimeInMillis, 0.0d).generate)
+        val u = ULID(ulid(cal.getTimeInMillis, 0).generate)
         u.epochMillis shouldBe cal.getTimeInMillis
       }
     }

--- a/airframe-ulid/.jvm/src/test/scala/wvlet/airframe/ulid/ULIDCalendarTest.scala
+++ b/airframe-ulid/.jvm/src/test/scala/wvlet/airframe/ulid/ULIDCalendarTest.scala
@@ -22,20 +22,20 @@ import wvlet.airspec.spi.PropertyCheck
 /**
   */
 class ULIDCalendarTest extends AirSpec with PropertyCheck {
-  private def ulid(timestamp: => Long, random: => Int) = {
+  private def ulid(timestamp: => Long, random: => Array[Byte]) = {
     new ULIDGenerator(() => timestamp, () => random)
   }
 
-  test("timestamp valid") {
-    import org.scalacheck.Gen
-    forAll(Gen.calendar) { cal: Calendar =>
-      if (
-        cal.getTimeInMillis > ULID.MinTime
-        && cal.getTimeInMillis < ULID.MaxTime
-      ) {
-        val u = ULID(ulid(cal.getTimeInMillis, 0).generate)
-        u.epochMillis shouldBe cal.getTimeInMillis
-      }
-    }
-  }
+//  test("timestamp valid") {
+//    import org.scalacheck.Gen
+//    forAll(Gen.calendar) { cal: Calendar =>
+//      if (
+//        cal.getTimeInMillis > ULID.MinTime
+//        && cal.getTimeInMillis < ULID.MaxTime
+//      ) {
+//        val u = ULID(ulid(cal.getTimeInMillis, 0).generate)
+//        u.epochMillis shouldBe cal.getTimeInMillis
+//      }
+//    }
+//  }
 }

--- a/airframe-ulid/.jvm/src/test/scala/wvlet/airframe/ulid/ULIDCalendarTest.scala
+++ b/airframe-ulid/.jvm/src/test/scala/wvlet/airframe/ulid/ULIDCalendarTest.scala
@@ -30,11 +30,11 @@ class ULIDCalendarTest extends AirSpec with PropertyCheck {
     import org.scalacheck.Gen
     forAll(Gen.calendar) { cal: Calendar =>
       if (
-        cal.getTimeInMillis > ULID.MIN_TIME
-        && cal.getTimeInMillis < ULID.MAX_TIME
+        cal.getTimeInMillis > ULID.MinTime
+        && cal.getTimeInMillis < ULID.MaxTime
       ) {
-        val result = ULID.extractEpochMillis(ulid(cal.getTimeInMillis, 0.0d).generate)
-        result.get shouldBe cal.getTimeInMillis
+        val u = ULID(ulid(cal.getTimeInMillis, 0.0d).generate)
+        u.epochMillis shouldBe cal.getTimeInMillis
       }
     }
   }

--- a/airframe-ulid/.jvm/src/test/scala/wvlet/airframe/ulid/ULIDCalendarTest.scala
+++ b/airframe-ulid/.jvm/src/test/scala/wvlet/airframe/ulid/ULIDCalendarTest.scala
@@ -13,6 +13,8 @@
  */
 package wvlet.airframe.ulid
 
+import wvlet.airframe.ulid.ULID.ULIDGenerator
+
 import java.util.Calendar
 import wvlet.airspec.AirSpec
 import wvlet.airspec.spi.PropertyCheck
@@ -28,8 +30,8 @@ class ULIDCalendarTest extends AirSpec with PropertyCheck {
     import org.scalacheck.Gen
     forAll(Gen.calendar) { cal: Calendar =>
       if (
-        cal.getTimeInMillis > ULID.constants.MIN_TIME
-        && cal.getTimeInMillis < ULID.constants.MAX_TIME
+        cal.getTimeInMillis > ULID.MIN_TIME
+        && cal.getTimeInMillis < ULID.MAX_TIME
       ) {
         val result = ULID.extractEpochMillis(ulid(cal.getTimeInMillis, 0.0d).generate)
         result.get shouldBe cal.getTimeInMillis

--- a/airframe-ulid/.jvm/src/test/scala/wvlet/airframe/ulid/ULIDCalendarTest.scala
+++ b/airframe-ulid/.jvm/src/test/scala/wvlet/airframe/ulid/ULIDCalendarTest.scala
@@ -13,29 +13,25 @@
  */
 package wvlet.airframe.ulid
 
-import wvlet.airframe.ulid.ULID.ULIDGenerator
-
-import java.util.Calendar
 import wvlet.airspec.AirSpec
 import wvlet.airspec.spi.PropertyCheck
+
+import java.util.Calendar
+import scala.util.Random
 
 /**
   */
 class ULIDCalendarTest extends AirSpec with PropertyCheck {
-  private def ulid(timestamp: => Long, random: => Array[Byte]) = {
-    new ULIDGenerator(() => timestamp, () => random)
+  test("timestamp valid") {
+    import org.scalacheck.Gen
+    forAll(Gen.calendar) { cal: Calendar =>
+      if (
+        cal.getTimeInMillis > ULID.MinTime
+        && cal.getTimeInMillis < ULID.MaxTime
+      ) {
+        val u = ULID.of(cal.getTimeInMillis, Random.nextLong(), Random.nextLong())
+        u.epochMillis shouldBe cal.getTimeInMillis
+      }
+    }
   }
-
-//  test("timestamp valid") {
-//    import org.scalacheck.Gen
-//    forAll(Gen.calendar) { cal: Calendar =>
-//      if (
-//        cal.getTimeInMillis > ULID.MinTime
-//        && cal.getTimeInMillis < ULID.MaxTime
-//      ) {
-//        val u = ULID(ulid(cal.getTimeInMillis, 0).generate)
-//        u.epochMillis shouldBe cal.getTimeInMillis
-//      }
-//    }
-//  }
 }

--- a/airframe-ulid/src/main/scala/wvlet/airframe/ulid/CrockfordBase32.scala
+++ b/airframe-ulid/src/main/scala/wvlet/airframe/ulid/CrockfordBase32.scala
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.ulid
+
+/**
+  */
+object CrockfordBase32 {
+  private val ENCODING_CHARS: Array[Char] = Array(
+    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'J', 'K', 'M', 'N', 'P',
+    'Q', 'R', 'S', 'T', 'V', 'W', 'X', 'Y', 'Z'
+  )
+
+  private val DECODING_CHARS: Array[Byte] = Array[Byte](
+    -1, -1, -1, -1, -1, -1, -1, -1, // 0
+    -1, -1, -1, -1, -1, -1, -1, -1, // 8
+    -1, -1, -1, -1, -1, -1, -1, -1, // 16
+    -1, -1, -1, -1, -1, -1, -1, -1, // 24
+    -1, -1, -1, -1, -1, -1, -1, -1, // 32
+    -1, -1, -1, -1, -1, -1, -1, -1, // 40
+    0, 1, 2, 3, 4, 5, 6, 7,         // 48
+    8, 9, -1, -1, -1, -1, -1, -1,   // 56
+    -1, 10, 11, 12, 13, 14, 15, 16, // 64
+    17, 1, 18, 19, 1, 20, 21, 0,    // 72
+    22, 23, 24, 25, 26, -1, 27, 28, // 80
+    29, 30, 31, -1, -1, -1, -1, -1, // 88
+    -1, 10, 11, 12, 13, 14, 15, 16, // 96
+    17, 1, 18, 19, 1, 20, 21, 0,    // 104
+    22, 23, 24, 25, 26, -1, 27, 28, // 112
+    29, 30, 31                      // 120
+  )
+
+  def decode(ch: Char): Byte = DECODING_CHARS(ch)
+  def encode(i: Int): Char   = ENCODING_CHARS(i)
+  def indexOf(ch: Char): Int = ENCODING_CHARS.indexOf(ch)
+}

--- a/airframe-ulid/src/main/scala/wvlet/airframe/ulid/CrockfordBase32.scala
+++ b/airframe-ulid/src/main/scala/wvlet/airframe/ulid/CrockfordBase32.scala
@@ -14,6 +14,7 @@
 package wvlet.airframe.ulid
 
 /**
+  * Base 32 encoding by Douglas Crockford: https://www.crockford.com/base32.html
   */
 object CrockfordBase32 {
   private val ENCODING_CHARS: Array[Char] = Array(
@@ -42,13 +43,18 @@ object CrockfordBase32 {
 
   @inline def decode(ch: Char): Byte = DECODING_CHARS(ch & 0x7f)
   @inline def encode(i: Int): Char   = ENCODING_CHARS(i & 0x1f)
-  def indexOf(ch: Char): Int         = ENCODING_CHARS.indexOf(ch)
 
+  /**
+    * Decode a string representation of 128 bit value (26 characters) as a pair of
+    * (Long, Long) (128 bits)
+    *
+    * Note that technically 26 characters x 5 bite can represent 130-bit values.
+    * This method will discard the top 2 bits from the string as ULID only uses 128 bits.
+    */
   def decode128bits(s: String): (Long, Long) = {
 
     /**
       * |      hi (64-bits)     |    low (64-bits)    |
-      * |--|                  |----|                  |
       */
     val len = s.length
     if (len != 26) {
@@ -70,6 +76,9 @@ object CrockfordBase32 {
     (hi, low)
   }
 
+  /**
+    * Encode 128-bit values (Long, Long) with Crockford Base32
+    */
   def encode128bits(hi: Long, low: Long): String = {
     val s = new StringBuilder(26)
     var i = 0
@@ -87,6 +96,10 @@ object CrockfordBase32 {
     s.reverseContents().toString()
   }
 
+  /**
+    * Decode 10-character Crockford Base32 as a 48-bit unsigned value.
+    * This is used for decoding ULID timestamp (48-bit value)
+    */
   def decode48bits(s: String): Long = {
     val len = s.length
     if (len != 10) {
@@ -100,5 +113,9 @@ object CrockfordBase32 {
       i += 1
     }
     l
+  }
+
+  def isValidBase32(s: String): Boolean = {
+    s.forall { decode(_) != -1 }
   }
 }

--- a/airframe-ulid/src/main/scala/wvlet/airframe/ulid/CrockfordBase32.scala
+++ b/airframe-ulid/src/main/scala/wvlet/airframe/ulid/CrockfordBase32.scala
@@ -75,6 +75,7 @@ object CrockfordBase32 {
     var i = 0
     var h = hi
     var l = low
+    // encode from lower 5-bit
     while (i < 26) {
       s += encode((l & 0x1fL).toInt)
       val carry = (h & 0x1fL) << (64 - 5)
@@ -86,46 +87,18 @@ object CrockfordBase32 {
     s.reverseContents().toString()
   }
 
-  def encodeLong(l: Long, len: Int): String = {
-    val max = if (len > 12) Long.MaxValue else 1L << (len * 5)
-    if (l > max) {
-      throw new IllegalArgumentException(f"Cannot encode ${l}%,d with ${len} characters.")
-    }
-    val s      = new StringBuilder
-    var cursor = len
-    while (cursor > 12) {
-      s += encode(0)
-      cursor -= 1
-    }
-    while (cursor >= 0) {
-      val mask = 0x1fL << (cursor * 5)
-      val v    = (l & mask) >>> (cursor * 5)
-      s += encode(v.toInt)
-      cursor -= 1
-    }
-    s.result()
-  }
-
-  def decodeAsLong(s: String): Long = {
+  def decode48bits(s: String): Long = {
     val len = s.length
-    if (len > 13) {
-
-      throw new IllegalArgumentException(
-        s"Cannot decode Base32 string longer than 12 characters with 64-bit Long: ${s}"
-      )
+    if (len != 10) {
+      throw new IllegalArgumentException(s"String size must be 10: ${s} (length:${len})")
     }
-
-    if (len == 0) {
-      0L
-    } else {
-      var l: Long = decode(s.charAt(0))
-      var i       = 1
-      while (i < len) {
-        l <<= 5
-        l |= decode(s.charAt(i))
-        i += 1
-      }
-      l
+    var l: Long = decode(s.charAt(0))
+    var i       = 1
+    while (i < len) {
+      l <<= 5
+      l |= decode(s.charAt(i))
+      i += 1
     }
+    l
   }
 }

--- a/airframe-ulid/src/main/scala/wvlet/airframe/ulid/CrockfordBase32.scala
+++ b/airframe-ulid/src/main/scala/wvlet/airframe/ulid/CrockfordBase32.scala
@@ -40,7 +40,26 @@ object CrockfordBase32 {
     29, 30, 31                      // 120
   )
 
-  def decode(ch: Char): Byte = DECODING_CHARS(ch)
-  def encode(i: Int): Char   = ENCODING_CHARS(i)
-  def indexOf(ch: Char): Int = ENCODING_CHARS.indexOf(ch)
+  @inline def decode(ch: Char): Byte = DECODING_CHARS(ch & 0x7f)
+  def encode(i: Int): Char           = ENCODING_CHARS(i)
+  def indexOf(ch: Char): Int         = ENCODING_CHARS.indexOf(ch)
+
+  def decodeAsLong(s: String): Long = {
+    val len = s.length
+    if (len > 12) {
+      throw new IllegalArgumentException(s"Cannot decode String longer than 12 characters as Long: ${s}")
+    }
+    if (len == 0) {
+      0L
+    } else {
+      var l: Long = decode(s.charAt(0))
+      var i       = 1
+      while (i < len) {
+        l <<= 5
+        l |= decode(s.charAt(i))
+        i += 1
+      }
+      l
+    }
+  }
 }

--- a/airframe-ulid/src/main/scala/wvlet/airframe/ulid/ULID.scala
+++ b/airframe-ulid/src/main/scala/wvlet/airframe/ulid/ULID.scala
@@ -18,7 +18,6 @@ import java.util.concurrent.atomic.AtomicLong
 
 /**
   * ULID string, consisting of 26 characters.
-  * @param ulid
   */
 final case class ULID(private val ulid: String) extends Ordered[ULID] {
 
@@ -101,6 +100,9 @@ object ULID {
     * @return
     */
   def of(unixTimeMillis: Long, randHi: Long, randLow: Long): ULID = {
+    if (unixTimeMillis < 0L || unixTimeMillis > MaxTime) {
+      throw new IllegalArgumentException(f"unixtime must be between 0 to ${MaxTime}%,d: ${unixTimeMillis}%,d")
+    }
     val hi: Long  = (unixTimeMillis << (64 - 48)) | (randHi & 0xffff)
     val low: Long = randLow
     new ULID(CrockfordBase32.encode128bits(hi, low))
@@ -162,7 +164,7 @@ object ULID {
     private val lastLow = new AtomicLong(0L)
 
     private def currentTimeInMillis: Long = {
-      // Avoid unexpected rollback of the sytem clock
+      // Avoid unexpected rollback of the system clock
       baseSystemTimeMillis + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - baseNanoTime)
     }
 

--- a/airframe-ulid/src/main/scala/wvlet/airframe/ulid/ULID.scala
+++ b/airframe-ulid/src/main/scala/wvlet/airframe/ulid/ULID.scala
@@ -12,6 +12,7 @@
  * limitations under the License.
  */
 package wvlet.airframe.ulid
+import java.time.Instant
 import scala.util.Random
 
 final case class ULID(private val ulid: String) {
@@ -25,6 +26,10 @@ final case class ULID(private val ulid: String) {
     ULID.extractEpochMillis(ulid).getOrElse {
       throw new IllegalArgumentException(s"Invalid ULID")
     }
+  }
+
+  def toInstant: Instant = {
+    Instant.ofEpochMilli(epochMillis)
   }
 }
 

--- a/airframe-ulid/src/main/scala/wvlet/airframe/ulid/ULID.scala
+++ b/airframe-ulid/src/main/scala/wvlet/airframe/ulid/ULID.scala
@@ -45,10 +45,10 @@ final case class ULID(private val ulid: String) extends Ordered[ULID] {
     val (hi, low) = CrockfordBase32.decode128bits(ulid)
     val b         = new Array[Byte](16)
     for (i <- 0 until 8) {
-      b(i) = ((hi >>> (64 - i * 8)) & 0xffL).toByte
+      b(i) = ((hi >>> (64 - (i + 1) * 8)) & 0xffL).toByte
     }
     for (i <- 0 until 8) {
-      b(i + 8) = ((low >>> (64 - i * 8)) & 0xffL).toByte
+      b(i + 8) = ((low >>> (64 - (i + 1) * 8)) & 0xffL).toByte
     }
     b
   }

--- a/airframe-ulid/src/main/scala/wvlet/airframe/ulid/ULID.scala
+++ b/airframe-ulid/src/main/scala/wvlet/airframe/ulid/ULID.scala
@@ -57,8 +57,8 @@ object ULID {
     * @return
     */
   def isValid(ulid: String): Boolean = {
-    if (ulid.length != constants.ULID_LENGTH) false
-    else ulid.forall { constants.DECODING_CHARS(_) != -1 }
+    if (ulid.length != ULID_LENGTH) false
+    else ulid.forall { CrockfordBase32.decode(_) != -1 }
   }
 
   /**
@@ -69,97 +69,70 @@ object ULID {
   def extractEpochMillis(ulid: String): Option[Long] = {
     if (isValid(ulid)) {
       val result = ulid.take(10).reverse.zipWithIndex.foldLeft(0L) { case (acc, (c, index)) =>
-        val idx = constants.ENCODING_CHARS.indexOf(c)
-        acc + (idx * Math.pow(constants.ENCODING_LENGTH, index)).toLong
+        val idx = CrockfordBase32.indexOf(c)
+        acc + (idx * Math.pow(ENCODING_LENGTH, index)).toLong
       }
       Option(result)
     } else None
   }
 
-  private[ulid] object constants {
-    val ENCODING_CHARS: Array[Char] = Array(
-      '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'J', 'K', 'M', 'N', 'P',
-      'Q', 'R', 'S', 'T', 'V', 'W', 'X', 'Y', 'Z'
-    )
+  private val ENCODING_LENGTH = 32
 
-    val DECODING_CHARS: Array[Byte] = Array[Byte](
-      -1, -1, -1, -1, -1, -1, -1, -1, // 0
-      -1, -1, -1, -1, -1, -1, -1, -1, // 8
-      -1, -1, -1, -1, -1, -1, -1, -1, // 16
-      -1, -1, -1, -1, -1, -1, -1, -1, // 24
-      -1, -1, -1, -1, -1, -1, -1, -1, // 32
-      -1, -1, -1, -1, -1, -1, -1, -1, // 40
-      0, 1, 2, 3, 4, 5, 6, 7,         // 48
-      8, 9, -1, -1, -1, -1, -1, -1,   // 56
-      -1, 10, 11, 12, 13, 14, 15, 16, // 64
-      17, 1, 18, 19, 1, 20, 21, 0,    // 72
-      22, 23, 24, 25, 26, -1, 27, 28, // 80
-      29, 30, 31, -1, -1, -1, -1, -1, // 88
-      -1, 10, 11, 12, 13, 14, 15, 16, // 96
-      17, 1, 18, 19, 1, 20, 21, 0,    // 104
-      22, 23, 24, 25, 26, -1, 27, 28, // 112
-      29, 30, 31                      // 120
-    )
+  private val TIMESTAMP_LENGTH       = 10
+  private val RANDOM_LENGTH          = 16
+  private[ulid] val ULID_LENGTH: Int = TIMESTAMP_LENGTH + RANDOM_LENGTH
 
-    val ENCODING_LENGTH = 32
-
-    val TIMESTAMP_LENGTH = 10
-    val RANDOM_LENGTH    = 16
-    val ULID_LENGTH: Int = TIMESTAMP_LENGTH + RANDOM_LENGTH
-
-    val MIN_TIME = 0x0L
-    val MAX_TIME = 0x0000ffffffffffffL
-
-  }
-}
-
-/**
-  * ULID generator
-  * @param timeSource a function returns the current time in milliseconds (e.g. java.lang.System.currentTimeMillis())
-  * @param random a function returns a random value (e.g. scala.util.Random.nextDouble())
-  */
-private[ulid] class ULIDGenerator(timeSource: () => Long, random: () => Double) {
-  import ULID.constants._
+  private[ulid] val MIN_TIME = 0x0L
+  private[ulid] val MAX_TIME = 0x0000ffffffffffffL
 
   /**
-    * generate ULID string
-    * @return
+    * ULID generator
+    * @param timeSource a function returns the current time in milliseconds (e.g. java.lang.System.currentTimeMillis())
+    * @param random a function returns a random value (e.g. scala.util.Random.nextDouble())
     */
-  def generate: String = encodeTime() + encodeRandom()
+  private[ulid] class ULIDGenerator(timeSource: () => Long, random: () => Double) {
 
-  private def encodeTime(): String = {
-    @annotation.tailrec
-    def run(time: Long, out: String = "", count: Int = 0): String = {
-      count match {
-        case TIMESTAMP_LENGTH => out
-        case _ =>
-          val mod = (time % ENCODING_LENGTH).toInt
-          run((time - mod) / ENCODING_LENGTH, s"${ENCODING_CHARS(mod)}${out}", count + 1)
+    /**
+      * generate ULID string
+      * @return
+      */
+    def generate: String = encodeTime() + encodeRandom()
+
+    private def encodeTime(): String = {
+      @annotation.tailrec
+      def run(time: Long, out: String = "", count: Int = 0): String = {
+        count match {
+          case TIMESTAMP_LENGTH => out
+          case _ =>
+            val mod = (time % ENCODING_LENGTH).toInt
+            run((time - mod) / ENCODING_LENGTH, s"${CrockfordBase32.encode(mod)}${out}", count + 1)
+        }
+      }
+
+      timeSource() match {
+        case time if (time < MIN_TIME) || (MAX_TIME < time) =>
+          throw new IllegalArgumentException(s"cannot generate ULID string. Time($time) is invalid");
+        case time =>
+          run(time)
       }
     }
 
-    timeSource() match {
-      case time if (time < MIN_TIME) || (MAX_TIME < time) =>
-        throw new IllegalArgumentException(s"cannot generate ULID string. Time($time) is invalid");
-      case time =>
-        run(time)
+    private def encodeRandom(): String = {
+      @annotation.tailrec
+      def run(out: String = "", count: Int = 0): String = {
+        count match {
+          case RANDOM_LENGTH => out
+          case _ =>
+            val rand = random()
+            if (rand < 0.0d || 1.0d < rand) {
+              throw new IllegalArgumentException(s"random must not under 0.0 or over 1.0. random value = $rand")
+            }
+            val index = Math.floor((ENCODING_LENGTH - 1) * rand).toInt
+            run(s"${CrockfordBase32.encode(index)}${out}", count + 1)
+        }
+      }
+      run()
     }
   }
 
-  private def encodeRandom(): String = {
-    @annotation.tailrec
-    def run(out: String = "", count: Int = 0): String = {
-      count match {
-        case RANDOM_LENGTH => out
-        case _ =>
-          val rand = random()
-          if (rand < 0.0d || 1.0d < rand) {
-            throw new IllegalArgumentException(s"random must not under 0.0 or over 1.0. random value = $rand")
-          }
-          val index = Math.floor((ENCODING_LENGTH - 1) * rand).toInt
-          run(s"${ENCODING_CHARS(index)}${out}", count + 1)
-      }
-    }
-    run()
-  }
 }

--- a/airframe-ulid/src/main/scala/wvlet/airframe/ulid/ULID.scala
+++ b/airframe-ulid/src/main/scala/wvlet/airframe/ulid/ULID.scala
@@ -16,6 +16,7 @@ import java.time.Instant
 import scala.util.Random
 
 final case class ULID(private val ulid: String) extends Ordered[ULID] {
+
   /**
     * Return the string representation of this ULID
     * @return
@@ -40,19 +41,21 @@ final case class ULID(private val ulid: String) extends Ordered[ULID] {
 
 /**
   * ULID generator implementation based on https://github.com/petitviolet/ulid4s
+  *
+  * ULID has 128 bit value:
+  * |-- Unix timestamp milliseconds (48-bit) ---- | -----  random value (80 bits) ------ |
+  *
+  * The string representation of ULID uses 26 characters in Crockford Base 32 representation,
+  * each character of which represents 5-bit value (0-31).
   */
 object ULID {
   val MaxValue: ULID        = ULID("7ZZZZZZZZZZZZZZZZZZZZZZZZZ")
   private[ulid] val MinTime = 0L
-  private[ulid] val MaxTime = ((~0L) >>> (64 - 48)) // Timestamp uses 48-bit range
-
-  private val ENCODING_LENGTH  = 32
-  private val TIMESTAMP_LENGTH = 10
-  private val RANDOM_LENGTH    = 16
+  private[ulid] val MaxTime = (~0L) >>> (64 - 48) // Timestamp uses 48-bit range
 
   private val defaultGenerator = {
     val timeSource = () => System.currentTimeMillis()
-    val randGen = { () => Random }
+    val randGen = { () => Random.nextInt() }
     new ULIDGenerator(timeSource, randGen)
   }
 
@@ -60,10 +63,35 @@ object ULID {
   def newULIDString: String = defaultGenerator.generate
 
   def apply(ulidString: String): ULID = fromString(ulidString)
-  def fromString(ulid: String): ULID  = {
+  def fromString(ulid: String): ULID = {
     require(ulid.length == 26, s"ULID must have 26 characters: ${ulid} (length: ${ulid.length})")
     require(CrockfordBase32.isValidBase32(ulid), s"Invalid Base32 character is found in ${ulid}")
     new ULID(ulid)
+  }
+  def fromBytes(bytes: Array[Byte], offset: Int): ULID = {
+    require(offset + 16 < bytes.length, s"ULID needs 16 bytes: ${offset + 16}")
+    var i  = 0
+    var hi = 0L
+    while (i < 8) {
+      hi <<= 8
+      hi |= bytes(offset + i) & 0xffL
+      i += 1
+    }
+    var low = 0L
+    while (i < 16) {
+      low <<= 8
+      low |= bytes(offset + i) & 0xffL
+      i += 1
+    }
+    new ULID(CrockfordBase32.encode128bits(hi, low))
+  }
+
+  def unapply(ulidString: String): Option[ULID] = {
+    if (isValid(ulidString)) {
+      Some(new ULID(ulidString))
+    } else {
+      None
+    }
   }
 
   /**
@@ -75,11 +103,10 @@ object ULID {
     ulid.length == 26 && CrockfordBase32.isValidBase32(ulid)
   }
 
-  def from(unixTimeMillis:Long, randHi: Long, randLow: Long): String = {
-    val hi: Long = (unixTimeMillis << (64 - 48)) |
-            (randHi >>> (64 - 16) & 0xFFFFL)
-
-    val low: Long = (randHi << 16) | (randLow <<
+  private def generateFrom(unixTimeMillis: Long, rand1: Int, rand2: Int, rand3: Int): String = {
+    // We need a 80-bit random value. Use 32-bit * 3 = 96 bits
+    val hi: Long  = (unixTimeMillis << (64 - 48)) | (rand1 & 0xffffL)
+    val low: Long = (rand2.toLong << 32) | (rand3 & 0xffffffffL)
 
     CrockfordBase32.encode128bits(hi, low)
   }
@@ -89,7 +116,7 @@ object ULID {
     * @param timeSource a function returns the current time in milliseconds (e.g. java.lang.System.currentTimeMillis())
     * @param random a function returns a random value (e.g. scala.util.Random.nextDouble())
     */
-  private[ulid] class ULIDGenerator(timeSource: () => Long, random: () => Random) {
+  private[ulid] class ULIDGenerator(timeSource: () => Long, random: () => Int) {
 
     /**
       * generate ULID string
@@ -97,22 +124,10 @@ object ULID {
       */
     def generate: String = {
       val unixTimeMillis: Long = timeSource()
-      // 80-bits
-      val rand = new Array[Byte](10)
-      random().nextBytes(rand)
-      val hi: Long = (unixTimeMillis << (64 - 48)) |
-        (rand(0) & 0xffL) << 8 |
-        (rand(1) & 0xffL)
-      val low: Long = ((rand(2) & 0xffL) << 56) |
-        ((rand(3) & 0xffL) << 48) |
-        ((rand(4) & 0xffL) << 40) |
-        ((rand(5) & 0xffL) << 32) |
-        ((rand(6) & 0xffL) << 24) |
-        ((rand(7) & 0xffL) << 16) |
-        ((rand(8) & 0xffL) << 8) |
-        (rand(9) & 0xffL)
-
-      CrockfordBase32.encode128bits(hi, low)
+      val r1                   = random()
+      val r2                   = random()
+      val r3                   = random()
+      generateFrom(unixTimeMillis, r1, r2, r3)
     }
   }
 

--- a/airframe-ulid/src/test/scala/wvlet/airframe/ulid/CrockfordBase32Test.scala
+++ b/airframe-ulid/src/test/scala/wvlet/airframe/ulid/CrockfordBase32Test.scala
@@ -23,8 +23,6 @@ class CrockfordBase32Test extends AirSpec with PropertyCheck {
     forAll { (hi: Long, low: Long) =>
       val encoded       = CrockfordBase32.encode128bits(hi, low)
       val (hi_d, low_d) = CrockfordBase32.decode128bits(encoded)
-
-      info(s"${hi}, ${low}, ${encoded}, ${hi_d}, ${low_d}")
       (hi, low) shouldBe (hi_d, low_d)
     }
   }

--- a/airframe-ulid/src/test/scala/wvlet/airframe/ulid/CrockfordBase32Test.scala
+++ b/airframe-ulid/src/test/scala/wvlet/airframe/ulid/CrockfordBase32Test.scala
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.ulid
+
+import wvlet.airspec.AirSpec
+import wvlet.airspec.spi.PropertyCheck
+
+/**
+  */
+class CrockfordBase32Test extends AirSpec with PropertyCheck {
+  test("Encode long") {
+    forAll { (hi: Long, low: Long) =>
+      val encoded       = CrockfordBase32.encode128bits(hi, low)
+      val (hi_d, low_d) = CrockfordBase32.decode128bits(encoded)
+
+      info(s"${hi}, ${low}, ${encoded}, ${hi_d}, ${low_d}")
+      (hi, low) shouldBe (hi_d, low_d)
+    }
+  }
+
+}

--- a/airframe-ulid/src/test/scala/wvlet/airframe/ulid/CrockfordBase32Test.scala
+++ b/airframe-ulid/src/test/scala/wvlet/airframe/ulid/CrockfordBase32Test.scala
@@ -19,7 +19,7 @@ import wvlet.airspec.spi.PropertyCheck
 /**
   */
 class CrockfordBase32Test extends AirSpec with PropertyCheck {
-  test("Encode long") {
+  test("Encode long pairs") {
     forAll { (hi: Long, low: Long) =>
       val encoded       = CrockfordBase32.encode128bits(hi, low)
       val (hi_d, low_d) = CrockfordBase32.decode128bits(encoded)

--- a/airframe-ulid/src/test/scala/wvlet/airframe/ulid/CrockfordBase32Test.scala
+++ b/airframe-ulid/src/test/scala/wvlet/airframe/ulid/CrockfordBase32Test.scala
@@ -23,7 +23,7 @@ class CrockfordBase32Test extends AirSpec with PropertyCheck {
     forAll { (hi: Long, low: Long) =>
       val encoded       = CrockfordBase32.encode128bits(hi, low)
       val (hi_d, low_d) = CrockfordBase32.decode128bits(encoded)
-      info(s"${hi}, ${low}, ${encoded}, ${hi_d}, ${low_d}")
+      debug(s"${hi}, ${low}, ${encoded}, ${hi_d}, ${low_d}")
       (hi, low) shouldBe (hi_d, low_d)
     }
   }

--- a/airframe-ulid/src/test/scala/wvlet/airframe/ulid/ULIDTest.scala
+++ b/airframe-ulid/src/test/scala/wvlet/airframe/ulid/ULIDTest.scala
@@ -78,7 +78,7 @@ class ULIDTest extends AirSpec with PropertyCheck {
     val ulid      = ULID.newULID
     val ts        = ulid.epochMillis
     val tsString  = ulid.toString.substring(0, 10)
-    val decodedTs = CrockfordBase32.decodeAsLong(tsString)
-    info(s"${ts}, ${tsString}, ${decodedTs}")
+    val decodedTs = CrockfordBase32.decode48bits(tsString)
+    debug(s"${ts}, ${tsString}, ${decodedTs}")
   }
 }

--- a/airframe-ulid/src/test/scala/wvlet/airframe/ulid/ULIDTest.scala
+++ b/airframe-ulid/src/test/scala/wvlet/airframe/ulid/ULIDTest.scala
@@ -21,7 +21,7 @@ import wvlet.airspec.spi.PropertyCheck
   */
 class ULIDTest extends AirSpec with PropertyCheck {
 
-  private def ulid(timestamp: => Long, random: => Double) = {
+  private def ulid(timestamp: => Long, random: => Int) = {
     new ULIDGenerator(() => timestamp, () => random)
   }
 
@@ -37,34 +37,34 @@ class ULIDTest extends AirSpec with PropertyCheck {
     }
   }
 
-  test("valid") {
-    ULID.isValid(ulid(System.currentTimeMillis(), 0.0d).generate) shouldBe true
-  }
-
-  test("generate") {
-    ulid(ULID.MinTime, 0.0d).generate shouldBe "00000000000000000000000000"
-    ulid(1L, 0.0d).generate shouldBe "00000000010000000000000000"
-    ulid(ULID.MaxTime, 0.0d).generate shouldBe "7ZZZZZZZZZ0000000000000000"
-
-    ulid(0L, 0.5d).generate shouldBe "0000000000FFFFFFFFFFFFFFFF"
-    ulid(0L, 1.0d).generate shouldBe "0000000000ZZZZZZZZZZZZZZZZ"
-  }
-
-  test("generation failures") {
-    intercept[IllegalArgumentException] {
-      ulid(ULID.MinTime - 1L, 0.0d).generate
-    }
-    intercept[IllegalArgumentException] {
-      ulid(ULID.MaxTime + 1L, 0.0d).generate
-    }
-
-    intercept[IllegalArgumentException] {
-      ulid(0L, -0.1d).generate
-    }
-    intercept[IllegalArgumentException] {
-      ulid(0L, 1.1d).generate
-    }
-  }
+//  test("valid") {
+//    ULID.isValid(ulid(System.currentTimeMillis(), 0.0d).generate) shouldBe true
+//  }
+//
+//  test("generate") {
+//    ulid(ULID.MinTime, 0.0d).generate shouldBe "00000000000000000000000000"
+//    ulid(1L, 0.0d).generate shouldBe "00000000010000000000000000"
+//    ulid(ULID.MaxTime, 0.0d).generate shouldBe "7ZZZZZZZZZ0000000000000000"
+//
+//    ulid(0L, 0.5d).generate shouldBe "0000000000FFFFFFFFFFFFFFFF"
+//    ulid(0L, 1.0d).generate shouldBe "0000000000ZZZZZZZZZZZZZZZZ"
+//  }
+//
+//  test("generation failures") {
+//    intercept[IllegalArgumentException] {
+//      ulid(ULID.MinTime - 1L, 0.0d).generate
+//    }
+//    intercept[IllegalArgumentException] {
+//      ulid(ULID.MaxTime + 1L, 0.0d).generate
+//    }
+//
+//    intercept[IllegalArgumentException] {
+//      ulid(0L, -0.1d).generate
+//    }
+//    intercept[IllegalArgumentException] {
+//      ulid(0L, 1.1d).generate
+//    }
+//  }
 
 //  test("invalid timestamp check") {
 //    forAll { str: String =>

--- a/airframe-ulid/src/test/scala/wvlet/airframe/ulid/ULIDTest.scala
+++ b/airframe-ulid/src/test/scala/wvlet/airframe/ulid/ULIDTest.scala
@@ -51,6 +51,7 @@ class ULIDTest extends AirSpec with PropertyCheck {
     ULID.of(ULID.MinTime, 0, 0) shouldBe ULID("00000000000000000000000000")
     ULID.of(1L, 0, 0) shouldBe ULID("00000000010000000000000000")
     ULID.of(ULID.MaxTime, 0, 0) shouldBe ULID("7ZZZZZZZZZ0000000000000000")
+    ULID.of(ULID.MaxTime, ~0L, ~0L) shouldBe ULID.MaxValue
     ULID.of(0L, 0, ~0L) shouldBe ULID("0000000000000FZZZZZZZZZZZZ")
     ULID.of(0L, ~0L, ~0L) shouldBe ULID("0000000000ZZZZZZZZZZZZZZZZ")
   }

--- a/airframe-ulid/src/test/scala/wvlet/airframe/ulid/ULIDTest.scala
+++ b/airframe-ulid/src/test/scala/wvlet/airframe/ulid/ULIDTest.scala
@@ -34,6 +34,7 @@ class ULIDTest extends AirSpec with PropertyCheck {
 
   test("generate monotonically increasing ULIDs") {
     val lst = (0 to 1000).map { i => ULID.newULID }
+    //info(lst.mkString("\n"))
     lst.sliding(2).forall { pair =>
       pair(0) < pair(1)
     }

--- a/airframe-ulid/src/test/scala/wvlet/airframe/ulid/ULIDTest.scala
+++ b/airframe-ulid/src/test/scala/wvlet/airframe/ulid/ULIDTest.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.ulid
 
-import wvlet.airframe.ulid.ULID.ULIDGenerator
+import wvlet.airframe.ulid.ULID.{ULIDGenerator}
 import wvlet.airspec.AirSpec
 import wvlet.airspec.spi.PropertyCheck
 
@@ -32,6 +32,7 @@ class ULIDTest extends AirSpec with PropertyCheck {
       val str       = ulid.toString
       val parsed    = ULID.fromString(str)
       ulid shouldBe parsed
+      ulid <= ULID.MaxValue shouldBe true
       debug(s"${ulid} ${timestamp} ${parsed}")
     }
   }
@@ -41,9 +42,9 @@ class ULIDTest extends AirSpec with PropertyCheck {
   }
 
   test("generate") {
-    ulid(ULID.MIN_TIME, 0.0d).generate shouldBe "00000000000000000000000000"
+    ulid(ULID.MinTime, 0.0d).generate shouldBe "00000000000000000000000000"
     ulid(1L, 0.0d).generate shouldBe "00000000010000000000000000"
-    ulid(ULID.MAX_TIME, 0.0d).generate shouldBe "7ZZZZZZZZZ0000000000000000"
+    ulid(ULID.MaxTime, 0.0d).generate shouldBe "7ZZZZZZZZZ0000000000000000"
 
     ulid(0L, 0.5d).generate shouldBe "0000000000FFFFFFFFFFFFFFFF"
     ulid(0L, 1.0d).generate shouldBe "0000000000ZZZZZZZZZZZZZZZZ"
@@ -51,10 +52,10 @@ class ULIDTest extends AirSpec with PropertyCheck {
 
   test("generation failures") {
     intercept[IllegalArgumentException] {
-      ulid(ULID.MIN_TIME - 1L, 0.0d).generate
+      ulid(ULID.MinTime - 1L, 0.0d).generate
     }
     intercept[IllegalArgumentException] {
-      ulid(ULID.MAX_TIME + 1L, 0.0d).generate
+      ulid(ULID.MaxTime + 1L, 0.0d).generate
     }
 
     intercept[IllegalArgumentException] {
@@ -65,14 +66,14 @@ class ULIDTest extends AirSpec with PropertyCheck {
     }
   }
 
-  test("invalid timestamp check") {
-    forAll { str: String =>
-      if (str.length != ULID.ULID_LENGTH) {
-        val result = ULID.extractEpochMillis(str)
-        result shouldBe empty
-      }
-    }
-  }
+//  test("invalid timestamp check") {
+//    forAll { str: String =>
+//      if (str.length != ULID.Length) {
+//        val result = ULID.extractEpochMillis(str)
+//        result shouldBe empty
+//      }
+//    }
+//  }
 
   test("encode timestamp") {
     val ulid      = ULID.newULID

--- a/airframe-ulid/src/test/scala/wvlet/airframe/ulid/ULIDTest.scala
+++ b/airframe-ulid/src/test/scala/wvlet/airframe/ulid/ULIDTest.scala
@@ -34,7 +34,6 @@ class ULIDTest extends AirSpec with PropertyCheck {
 
   test("generate monotonically increasing ULIDs") {
     val lst = (0 to 1000).map { i => ULID.newULID }
-    //info(lst.mkString("\n"))
     lst.sliding(2).forall { pair =>
       pair(0) < pair(1)
     }

--- a/airframe-ulid/src/test/scala/wvlet/airframe/ulid/ULIDTest.scala
+++ b/airframe-ulid/src/test/scala/wvlet/airframe/ulid/ULIDTest.scala
@@ -13,6 +13,7 @@
  */
 package wvlet.airframe.ulid
 
+import wvlet.airframe.ulid.ULID.ULIDGenerator
 import wvlet.airspec.AirSpec
 import wvlet.airspec.spi.PropertyCheck
 
@@ -40,9 +41,9 @@ class ULIDTest extends AirSpec with PropertyCheck {
   }
 
   test("generate") {
-    ulid(ULID.constants.MIN_TIME, 0.0d).generate shouldBe "00000000000000000000000000"
+    ulid(ULID.MIN_TIME, 0.0d).generate shouldBe "00000000000000000000000000"
     ulid(1L, 0.0d).generate shouldBe "00000000010000000000000000"
-    ulid(ULID.constants.MAX_TIME, 0.0d).generate shouldBe "7ZZZZZZZZZ0000000000000000"
+    ulid(ULID.MAX_TIME, 0.0d).generate shouldBe "7ZZZZZZZZZ0000000000000000"
 
     ulid(0L, 0.5d).generate shouldBe "0000000000FFFFFFFFFFFFFFFF"
     ulid(0L, 1.0d).generate shouldBe "0000000000ZZZZZZZZZZZZZZZZ"
@@ -50,10 +51,10 @@ class ULIDTest extends AirSpec with PropertyCheck {
 
   test("generation failures") {
     intercept[IllegalArgumentException] {
-      ulid(ULID.constants.MIN_TIME - 1L, 0.0d).generate
+      ulid(ULID.MIN_TIME - 1L, 0.0d).generate
     }
     intercept[IllegalArgumentException] {
-      ulid(ULID.constants.MAX_TIME + 1L, 0.0d).generate
+      ulid(ULID.MAX_TIME + 1L, 0.0d).generate
     }
 
     intercept[IllegalArgumentException] {
@@ -66,7 +67,7 @@ class ULIDTest extends AirSpec with PropertyCheck {
 
   test("invalid timestamp check") {
     forAll { str: String =>
-      if (str.length != ULID.constants.ULID_LENGTH) {
+      if (str.length != ULID.ULID_LENGTH) {
         val result = ULID.extractEpochMillis(str)
         result shouldBe empty
       }

--- a/airframe-ulid/src/test/scala/wvlet/airframe/ulid/ULIDTest.scala
+++ b/airframe-ulid/src/test/scala/wvlet/airframe/ulid/ULIDTest.scala
@@ -51,34 +51,18 @@ class ULIDTest extends AirSpec with PropertyCheck {
     ULID.of(ULID.MinTime, 0, 0) shouldBe ULID("00000000000000000000000000")
     ULID.of(1L, 0, 0) shouldBe ULID("00000000010000000000000000")
     ULID.of(ULID.MaxTime, 0, 0) shouldBe ULID("7ZZZZZZZZZ0000000000000000")
-    //ULID.of(0L, 0, ~0L) shouldBe ULID("0000000000FFFFFFFFFFFFFFFF")
+    ULID.of(0L, 0, ~0L) shouldBe ULID("0000000000000FZZZZZZZZZZZZ")
     ULID.of(0L, ~0L, ~0L) shouldBe ULID("0000000000ZZZZZZZZZZZZZZZZ")
   }
-//
-//  test("generation failures") {
-//    intercept[IllegalArgumentException] {
-//      ulid(ULID.MinTime - 1L, 0.0d).generate
-//    }
-//    intercept[IllegalArgumentException] {
-//      ulid(ULID.MaxTime + 1L, 0.0d).generate
-//    }
-//
-//    intercept[IllegalArgumentException] {
-//      ulid(0L, -0.1d).generate
-//    }
-//    intercept[IllegalArgumentException] {
-//      ulid(0L, 1.1d).generate
-//    }
-//  }
 
-//  test("invalid timestamp check") {
-//    forAll { str: String =>
-//      if (str.length != ULID.Length) {
-//        val result = ULID.extractEpochMillis(str)
-//        result shouldBe empty
-//      }
-//    }
-//  }
+  test("generation failures") {
+    intercept[IllegalArgumentException] {
+      ULID.of(ULID.MinTime - 1L, 0, 0)
+    }
+    intercept[IllegalArgumentException] {
+      ULID.of(ULID.MaxTime + 1L, 0, 0)
+    }
+  }
 
   test("encode timestamp") {
     val ulid      = ULID.newULID

--- a/airframe-ulid/src/test/scala/wvlet/airframe/ulid/ULIDTest.scala
+++ b/airframe-ulid/src/test/scala/wvlet/airframe/ulid/ULIDTest.scala
@@ -73,4 +73,12 @@ class ULIDTest extends AirSpec with PropertyCheck {
       }
     }
   }
+
+  test("encode timestamp") {
+    val ulid      = ULID.newULID
+    val ts        = ulid.epochMillis
+    val tsString  = ulid.toString.substring(0, 10)
+    val decodedTs = CrockfordBase32.decodeAsLong(tsString)
+    info(s"${ts}, ${tsString}, ${decodedTs}")
+  }
 }

--- a/airframe-ulid/src/test/scala/wvlet/airframe/ulid/ULIDTest.scala
+++ b/airframe-ulid/src/test/scala/wvlet/airframe/ulid/ULIDTest.scala
@@ -13,17 +13,12 @@
  */
 package wvlet.airframe.ulid
 
-import wvlet.airframe.ulid.ULID.{ULIDGenerator}
 import wvlet.airspec.AirSpec
 import wvlet.airspec.spi.PropertyCheck
 
 /**
   */
 class ULIDTest extends AirSpec with PropertyCheck {
-
-  private def ulid(timestamp: => Long, random: => Array[Byte]) = {
-    new ULIDGenerator(() => timestamp, () => random)
-  }
 
   test("generate ULID") {
     for (i <- 0 to 10) {
@@ -44,18 +39,21 @@ class ULIDTest extends AirSpec with PropertyCheck {
     }
   }
 
-//  test("valid") {
-//    ULID.isValid(ulid(System.currentTimeMillis(), 0.0d).generate) shouldBe true
-//  }
-//
-//  test("generate") {
-//    ulid(ULID.MinTime, 0.0d).generate shouldBe "00000000000000000000000000"
-//    ulid(1L, 0.0d).generate shouldBe "00000000010000000000000000"
-//    ulid(ULID.MaxTime, 0.0d).generate shouldBe "7ZZZZZZZZZ0000000000000000"
-//
-//    ulid(0L, 0.5d).generate shouldBe "0000000000FFFFFFFFFFFFFFFF"
-//    ulid(0L, 1.0d).generate shouldBe "0000000000ZZZZZZZZZZZZZZZZ"
-//  }
+  test("valid") {
+    forAll { (timeMillis: Long) =>
+      val unixtime = timeMillis & 0xffffffffffffL
+      val ulid     = ULID.of(unixtime, 0, 0)
+      ulid.epochMillis shouldBe unixtime
+    }
+  }
+
+  test("generate") {
+    ULID.of(ULID.MinTime, 0, 0) shouldBe ULID("00000000000000000000000000")
+    ULID.of(1L, 0, 0) shouldBe ULID("00000000010000000000000000")
+    ULID.of(ULID.MaxTime, 0, 0) shouldBe ULID("7ZZZZZZZZZ0000000000000000")
+    //ULID.of(0L, 0, ~0L) shouldBe ULID("0000000000FFFFFFFFFFFFFFFF")
+    ULID.of(0L, ~0L, ~0L) shouldBe ULID("0000000000ZZZZZZZZZZZZZZZZ")
+  }
 //
 //  test("generation failures") {
 //    intercept[IllegalArgumentException] {
@@ -87,6 +85,6 @@ class ULIDTest extends AirSpec with PropertyCheck {
     val ts        = ulid.epochMillis
     val tsString  = ulid.toString.substring(0, 10)
     val decodedTs = CrockfordBase32.decode48bits(tsString)
-    debug(s"${ts}, ${tsString}, ${decodedTs}")
+    ts shouldBe decodedTs
   }
 }

--- a/airframe-ulid/src/test/scala/wvlet/airframe/ulid/ULIDTest.scala
+++ b/airframe-ulid/src/test/scala/wvlet/airframe/ulid/ULIDTest.scala
@@ -21,7 +21,7 @@ import wvlet.airspec.spi.PropertyCheck
   */
 class ULIDTest extends AirSpec with PropertyCheck {
 
-  private def ulid(timestamp: => Long, random: => Int) = {
+  private def ulid(timestamp: => Long, random: => Array[Byte]) = {
     new ULIDGenerator(() => timestamp, () => random)
   }
 

--- a/airframe-ulid/src/test/scala/wvlet/airframe/ulid/ULIDTest.scala
+++ b/airframe-ulid/src/test/scala/wvlet/airframe/ulid/ULIDTest.scala
@@ -37,6 +37,13 @@ class ULIDTest extends AirSpec with PropertyCheck {
     }
   }
 
+  test("generate monotonically increasing ULIDs") {
+    val lst = (0 to 1000).map { i => ULID.newULID }
+    lst.sliding(2).forall { pair =>
+      pair(0) < pair(1)
+    }
+  }
+
 //  test("valid") {
 //    ULID.isValid(ulid(System.currentTimeMillis(), 0.0d).generate) shouldBe true
 //  }

--- a/airframe-ulid/src/test/scala/wvlet/airframe/ulid/ULIDTest.scala
+++ b/airframe-ulid/src/test/scala/wvlet/airframe/ulid/ULIDTest.scala
@@ -33,11 +33,17 @@ class ULIDTest extends AirSpec with PropertyCheck {
   }
 
   test("toString/toBytes") {
-    val lst = (0 to 10000).map { i => ULID.newULID }
-    lst.forall { x =>
+    forAll { (a: Long, rh: Long, rl: Long) =>
+      val unixTime = a & ((~0L) >>> (64 - 48))
+      val ulid     = ULID.of(unixTime, rh, rl)
       // Identity
-      ULID.fromString(x.toString) shouldBe x
-      //ULID.fromBytes(x.toBytes) shouldBe x
+      ulid.compareTo(ulid) shouldBe 0
+      ULID.fromString(ulid.toString) shouldBe ulid
+      ULID.fromBytes(ulid.toBytes) shouldBe ulid
+
+      // Condition
+      ulid.epochMillis shouldBe unixTime
+      ULID.isValid(ulid.toString) shouldBe true
     }
   }
 

--- a/airframe-ulid/src/test/scala/wvlet/airframe/ulid/ULIDTest.scala
+++ b/airframe-ulid/src/test/scala/wvlet/airframe/ulid/ULIDTest.scala
@@ -32,10 +32,26 @@ class ULIDTest extends AirSpec with PropertyCheck {
     }
   }
 
+  test("toString/toBytes") {
+    val lst = (0 to 10000).map { i => ULID.newULID }
+    lst.forall { x =>
+      // Identity
+      ULID.fromString(x.toString) shouldBe x
+      //ULID.fromBytes(x.toBytes) shouldBe x
+    }
+  }
+
   test("generate monotonically increasing ULIDs") {
-    val lst = (0 to 1000).map { i => ULID.newULID }
+    val start = System.currentTimeMillis() - 1
+    val lst   = (0 to 10000).map { i => ULID.newULID }
+    val end   = System.currentTimeMillis()
+    lst.forall { x =>
+      start <= x.epochMillis && x.epochMillis <= end shouldBe true
+    }
+
     lst.sliding(2).forall { pair =>
-      pair(0) < pair(1) && pair(0).epochMillis <= pair(1).epochMillis
+      pair(0) < pair(1) &&
+      pair(0).epochMillis <= pair(1).epochMillis
     }
   }
 

--- a/airframe-ulid/src/test/scala/wvlet/airframe/ulid/ULIDTest.scala
+++ b/airframe-ulid/src/test/scala/wvlet/airframe/ulid/ULIDTest.scala
@@ -35,7 +35,7 @@ class ULIDTest extends AirSpec with PropertyCheck {
   test("generate monotonically increasing ULIDs") {
     val lst = (0 to 1000).map { i => ULID.newULID }
     lst.sliding(2).forall { pair =>
-      pair(0) < pair(1)
+      pair(0) < pair(1) && pair(0).epochMillis <= pair(1).epochMillis
     }
   }
 

--- a/build.sbt
+++ b/build.sbt
@@ -817,7 +817,8 @@ lazy val benchmark =
         // "com.thesamet.scalapb" %% "scalapb-runtime-grpc" % scalapb.compiler.Version.scalapbVersion
         // For grpc-java
         "io.grpc"             % "grpc-protobuf" % GRPC_VERSION,
-        "com.google.protobuf" % "protobuf-java" % "3.15.8"
+        "com.google.protobuf" % "protobuf-java" % "3.15.8",
+        "com.chatwork"       %% "scala-ulid"    % "1.0.2"
       )
       //      PB.targets in Compile := Seq(
       //        scalapb.gen() -> (sourceManaged in Compile).value / "scalapb"
@@ -825,7 +826,7 @@ lazy val benchmark =
       // publishing .tgz
       // publishPackArchiveTgz
     )
-    .dependsOn(msgpackJVM, jsonJVM, metricsJVM, launcher, finagle, grpc)
+    .dependsOn(msgpackJVM, jsonJVM, metricsJVM, launcher, finagle, grpc, ulidJVM)
 
 lazy val fluentd =
   project


### PR DESCRIPTION
- airframe-ulid is now a single module without any dependency #1585 
- Split CrockfordBase32 encoder as a class
- Optimize Base32 encoding/decoding with bit-shift operations
- Add various ULID factories
- Use SecureRandom by default. Use standard Random for Scala.js
- Generate 80-bit random values with Array[Byte] for improving the performance
- Support generating monotonically increasing ULID by default. This has accelerated the performance 2x ~ 3x by eliminating random value generation within the same millisecond

Benchmark results:
```
$ ./sbt
> benchmark/run bench ulid

Benchmark                    Mode  Cnt        Score        Error  Units
Airframe.generateMonotonic  thrpt   10  5514410.915 ± 534378.141  ops/s
Chatwork.generate           thrpt   10  2063919.975 ±  62641.190  ops/s
Chatwork.generateMonotonic  thrpt   10  4715112.355 ± 680190.587  ops/s
UUID.generate               thrpt   10  3056452.879 ± 121768.161  ops/s
````

cc: @petitviolet @j5ik2o @exoego