### PR TITLE
airframe-rx: Add MacroTask Executor as a dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -120,9 +120,7 @@ ThisBuild / publishTo := sonatypePublishToBundle.value
 
 val jsBuildSettings = Seq[Setting[_]](
   crossScalaVersions := targetScalaVersions,
-  coverageEnabled    := false,
-  // For addressing the fairness issue of the global ExecutorContext https://github.com/scala-js/scala-js/issues/4129
-  libraryDependencies += "org.scala-js" %%% "scala-js-macrotask-executor" % "1.0.0"
+  coverageEnabled    := false
 )
 
 val noPublish = Seq(
@@ -665,7 +663,9 @@ lazy val rx =
       )
     )
     .jsSettings(
-      jsBuildSettings
+      jsBuildSettings,
+      // For addressing the fairness issue of the global ExecutorContext https://github.com/scala-js/scala-js/issues/4129
+      libraryDependencies += "org.scala-js" %%% "scala-js-macrotask-executor" % "1.0.0"
     )
     .dependsOn(log, airspecRef % Test)
 


### PR DESCRIPTION
Scala.js 1.8.0 deprecates `ExecutionContext.global` https://www.scala-js.org/news/2021/12/10/announcing-scalajs-1.8.0/