### PR TITLE
Make ULIDGenerator class public allowing Random injection

### DIFF
--- a/airframe-ulid/src/main/scala/wvlet/airframe/ulid/ULID.scala
+++ b/airframe-ulid/src/main/scala/wvlet/airframe/ulid/ULID.scala
@@ -184,7 +184,7 @@ object ULID {
     * @param timeSource a function that returns the current time in milliseconds (e.g. java.lang.System.currentTimeMillis())
     * @param random a function that returns a 80-bit random values in Array[Byte] (size:10)
     */
-  private class ULIDGenerator(random: () => Array[Byte]) {
+  class ULIDGenerator(random: () => Array[Byte]) {
     private val baseSystemTimeMillis = System.currentTimeMillis()
     private val baseNanoTime         = System.nanoTime()
 


### PR DESCRIPTION
We've noticed the ULID generation taking up to 10s due to threading issues on the default `SecureRandom` instance. 

When using a non-secure `Random` instance, it works fine. 

As far as I understand, as long as we simply use the generated ULIDs as an internal id that is only used for uniqueness and sorting, it is fine to use the non-secure `Random`