### PR TITLE
airframe-http: Properly decode URL-encoded paths in ClassScanner

### DIFF
--- a/airframe-http-codegen/src/main/scala/wvlet/airframe/http/codegen/ClassScanner.scala
+++ b/airframe-http-codegen/src/main/scala/wvlet/airframe/http/codegen/ClassScanner.scala
@@ -15,13 +15,19 @@ package wvlet.airframe.http.codegen
 import java.io.File
 import java.net.{URL, URLClassLoader}
 import java.util.jar.JarFile
-
 import wvlet.log.LogSupport
+
+import java.nio.charset.StandardCharsets
 
 /**
   * Scan all class files in the class path and jar files to find airframe-http interface classes
   */
 object ClassScanner extends LogSupport {
+
+  private[codegen] def decodePath(path: String): String = {
+    // Decode URL-encoded string paths
+    java.net.URLDecoder.decode(path, StandardCharsets.UTF_8)
+  }
 
   def scanClasses(cl: ClassLoader, targetPackageNames: Seq[String]): Seq[String] = {
     def loop(c: ClassLoader): Seq[URL] = {
@@ -41,9 +47,9 @@ object ClassScanner extends LogSupport {
     def findClasses(url: URL): Seq[String] = {
       url match {
         case dir if dir.getProtocol == "file" && { val d = new File(dir.getPath); d.exists() && d.isDirectory } =>
-          scanClassesInDirectory(dir.getPath, targetPackageNames)
+          scanClassesInDirectory(decodePath(dir.getPath), targetPackageNames)
         case jarFile if jarFile.getProtocol == "file" && jarFile.getPath.endsWith(".jar") =>
-          scanClassesInJar(jarFile.getPath, targetPackageNames)
+          scanClassesInJar(decodePath(jarFile.getPath), targetPackageNames)
         case _ =>
           Seq.empty
       }

--- a/airframe-http-codegen/src/test/scala/wvlet/airframe/http/codegen/ClassScannerTest.scala
+++ b/airframe-http-codegen/src/test/scala/wvlet/airframe/http/codegen/ClassScannerTest.scala
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.http.codegen
+
+import wvlet.airspec.AirSpec
+
+/**
+  */
+class ClassScannerTest extends AirSpec {
+  test("decoded URL encoded file paths") {
+    ClassScanner.decodePath(
+      "/lib/0.0.1%2Btest/xxxx-0.0.1%2Btest.jar"
+    ) shouldBe "/lib/0.0.1+test/xxxx-0.0.1+test.jar"
+  }
+}


### PR DESCRIPTION
Fixes #1772