### PR TITLE
airframe-surface: Support EnumSurface for Scala 3

### DIFF
--- a/airframe-surface/.jvm/src/main/scala-2/wvlet/airframe/surface/reflect/ReflectSurfaceFactory.scala
+++ b/airframe-surface/.jvm/src/main/scala-2/wvlet/airframe/surface/reflect/ReflectSurfaceFactory.scala
@@ -505,6 +505,7 @@ object ReflectSurfaceFactory extends LogSupport {
       }
 
       for (params <- constructor.paramLists) yield {
+        // Necessary for resolving type parameters e.g., Cons[A](p:Cons[A]) => Cons[String](p:Cons[String])
         val concreteArgTypes = params.map { p =>
           try {
             p.typeSignature.substituteTypes(classTypeParams, targetType.typeArgs)

--- a/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
+++ b/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
@@ -240,27 +240,51 @@ private[surface] class CompileTimeSurfaceFactory(using quotes:Quotes) {
       '{ new GenericSurface(${clsOf(a)}, typeArgs = ${Expr.ofSeq(typeArgs)}.toIndexedSeq) }
     case r: Refinement =>
       newGenericSurfaceOf(r.info)
+    case t if hasStringUnapply(t) =>
+      '{
+        EnumSurface(
+          ${clsOf(t)},
+          { (cl: Class[_], s: String) => wvlet.airframe.surface.reflect.TypeConverter.convertToCls(s, cl) }
+        )
+      }
     case t =>
       newGenericSurfaceOf(t)
   }
 
-//  private def hasStringUnapply(t: TypeRepr): Boolean = {
-//    t.typeSymbol.companionClass match {
-//      case cp: Symbol if !cp.isNoSymbol =>
-//        cp.memberMethod("unapply") match {
-//          case m: Symbol if m.paramSymss.size == 1 =>
-//            val args: List[Symbol] = m.paramSymss.head
-//            if(args.size == 1) {
-//              args.head.tree match {
-//                case v:ValDef if v.tpt.tpe =:= Type.of[String]
-//            false
-//          case _ => false
-//        }
-//      case _ =>
-//        false
-//    }
-//  }
-//
+  private def hasOptionReturnType(d: DefDef, retElementType: TypeRepr): Boolean = {
+    if(d.returnTpt.tpe <:< TypeRepr.of[Option[_]]) {
+      val typeArgs = typeArgsOf(d.returnTpt.tpe)
+      typeArgs.headOption match {
+        case Some(t) if t =:= retElementType => true
+        case _ => false
+      }
+    }
+    else {
+      false
+    }
+  }
+
+  private def hasStringUnapply(t: TypeRepr): Boolean = {
+    t.typeSymbol.companionClass match {
+      case cp: Symbol =>
+        cp.memberMethod("unapply").headOption.map(_.tree) match {
+          case Some(m: DefDef) if m.paramss.size == 1 && hasOptionReturnType(m, t) =>
+            val args: List[ParamClause] = m.paramss
+            args.headOption.flatMap(_.params.headOption) match {
+              // Is the first argument type String? def unapply(s: String)
+              case Some(v:ValDef) if v.tpt.tpe =:= TypeRepr.of[String] =>
+                true
+              case _ =>
+                false
+            }
+          case _ =>
+            false
+        }
+     case _ =>
+       false
+   }
+ }
+
   private def methodArgsOf(method:Symbol): List[Symbol] = {
     // TODO: Substitute (apply) type parameters
     method.paramSymss.flatten

--- a/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
+++ b/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
@@ -59,7 +59,7 @@ private[surface] class CompileTimeSurfaceFactory(using quotes:Quotes) {
   private val memo = scala.collection.mutable.Map[TypeRepr, Expr[Surface]]()
 
   private def surfaceOf(t: TypeRepr): Expr[Surface] = {
-    println(s"surfaceOf ${fullTypeNameOf(t)}")
+    //println(s"surfaceOf ${fullTypeNameOf(t)}")
     if(seen.contains(t)) {
       if(memo.contains(t)) {
         memo(t)
@@ -75,7 +75,7 @@ private[surface] class CompileTimeSurfaceFactory(using quotes:Quotes) {
       val generator = factory.andThen { expr =>
         '{ wvlet.airframe.surface.surfaceCache.getOrElseUpdate(${Expr(fullTypeNameOf(t))}, ${expr}) }
       }
-      println(s"--- surfaceOf(${t})")
+      //println(s"--- surfaceOf(${t})")
       val surface = generator(t)
       memo += (t -> surface)
       surface
@@ -275,7 +275,7 @@ private[surface] class CompileTimeSurfaceFactory(using quotes:Quotes) {
     val methodArgs = methodArgsOf(method)
     val argClasses = methodArgs.map(_.tree).collect {
       case v:ValDef =>
-        println(s"${v.name}: ${v}")
+        //println(s"${v.name}: ${v}")
         clsOf(v.tpt.tpe.dealias)
     }
     val isConstructor = t.typeSymbol.primaryConstructor == method

--- a/airframe-surface/src/test/scala/wvlet/airframe/surface/EnumTest.scala
+++ b/airframe-surface/src/test/scala/wvlet/airframe/surface/EnumTest.scala
@@ -38,7 +38,7 @@ object EnumTest extends AirSpec {
         f(classOf[Color], "Red") shouldBe Some(Red)
         f(classOf[Color], "White") shouldBe empty
       case _ =>
-        fail("EnumSurface is not found...")
+        fail("EnumSurface is not found")
     }
   }
 }

--- a/airframe-surface/src/test/scala/wvlet/airframe/surface/RecursiveSurfaceTest.scala
+++ b/airframe-surface/src/test/scala/wvlet/airframe/surface/RecursiveSurfaceTest.scala
@@ -13,12 +13,10 @@
  */
 package wvlet.airframe.surface
 
-import wvlet.airframe.surface
-
 object RecursiveSurfaceTest {
   case class Leaf(name: String)
   case class Cons(head: String, tail: Cons)
-  case class TypedCons[A](head: String, tail: TypedCons[A])
+  case class TypedCons[A](head: Int, tail: TypedCons[A])
 }
 
 /**
@@ -26,42 +24,44 @@ object RecursiveSurfaceTest {
 class RecursiveSurfaceTest extends SurfaceSpec {
   import RecursiveSurfaceTest._
 
-  test("find surface from full type name string") {
-    val s = Surface.of[Leaf]
-    assert(surface.getCached("wvlet.airframe.surface.RecursiveSurfaceTest.Leaf") == s)
-  }
-
-  test("support recursive type") {
-    val c: Surface = Surface.of[Cons]
-    assert(c.toString == "Cons")
-
-    assert(c.params.length == 2)
-    val h = c.params(0)
-    assert(h.name == "head")
-    assert(h.surface == Primitive.String)
-
-    val t = c.params(1)
-    assert(t.name == "tail")
-    val lazyC: Surface = t.surface
-    assert(lazyC.toString == "Cons")
-    assert(lazyC.params.length == 2)
-    assert(lazyC.isPrimitive == false)
-    assert(lazyC.isOption == false)
-    assert(lazyC.isAlias == false)
-    assert(lazyC.objectFactory.isDefined)
-  }
+//  test("find surface from full type name string") {
+//    val s = Surface.of[Leaf]
+//    assert(surface.getCached("wvlet.airframe.surface.RecursiveSurfaceTest.Leaf") == s)
+//  }
+//
+//  test("support recursive type") {
+//    val c: Surface = Surface.of[Cons]
+//    assert(c.toString == "Cons")
+//
+//    assert(c.params.length == 2)
+//    val h = c.params(0)
+//    assert(h.name == "head")
+//    assert(h.surface == Primitive.String)
+//
+//    val t = c.params(1)
+//    assert(t.name == "tail")
+//    val lazyC: Surface = t.surface
+//    assert(lazyC.toString == "Cons")
+//    assert(lazyC.params.length == 2)
+//    assert(lazyC.isPrimitive == false)
+//    assert(lazyC.isOption == false)
+//    assert(lazyC.isAlias == false)
+//    assert(lazyC.objectFactory.isDefined)
+//  }
 
   test("support generic recursive type") {
     val c: Surface = Surface.of[TypedCons[String]]
-    assert(c.toString == "TypedCons[String]")
+    debug(s"TypeCons[String] ${c.getClass}")
+    c.toString shouldBe "TypedCons[String]"
 
-    assert(c.params.length == 2)
-    assert(c.params(0).surface == Primitive.String)
+    c.params.length shouldBe 2
+    c.params(0).surface shouldBe Primitive.Int
 
     val lazyC: Surface = c.params(1).surface
-    assert(lazyC.toString == "TypedCons[String]")
-    assert(lazyC.params.length == 2)
-    assert(lazyC.isPrimitive == false)
-    assert(lazyC.isOption == false)
+    debug(s"lazyC surface: ${lazyC.getClass}...")
+    lazyC.toString shouldBe "TypedCons[String]"
+    lazyC.params.length shouldBe 2
+    lazyC.isPrimitive shouldBe false
+    lazyC.isOption shouldBe false
   }
 }

--- a/airframe-surface/src/test/scala/wvlet/airframe/surface/RecursiveSurfaceTest.scala
+++ b/airframe-surface/src/test/scala/wvlet/airframe/surface/RecursiveSurfaceTest.scala
@@ -24,30 +24,30 @@ object RecursiveSurfaceTest {
 class RecursiveSurfaceTest extends SurfaceSpec {
   import RecursiveSurfaceTest._
 
-//  test("find surface from full type name string") {
-//    val s = Surface.of[Leaf]
-//    assert(surface.getCached("wvlet.airframe.surface.RecursiveSurfaceTest.Leaf") == s)
-//  }
-//
-//  test("support recursive type") {
-//    val c: Surface = Surface.of[Cons]
-//    assert(c.toString == "Cons")
-//
-//    assert(c.params.length == 2)
-//    val h = c.params(0)
-//    assert(h.name == "head")
-//    assert(h.surface == Primitive.String)
-//
-//    val t = c.params(1)
-//    assert(t.name == "tail")
-//    val lazyC: Surface = t.surface
-//    assert(lazyC.toString == "Cons")
-//    assert(lazyC.params.length == 2)
-//    assert(lazyC.isPrimitive == false)
-//    assert(lazyC.isOption == false)
-//    assert(lazyC.isAlias == false)
-//    assert(lazyC.objectFactory.isDefined)
-//  }
+  test("find surface from full type name string") {
+    val s = Surface.of[Leaf]
+    assert(wvlet.airframe.surface.getCached("wvlet.airframe.surface.RecursiveSurfaceTest.Leaf") == s)
+  }
+
+  test("support recursive type") {
+    val c: Surface = Surface.of[Cons]
+    assert(c.toString == "Cons")
+
+    assert(c.params.length == 2)
+    val h = c.params(0)
+    assert(h.name == "head")
+    assert(h.surface == Primitive.String)
+
+    val t = c.params(1)
+    assert(t.name == "tail")
+    val lazyC: Surface = t.surface
+    assert(lazyC.toString == "Cons")
+    assert(lazyC.params.length == 2)
+    assert(lazyC.isPrimitive == false)
+    assert(lazyC.isOption == false)
+    assert(lazyC.isAlias == false)
+    assert(lazyC.objectFactory.isDefined)
+  }
 
   test("support generic recursive type") {
     val c: Surface = Surface.of[TypedCons[String]]


### PR DESCRIPTION
Resolve Surface for enum-like classes that have unapply(s:String): Option[A] method