### PR TITLE
airframe-control: Remove scala-parser-combinators dependency

### DIFF
--- a/airframe-control/.jvm/src/main/scala/wvlet/airframe/control/CommandLineTokenizer.scala
+++ b/airframe-control/.jvm/src/main/scala/wvlet/airframe/control/CommandLineTokenizer.scala
@@ -14,8 +14,6 @@
 package wvlet.airframe.control
 import wvlet.log.LogSupport
 
-import scala.annotation.tailrec
-
 /**
   * Tokenize single string representations of command line arguments into Array[String]
   */
@@ -63,6 +61,7 @@ object CommandLineTokenizer extends LogSupport {
       val ch = line.charAt(cursor)
       ch match {
         case '\'' =>
+          // Parse single quoted token
           SINGLE_QUOTED_LITERAL.findPrefixMatchOf(line.substring(cursor)) match {
             case Some(m) =>
               val token = m.matched
@@ -71,6 +70,7 @@ object CommandLineTokenizer extends LogSupport {
               parseToken
           }
         case '"' =>
+          // Parse double quoted token
           DOUBLE_QUOTED_LITERAL.findPrefixMatchOf(line.substring(cursor)) match {
             case Some(m) =>
               val token = m.matched

--- a/airframe-control/.jvm/src/main/scala/wvlet/airframe/control/CommandLineTokenizer.scala
+++ b/airframe-control/.jvm/src/main/scala/wvlet/airframe/control/CommandLineTokenizer.scala
@@ -14,35 +14,73 @@
 package wvlet.airframe.control
 import wvlet.log.LogSupport
 
-import scala.util.parsing.combinator.RegexParsers
+import scala.annotation.tailrec
 
 /**
   * Tokenize single string representations of command line arguments into Array[String]
   */
-object CommandLineTokenizer extends RegexParsers with LogSupport {
+object CommandLineTokenizer extends LogSupport {
+  private val DOUBLE_QUOTED_LITERAL = ("\"" + """([^"\p{Cntrl}\\]|\\[\\/\\"bfnrt]|\\u[a-fA-F0-9]{4})*""" + "\"").r
+  private val SINGLE_QUOTED_LITERAL = ("'" + """([^'\p{Cntrl}\\]|\\[\\/\\"bfnrt]|\\u[a-fA-F0-9]{4})*""" + "'").r
+  private val REGULAR_TOKEN         = """([^\"'\s]+)""".r
+
   private def unquote(s: String): String = s.substring(1, s.length() - 1)
 
-  def stringLiteral: Parser[String] =
-    ("\"" + """([^"\p{Cntrl}\\]|\\[\\/\\"bfnrt]|\\u[a-fA-F0-9]{4})*""" + "\"").r ^^ { unquote(_) }
-  def quotation: Parser[String] =
-    ("'" + """([^'\p{Cntrl}\\]|\\[\\/\\"bfnrt]|\\u[a-fA-F0-9]{4})*""" + "'").r ^^ { unquote(_) }
-  def other: Parser[String]        = """([^\"'\s]+)""".r
-  def token: Parser[String]        = stringLiteral | quotation | other
-  def tokens: Parser[List[String]] = rep(token)
-
   def tokenize(line: String): Array[String] = {
-    val p = parseAll(tokens, line)
-    val r = p match {
-      case Success(result, next) => result
-      case Error(msg, next) => {
-        warn(msg)
-        List.empty
-      }
-      case Failure(msg, next) => {
-        warn(msg)
-        List.empty
+    parse(0, line).toArray
+  }
+
+  private def parse(pos: Int, line: String): List[String] = {
+    var cursor = pos
+
+    def skipWhiteSpaces: Unit = {
+      var toContinue = true
+      while (toContinue && cursor < line.length) {
+        val ch = line.charAt(cursor)
+        ch match {
+          case ' ' | '\t' | '\n' | '\r' =>
+            cursor += 1
+          case _ =>
+            toContinue = false
+        }
       }
     }
-    r.toArray
+
+    def parseToken: List[String] = {
+      REGULAR_TOKEN.findPrefixMatchOf(line.substring(cursor)) match {
+        case Some(m) =>
+          val token = m.matched
+          token :: parse(cursor + token.length, line)
+        case None =>
+          throw new IllegalArgumentException(s"Failed to parse token. pos:${pos}\n${line}")
+      }
+    }
+
+    skipWhiteSpaces
+    if (cursor >= line.length) {
+      Nil
+    } else {
+      val ch = line.charAt(cursor)
+      ch match {
+        case '\'' =>
+          SINGLE_QUOTED_LITERAL.findPrefixMatchOf(line.substring(cursor)) match {
+            case Some(m) =>
+              val token = m.matched
+              unquote(token) :: parse(cursor + token.length, line)
+            case None =>
+              parseToken
+          }
+        case '"' =>
+          DOUBLE_QUOTED_LITERAL.findPrefixMatchOf(line.substring(cursor)) match {
+            case Some(m) =>
+              val token = m.matched
+              unquote(token) :: parse(cursor + token.length, line)
+            case None =>
+              parseToken
+          }
+        case _ =>
+          parseToken
+      }
+    }
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -483,11 +483,6 @@ lazy val control =
       name := "airframe-control",
       description := "A library for controlling program flows and retrying"
     )
-    .jvmSettings(
-      libraryDependencies ++= Seq(
-        "org.scala-lang.modules" %% "scala-parser-combinators" % SCALA_PARSER_COMBINATOR_VERSION
-      )
-    )
     .dependsOn(log, airspecRef % Test)
 
 lazy val controlJVM = control.jvm
@@ -528,10 +523,7 @@ lazy val launcher =
     .settings(buildSettings)
     .settings(
       name := "airframe-launcher",
-      description := "Command-line program launcher",
-      libraryDependencies ++= Seq(
-        "org.scala-lang.modules" %% "scala-parser-combinators" % SCALA_PARSER_COMBINATOR_VERSION
-      )
+      description := "Command-line program launcher"
     )
     .dependsOn(surfaceJVM, controlJVM, codecJVM, airspecRefJVM % Test)
 


### PR DESCRIPTION
Implementing the tokenizer without using scala-parser-combinator. 