### PR TITLE
Remove airframe-ulid from the community build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -163,7 +163,6 @@ lazy val communityBuildProjects: Seq[ProjectReference] = Seq(
   canvas,
   config,
   controlJVM,
-  ulidJVM,
   jmx,
   launcher,
   metricsJVM,
@@ -189,6 +188,7 @@ lazy val jvmProjects: Seq[ProjectReference] = communityBuildProjects ++ Seq[Proj
   httpRecorder,
   benchmark,
   sql,
+  ulidJVM,
   examples
 )
 


### PR DESCRIPTION
A workaround for https://github.com/scala/community-build/pull/1425