### PR TITLE
airframe-ulid: Support non-secure random ULID generator

### DIFF
--- a/airframe-benchmark/README.md
+++ b/airframe-benchmark/README.md
@@ -81,19 +81,22 @@ usage: bench [targetPackage]
 $ ./sbt
 
 # Run JSON benchmark:
-> benchmark/run bench-quick json
+> benchmark/run bench json
 
 # Run JSON-MsgPack conversion benchmark:
-> benchmark/run bench-quick json_stream
+> benchmark/run bench json_stream
 
 # Run benchmark for measuring JSON parse time:
-> benchmark/run json-perf
+> benchmark/run bench json-perf
 
 # Run Msgpack benchmark:
-> benchmark/run bench-quick msgpack
+> benchmark/run bench msgpack
+
+# Run ULID benchmark:
+> benchmark/run bench ulid
 
 # Run all JMH benchmarks:
-> benchmark/run bench-quick
+> benchmark/run bench
 ```
 
 To see more stable performance characteristics, use `bench` command, instead of `bench-quick`.

--- a/airframe-ulid/src/main/scala/wvlet/airframe/ulid/ULID.scala
+++ b/airframe-ulid/src/main/scala/wvlet/airframe/ulid/ULID.scala
@@ -15,6 +15,7 @@ package wvlet.airframe.ulid
 import java.time.Instant
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.{AtomicLong, AtomicReference}
+import scala.util.Random
 
 /**
   * ULID string, consisting of 26 characters.
@@ -85,9 +86,13 @@ object ULID {
   private[ulid] val MinTime = 0L
   private[ulid] val MaxTime = (~0L) >>> (64 - 48) // Timestamp uses 48-bit range
 
-  private val random: scala.util.Random = compat.random
+  private var _generator: ULIDGenerator = defaultULIDGenerator
 
-  private val defaultGenerator = {
+  /**
+    * The default secure random-based ULID Generator
+    */
+  def defaultULIDGenerator: ULIDGenerator = {
+    val random: scala.util.Random = compat.random
     val randGen = { () =>
       val r = new Array[Byte](10)
       random.nextBytes(r)
@@ -97,14 +102,47 @@ object ULID {
   }
 
   /**
+    * Return a fast ULID generator, but with a reduced randomness
+    */
+  def nonSecureRandomULIDGenerator: ULIDGenerator = {
+    val randGen = { () =>
+      val r = new Array[Byte](10); Random.nextBytes(r); r
+    }
+    new ULIDGenerator(randGen)
+  }
+
+  /**
+    * Set the default ULIDGenerator that will be used for ULID.newULID.
+    * @param newGenerator
+    */
+  def setDefaultULIDGenerator(newGenerator: ULIDGenerator): Unit = {
+    require(newGenerator != null, "ULIDGenerator is null")
+    _generator = newGenerator
+  }
+
+  /**
+    * Use the fast ULID generator by default with reduced randomness
+    */
+  def useNonSecureRandomULIDGenerator: Unit = {
+    setDefaultULIDGenerator(nonSecureRandomULIDGenerator)
+  }
+
+  /**
+    * Use the default secura-random based ULID generator.
+    */
+  def useDefaultULIDGenerator: Unit = {
+    setDefaultULIDGenerator(defaultULIDGenerator)
+  }
+
+  /**
     * Create a new ULID
     */
-  def newULID: ULID = new ULID(defaultGenerator.generate)
+  def newULID: ULID = _generator.newULID
 
   /**
     * Create a new ULID string
     */
-  def newULIDString: String = defaultGenerator.generate
+  def newULIDString: String = _generator.newULIDString
 
   /**
     * Create a new ULID from a given string of size 26
@@ -195,8 +233,10 @@ object ULID {
       baseSystemTimeMillis + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - baseNanoTime)
     }
 
+    def newULID: ULID = new ULID(newULIDString)
+
     /**
-      * Generate ULID string.
+      * Generate a new ULID string.
       *
       * Tips for optimizing performance:
       *
@@ -208,7 +248,7 @@ object ULID {
       * is ideal.
       * 4. In base32 encoding/decoding, use bit-shift operators as much as possible to utilize CPU registers and memory cache.
       */
-    def generate: String = {
+    def newULIDString: String = {
       val unixTimeMillis: Long = currentTimeInMillis
       if (unixTimeMillis > MaxTime) {
         throw new IllegalStateException(f"unixtime should be less than: ${MaxTime}%,d: ${unixTimeMillis}%,d")
@@ -227,7 +267,7 @@ object ULID {
             if ((nextHi & (~0L << 16)) != 0) {
               // Random number overflow. Wait for one millisecond and retry
               compat.sleep(1)
-              generate
+              newULIDString
             } else {
               nextHi |= unixTimeMillis << (64 - 48)
               generateFrom(nextHi, 0)

--- a/airframe-ulid/src/test/scala/wvlet/airframe/ulid/ULIDTest.scala
+++ b/airframe-ulid/src/test/scala/wvlet/airframe/ulid/ULIDTest.scala
@@ -96,4 +96,22 @@ class ULIDTest extends AirSpec with PropertyCheck {
     val decodedTs = CrockfordBase32.decode48bits(tsString)
     ts shouldBe decodedTs
   }
+
+  test("customize random generator") {
+    try {
+      ULID.useNonSecureRandomULIDGenerator
+      for (i <- 0 to 10) {
+        val ulid      = ULID.newULID
+        val timestamp = ulid.epochMillis
+        val str       = ulid.toString
+        val parsed    = ULID.fromString(str)
+        ulid shouldBe parsed
+        ulid <= ULID.MaxValue shouldBe true
+        debug(s"${ulid} ${timestamp} ${parsed}")
+      }
+    } finally {
+      ULID.useDefaultULIDGenerator
+    }
+
+  }
 }


### PR DESCRIPTION
Add non-secure Random-based ULID generator. 

Although, it's slightly faster than the default one, the overhead of generating monotonically increasing ULIDs, which uses the synchronization block, seems the bottleneck because using a single thread for generating ULID was much faster (12M ULIDs/sec.)

JMH Benchamark with 4 threads (with M1 Mac mini):
```
sbt> benchmark/run  bench ulid

Benchmark                             Mode  Cnt        Score        Error  Units
Airframe.generateMonotonic           thrpt   10  7456080.727 ±  64518.094  ops/s
AirframeNonSecure.generateMonotonic  thrpt   10  7544899.339 ±  26569.171  ops/s
Chatwork.generate                    thrpt   10  2685346.054 ±   9523.277  ops/s
Chatwork.generateMonotonic           thrpt   10  6409200.174 ± 156695.839  ops/s
UUID.generate                        thrpt   10  2343140.507 ±  41251.450  ops/s
```