### PR TITLE
Build AirSpec using a sub project

### DIFF
--- a/.github/workflows/release-airspec.yml
+++ b/.github/workflows/release-airspec.yml
@@ -1,0 +1,39 @@
+name: Release AirSpec
+
+on:
+  push:
+    tags:
+      - v*
+  workflow_dispatch:
+
+jobs:
+  publish_jvm:
+    name: Publish AirSpec
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 10000
+      # Fetch all tags so that sbt-dynver can find the previous release version
+      - run: git fetch --tags -f
+      # Install OpenJDK 11
+      - uses: olafurpg/setup-scala@v11
+        with:
+          java-version: zulu@1.11
+      - name: Setup GPG
+        env:
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+        run: echo $PGP_SECRET | base64 --decode | gpg --import --batch --yes
+      - name: Build bundle
+        env:
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+        run: |
+          ../sbt "+airspecJVM/publishSigned; +airspecJS/publishSigned"
+          DOTTY=true ../sbt airspecJVM/publishSigned
+        working-directory: ./airspec
+      - name: Release to Sonatype
+        env:
+          SONATYPE_USERNAME: '${{ secrets.SONATYPE_USER }}'
+          SONATYPE_PASSWORD: '${{ secrets.SONATYPE_PASS }}'
+        run: ../sbt sonatypeBundleRelease
+        working-directory: ./airspec

--- a/.github/workflows/sbt-integration.yml
+++ b/.github/workflows/sbt-integration.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Create a snapshot of Airframe
         run: ./sbt ++2.12.15 "projectJVM/publishLocal; projectJS/publishLocal"
       - name: Create a snapshot of AirSpec
-        run: ../sbt "airspecJVM/publishLocal; airspecJS/publishLocal"
+        run: ../sbt "+airspecJVM/publishLocal; +airspecJS/publishLocal"
         working-directory: ./airspec
       - name: Run sbt-airframe plugin tests
         run: AIRFRAME_VERSION=${AIRFRAME_VERSION} ./sbt scripted

--- a/.github/workflows/sbt-integration.yml
+++ b/.github/workflows/sbt-integration.yml
@@ -34,6 +34,9 @@ jobs:
         run: echo ${AIRFRAME_VERSION}
       - name: Create a snapshot of Airframe
         run: ./sbt ++2.12.15 "projectJVM/publishLocal; projectJS/publishLocal"
+      - name: Create a snapshot of AirSpec
+        run: ../sbt "airspecJVM/publishLocal; airspecJS/publishLocal"
+        working-directory: ./airspec
       - name: Run sbt-airframe plugin tests
         run: AIRFRAME_VERSION=${AIRFRAME_VERSION} ./sbt scripted
         working-directory: ./sbt-airframe

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -32,3 +32,11 @@ jobs:
         run: |
           ./sbt publishSnapshots
           DOTTY=true ./sbt projectDotty/publish
+      - name: Publish snapshots of AirSpec
+        env:
+          SONATYPE_USERNAME: '${{ secrets.SONATYPE_USER }}'
+          SONATYPE_PASSWORD: '${{ secrets.SONATYPE_PASS }}'
+        run: |
+          ../sbt "+airspecJVM/publish; +airspecJS/publish"
+          DOTTY=true ../sbt airspecJVM/publish
+        working-directory: ./airspec

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -37,6 +37,6 @@ jobs:
           SONATYPE_USERNAME: '${{ secrets.SONATYPE_USER }}'
           SONATYPE_PASSWORD: '${{ secrets.SONATYPE_PASS }}'
         run: |
-          ../sbt "+airspecJVM/publish; +airspecJS/publish"
+          ../sbt publishSnapshots
           DOTTY=true ../sbt airspecJVM/publish
         working-directory: ./airspec

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,8 +23,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: scalafmt test
+      - name: scalafmt
         run: ./sbt scalafmtCheckAll
+      - name: scalafmt airspec
+        run: ../sbt scalafmtCheckAll
+        working-directory: ./airspec
       - name: scalafmt sbt-airframe
         run: ./sbt scalafmtCheckAll
         working-directory: ./sbt-airframe

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -138,3 +138,24 @@ jobs:
         with:
           report_paths: '**/target/test-reports/TEST-*.xml'
           check_name: Test Report Scala.js / Scala 2.13
+  test_airspec:
+    name: AirSpec
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: olafurpg/setup-scala@v11
+        with:
+          java-version: zulu@1.11
+      - name: Scala JVM and Scala.js Test
+        run: ../sbt "++airspecJVM/test; ++airspecJS/test"
+        working-directory: ./airspec
+      - name: Scala 3 Test
+        run: DOTTY=true ../sbt airspecJVM/test
+        working-directory: ./airspec
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v2
+        if: always() # always run even if the previous step fails
+        with:
+          report_paths: '**/target/test-reports/TEST-*.xml'
+          check_name: Test Report AirSpec
+        working-directory: ./airspec

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,4 +158,3 @@ jobs:
         with:
           report_paths: '**/target/test-reports/TEST-*.xml'
           check_name: Test Report AirSpec
-        working-directory: ./airspec

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,5 +1,6 @@
 buildRoots = [
   ".",
+  "airspec",
   "sbt-airframe",
   "examples/rx-demo/gallery",
   "examples/rpc-examples/hello-rpc",

--- a/airspec/.scalafmt.conf
+++ b/airspec/.scalafmt.conf
@@ -1,0 +1,7 @@
+version = 3.2.1
+project.layout = StandardConvention
+runner.dialect = scala213source3
+maxColumn = 120
+style = defaultWithAlign
+optIn.breaksInsideChains = true
+docstrings.blankFirstLine = yes

--- a/airspec/README.md
+++ b/airspec/README.md
@@ -11,16 +11,24 @@ AirSpec uses pure Scala functions for writing test cases. This style requires no
 
 ## For Developers
 
+
 ```scala
 $ ../sbt
 
+// Publish a local snapshot of AirSpec for Scala 2.12, 2.13
+> publishAllLocal
+
+// Publish a snapshot of AirSpec for Scala 2.12, 2.13 to Sonatype
+> publishSnapshot
+
+// Building individual projects
 > airspecJVM/compile
 > airspecJVM/test
 > airspecJVM/publishLocal
 
-
 > airspecJS/compile
 > airspecJS/test
+> airspecJS/publishLocal
 ```
 
 For Scala 3, launch sbt with DOTTY=true environment variable:

--- a/airspec/README.md
+++ b/airspec/README.md
@@ -7,3 +7,32 @@ AirSpec uses pure Scala functions for writing test cases. This style requires no
 
 - [GitHub: AirSpec](https://github.com/wvlet/airframe/tree/master/airspec)
 - [Documentation](https://wvlet.org/airframe/docs/airspec)
+
+
+## For Developers
+
+```scala
+$ ../sbt
+
+> airspecJVM/compile
+> airspecJVM/test
+> airspecJVM/publishLocal
+
+
+> airspecJS/compile
+> airspecJS/test
+```
+
+For Scala 3, launch sbt with DOTTY=true environment variable:
+
+```scala
+$ DOTTY=true ../sbt
+```
+
+
+Scals.js + Scala 3 version is not natively built, but you can use AirSpec by importing it with `.cross(CrossVersion.for3Use2_13)`:
+
+```scala
+libraryDependencies +=
+ ("org.wvlet.airframe" %% "airspec" % AIRSPEC_VERSION).cross(CrossVersion.for3Use2_13)
+```

--- a/airspec/build.sbt
+++ b/airspec/build.sbt
@@ -1,0 +1,340 @@
+// Reload build.sbt on changes
+Global / onChangedBuildSource := ReloadOnSourceChanges
+
+val SCALA_2_12          = "2.12.15"
+val SCALA_2_13          = "2.13.7"
+val SCALA_3_0           = "3.1.0"
+val targetScalaVersions = SCALA_2_13 :: SCALA_2_12 :: Nil
+val withDotty           = SCALA_3_0 :: targetScalaVersions
+
+val SCALACHECK_VERSION           = "1.15.4"
+val JS_JAVA_LOGGING_VERSION      = "1.0.0"
+val JAVAX_ANNOTATION_API_VERSION = "1.3.2"
+
+// A build configuration switch for working on Dotty migration. This needs to be removed eventually
+val DOTTY = sys.env.isDefinedAt("DOTTY")
+
+// We MUST use Scala 2.12 for building sbt-airframe
+ThisBuild / scalaVersion := {
+  if (DOTTY) SCALA_3_0
+  else SCALA_2_13
+}
+ThisBuild / organization := "org.wvlet.airframe"
+
+// Use dynamic snapshot version strings for non tagged versions
+ThisBuild / dynverSonatypeSnapshots := true
+// Use coursier friendly version separator
+ThisBuild / dynverSeparator := "-"
+
+val noPublish = Seq(
+  publishArtifact := false,
+  publish         := {},
+  publishLocal    := {},
+  // Explicitly skip the doc task because protobuf related Java files causes no type found error
+  Compile / doc / sources                := Seq.empty,
+  Compile / packageDoc / publishArtifact := false
+)
+
+val buildSettings = Seq[Setting[_]](
+  licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html")),
+  homepage := Some(url("https://wvlet.org/airframe")),
+  scmInfo := Some(
+    ScmInfo(
+      browseUrl = url("https://github.com/wvlet/airframe"),
+      connection = "scm:git@github.com:wvlet/airframe.git"
+    )
+  ),
+  developers := List(
+    Developer(id = "leo", name = "Taro L. Saito", email = "leo@xerial.org", url = url("http://xerial.org/leo"))
+  ),
+  // Exclude compile-time only projects. This is a workaround for bloop,
+  // which cannot resolve Optional dependencies nor compile-internal dependencies.
+  pomPostProcess     := excludePomDependency(Seq("airspec_2.12", "airspec_2.13")),
+  crossScalaVersions := targetScalaVersions,
+  crossPaths         := true,
+  publishMavenStyle  := true,
+  javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
+  scalacOptions ++= Seq(
+    "-feature",
+    "-deprecation"
+  ) ++ {
+    if (DOTTY) {
+      Seq.empty
+    } else {
+      Seq(
+        // Necessary for tracking source code range in airframe-rx demo
+        "-Yrangepos"
+      )
+    }
+  },
+  testFrameworks += new TestFramework("wvlet.airspec.Framework"),
+  libraryDependencies ++= Seq(
+    "org.scalacheck" %%% "scalacheck" % SCALACHECK_VERSION % Test
+  ) ++ {
+    if (DOTTY)
+      Seq.empty
+    else
+      Seq("org.scala-lang.modules" %%% "scala-collection-compat" % "2.6.0")
+  }
+)
+
+def crossBuildSources(scalaBinaryVersion: String, baseDir: String, srcType: String = "main"): Seq[sbt.File] = {
+  val scalaMajorVersion = scalaBinaryVersion.split("\\.").head
+  for (suffix <- Seq("", s"-${scalaBinaryVersion}", s"-${scalaMajorVersion}").distinct)
+    yield {
+      file(s"${baseDir}/src/${srcType}/scala${suffix}")
+    }
+}
+
+// https://stackoverflow.com/questions/41670018/how-to-prevent-sbt-to-include-test-dependencies-into-the-pom
+import scala.xml.{Node => XmlNode, NodeSeq => XmlNodeSeq, _}
+import scala.xml.transform.{RewriteRule, RuleTransformer}
+
+def excludePomDependency(excludes: Seq[String]) = { node: XmlNode =>
+  def isExcludeTarget(artifactId: String): Boolean =
+    excludes.exists(artifactId.startsWith(_))
+
+  def artifactId(e: Elem): Option[String] =
+    e.child.find(_.label == "artifactId").map(_.text.trim())
+
+  new RuleTransformer(new RewriteRule {
+    override def transform(node: XmlNode): XmlNodeSeq =
+      node match {
+        case e: Elem
+            if e.label == "dependency"
+              && artifactId(e).exists(id => isExcludeTarget(id)) =>
+          Comment(s"Excluded compile-time only dependency: ${artifactId(e).getOrElse("")}")
+        case _ =>
+          node
+      }
+  }).transform(node).head
+}
+
+/**
+  * AirSpec build definitions.
+  *
+  * To make AirSpec a standalone library without any cyclic project references, AirSpec embeds the source code of
+  * airframe-log, di, surface, etc.
+  *
+  * Since airframe-log, di, and surfaces uses Scala macros whose def-macros cannot be called within the same project, we
+  * need to split the source code into 4 projects:
+  *
+  *   - airspec-log (dependsOn airframe-log's source)
+  *   - airspec-core (di-macros, surface) # surface uses airframe-log macros
+  *   - airspec-deps (di, metrics) # di uses di-macros
+  *   - airspec (test-interface) # Need to split this as IntelliJ cannot find classes in unmanagedSourceDirectories
+  *
+  * airspec.jar will be an all-in-one jar with airframe-log, di, surface, metrics, etc.
+  */
+val airspecLogDependencies  = Seq("airframe-log")
+val airspecCoreDependencies = Seq("airframe-di-macros", "airframe-surface")
+val airspecDependencies     = Seq("airframe-di", "airframe-metrics")
+
+// Setting keys for AirSpec
+val airspecDependsOn =
+  settingKey[Seq[String]]("Dependent module names of airspec projects")
+
+// Read sources from the sibling projects
+val airspecBuildSettings = Seq[Setting[_]](
+  Compile / unmanagedSourceDirectories ++= {
+    val baseDir = (ThisBuild / baseDirectory).value.getAbsoluteFile
+    val sv      = scalaBinaryVersion.value
+    val sourceDirs =
+      for (m <- airspecDependsOn.value; infix <- Seq("")) yield {
+        crossBuildSources(sv, s"${baseDir}/../${m}${infix}")
+      }
+    sourceDirs.flatten
+  }
+)
+
+val airspecJVMBuildSettings = Seq[Setting[_]](
+  Compile / unmanagedSourceDirectories ++= {
+    val baseDir = (ThisBuild / baseDirectory).value.getAbsoluteFile
+    val sv      = scalaBinaryVersion.value
+    val sourceDirs =
+      for (m <- airspecDependsOn.value; folder <- Seq(".jvm")) yield {
+        crossBuildSources(sv, s"${baseDir}/../${m}/${folder}")
+      }
+    sourceDirs.flatten
+  }
+)
+
+val airspecJSBuildSettings = Seq[Setting[_]](
+  Compile / unmanagedSourceDirectories ++= {
+    val baseDir = (ThisBuild / baseDirectory).value.getAbsoluteFile
+    val sv      = scalaBinaryVersion.value
+    val sourceDirs =
+      for (m <- airspecDependsOn.value; folder <- Seq(".js")) yield {
+        crossBuildSources(sv, s"${baseDir}/../${m}/${folder}")
+      }
+    sourceDirs.flatten
+  }
+)
+
+lazy val airspecLog =
+  crossProject(JSPlatform, JVMPlatform)
+    .crossType(CrossType.Pure)
+    .in(file("airspec-log"))
+    .settings(buildSettings)
+    .settings(noPublish)
+    .settings(
+      airspecDependsOn := airspecLogDependencies,
+      airspecBuildSettings,
+      name        := "airspec-log",
+      description := "airframe-log for AirSpec",
+      libraryDependencies ++= {
+        scalaVersion.value match {
+          case s if DOTTY =>
+            Seq.empty
+          case v =>
+            Seq("org.scala-lang" % "scala-reflect" % v % Provided)
+        }
+      }
+    )
+    .jvmSettings(
+      airspecJVMBuildSettings,
+      libraryDependencies ++= Seq(
+        // For rotating log files
+        "ch.qos.logback" % "logback-core" % "1.2.10"
+      )
+    )
+    .jsSettings(
+      airspecJSBuildSettings,
+      libraryDependencies ++= Seq(
+        ("org.scala-js" %%% "scalajs-java-logging" % JS_JAVA_LOGGING_VERSION).cross(CrossVersion.for3Use2_13)
+      )
+    )
+
+lazy val airspecLogJVM = airspecLog.jvm
+lazy val airspecLogJS  = airspecLog.js
+
+lazy val airspecCore =
+  crossProject(JSPlatform, JVMPlatform)
+    .crossType(CrossType.Pure)
+    .in(file("airspec-core"))
+    .settings(buildSettings)
+    .settings(noPublish)
+    .settings(
+      airspecDependsOn := airspecCoreDependencies,
+      airspecBuildSettings,
+      name        := "airspec-core",
+      description := "A core module of AirSpec with Surface and DI macros",
+      libraryDependencies ++= {
+        scalaVersion.value match {
+          case s if s.startsWith("3.") =>
+            Seq.empty
+          case v =>
+            Seq(
+              ("org.scala-lang" % "scala-reflect"  % v),
+              ("org.scala-lang" % "scala-compiler" % v % Provided)
+            )
+        }
+      }
+    )
+    .jvmSettings(
+      airspecJVMBuildSettings,
+      libraryDependencies ++= {
+        scalaVersion.value match {
+          case s if s.startsWith("3.") =>
+            Seq(
+              "org.scala-lang" %% "scala3-tasty-inspector" % s,
+              "org.scala-lang" %% "scala3-staging"         % s
+            )
+          case _ => Seq.empty
+        }
+      },
+      Compile / packageBin / mappings ++= (airspecLogJVM / Compile / packageBin / mappings).value,
+      Compile / packageSrc / mappings ++= (airspecLogJVM / Compile / packageSrc / mappings).value
+    )
+    .jsSettings(
+      airspecJSBuildSettings,
+      Compile / packageBin / mappings ++= (airspecLogJS / Compile / packageBin / mappings).value
+        .filter(x => x._2 != "JS_DEPENDENCIES"),
+      Compile / packageSrc / mappings ++= (airspecLogJS / Compile / packageSrc / mappings).value
+    )
+    .dependsOn(airspecLog)
+
+lazy val airspecCoreJVM = airspecCore.jvm
+lazy val airspecCoreJS  = airspecCore.js
+
+lazy val airspecDeps =
+  crossProject(JSPlatform, JVMPlatform)
+    .crossType(CrossType.Pure)
+    .in(file("airspec-deps"))
+    .settings(buildSettings)
+    .settings(noPublish)
+    .settings(
+      airspecDependsOn := airspecDependencies,
+      airspecBuildSettings,
+      name        := "airspec-deps",
+      description := "Dependencies of AirSpec"
+    )
+    .jvmSettings(
+      airspecJVMBuildSettings,
+      libraryDependencies ++= Seq(
+        "javax.annotation" % "javax.annotation-api" % JAVAX_ANNOTATION_API_VERSION
+      ),
+      Compile / packageBin / mappings ++= (airspecCoreJVM / Compile / packageBin / mappings).value,
+      Compile / packageSrc / mappings ++= (airspecCoreJVM / Compile / packageSrc / mappings).value
+    )
+    .jsSettings(
+      airspecJSBuildSettings,
+      Compile / packageBin / mappings ++= (airspecCoreJS / Compile / packageBin / mappings).value
+        .filter(x => x._2 != "JS_DEPENDENCIES"),
+      Compile / packageSrc / mappings ++= (airspecCoreJS / Compile / packageSrc / mappings).value
+    )
+    .dependsOn(airspecCore)
+
+lazy val airspecDepsJVM = airspecDeps.jvm
+lazy val airspecDepsJS  = airspecDeps.js
+
+lazy val airspec =
+  crossProject(JSPlatform, JVMPlatform)
+    .crossType(CrossType.Pure)
+    .in(file("."))
+    .settings(buildSettings)
+    .settings(
+      airspecDependsOn := Seq.empty,
+      airspecBuildSettings,
+      name        := "airspec",
+      description := "AirSpec: A Functional Testing Framework for Scala",
+      libraryDependencies ++= Seq(
+        "org.scalacheck" %%% "scalacheck" % SCALACHECK_VERSION % Optional
+      ),
+      // A workaround for bloop, which cannot resolve Optional dependencies
+      pomPostProcess := excludePomDependency(Seq("airspec-deps", "airspec_2.12", "airspec_2.13"))
+    )
+    .jvmSettings(
+      // Embed dependent project codes to make airspec a single jar
+      Compile / packageBin / mappings ++= (airspecDepsJVM / Compile / packageBin / mappings).value,
+      Compile / packageSrc / mappings ++= (airspecDepsJVM / Compile / packageSrc / mappings).value,
+      libraryDependencies ++= {
+        scalaVersion.value match {
+          case sv if sv.startsWith("3.") =>
+            Seq(
+              "org.scala-sbt" % "test-interface" % "1.0"
+            )
+          case sv =>
+            Seq(
+              "org.scala-lang" % "scala-reflect"  % sv,
+              "org.scala-sbt"  % "test-interface" % "1.0"
+            )
+        }
+      }
+    )
+    .jsSettings(
+      Compile / packageBin / mappings ++= (airspecDepsJS / Compile / packageBin / mappings).value
+        .filter(x => x._2 != "JS_DEPENDENCIES"),
+      Compile / packageSrc / mappings ++= (airspecDepsJS / Compile / packageSrc / mappings).value,
+      libraryDependencies ++= Seq(
+        ("org.scala-js"        %% "scalajs-test-interface" % scalaJSVersion).cross(CrossVersion.for3Use2_13),
+        ("org.portable-scala" %%% "portable-scala-reflect" % "1.1.1").cross(CrossVersion.for3Use2_13)
+      )
+    )
+    .dependsOn(airspecDeps % Provided) // Use Provided dependency for bloop, and remove it later with pomPostProcess
+
+lazy val airspecJVM = airspec.jvm
+lazy val airspecJS  = airspec.js
+
+def isAirSpecClass(mapping: (File, String)): Boolean =
+  mapping._2.startsWith("wvlet/airspec/")

--- a/airspec/build.sbt
+++ b/airspec/build.sbt
@@ -53,6 +53,7 @@ val buildSettings = Seq[Setting[_]](
   crossScalaVersions := targetScalaVersions,
   crossPaths         := true,
   publishMavenStyle  := true,
+  versionScheme      := None,
   javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
   scalacOptions ++= Seq(
     "-feature",
@@ -68,9 +69,7 @@ val buildSettings = Seq[Setting[_]](
     }
   },
   testFrameworks += new TestFramework("wvlet.airspec.Framework"),
-  libraryDependencies ++= Seq(
-    "org.scalacheck" %%% "scalacheck" % SCALACHECK_VERSION % Test
-  ) ++ {
+  libraryDependencies ++= {
     if (DOTTY)
       Seq.empty
     else

--- a/airspec/build.sbt
+++ b/airspec/build.sbt
@@ -26,6 +26,9 @@ ThisBuild / dynverSonatypeSnapshots := true
 // Use coursier friendly version separator
 ThisBuild / dynverSeparator := "-"
 
+// We need to define this globally as a workaround for https://github.com/sbt/sbt/pull/3760
+ThisBuild / publishTo := sonatypePublishToBundle.value
+
 val noPublish = Seq(
   publishArtifact := false,
   publish         := {},
@@ -53,7 +56,6 @@ val buildSettings = Seq[Setting[_]](
   crossScalaVersions := targetScalaVersions,
   crossPaths         := true,
   publishMavenStyle  := true,
-  versionScheme      := None,
   javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
   scalacOptions ++= Seq(
     "-feature",

--- a/airspec/build.sbt
+++ b/airspec/build.sbt
@@ -29,6 +29,10 @@ ThisBuild / dynverSeparator := "-"
 // We need to define this globally as a workaround for https://github.com/sbt/sbt/pull/3760
 ThisBuild / publishTo := sonatypePublishToBundle.value
 
+// For Sonatype
+ThisBuild / sonatypeProfileName := "org.wvlet"
+ThisBuild / sonatypeSessionName := s"${sonatypeSessionName.value} for AirSpec"
+
 val noPublish = Seq(
   publishArtifact := false,
   publish         := {},

--- a/airspec/project/build.properties
+++ b/airspec/project/build.properties
@@ -1,0 +1,14 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+sbt.version=1.5.8

--- a/airspec/project/plugin.sbt
+++ b/airspec/project/plugin.sbt
@@ -1,0 +1,21 @@
+addSbtPlugin("org.xerial.sbt"     % "sbt-sonatype"             % "3.9.10")
+addSbtPlugin("com.github.sbt"     % "sbt-pgp"                  % "2.1.2")
+addSbtPlugin("org.scoverage"      % "sbt-scoverage"            % "1.9.2")
+addSbtPlugin("org.scalameta"      % "sbt-scalafmt"             % "2.4.5")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.1.0")
+addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"            % "0.10.0")
+
+addDependencyTreePlugin
+
+// For Scala.js
+val SCALAJS_VERSION = sys.env.getOrElse("SCALAJS_VERSION", "1.8.0")
+addSbtPlugin("org.scala-js"  % "sbt-scalajs"         % SCALAJS_VERSION)
+addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.20.0")
+libraryDependencies ++= (
+  Seq("org.scala-js" %% "scalajs-env-jsdom-nodejs" % "1.1.0")
+)
+
+// For setting explicit versions for each commit
+addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
+
+scalacOptions ++= Seq("-deprecation", "-feature")

--- a/airspec/src/main/scala-3/wvlet/airspec/AirSpecSpiCompat.scala
+++ b/airspec/src/main/scala-3/wvlet/airspec/AirSpecSpiCompat.scala
@@ -39,7 +39,14 @@ object AirSpecTestBuilder extends wvlet.log.LogSupport {
       v.spec.addLocalTestDef(AirSpecDefF0(v.name, v.design, r, body))
     }
     def addF1[D1, R](d1: Surface, r: Surface, body: D1 => R): Unit = {
-      v.spec.addLocalTestDef(AirSpecDefF1(v.name, v.design, d1, r, body))
+      val spec = body match {
+        case s: Seq[_] =>
+          // Workaround for: https://github.com/wvlet/airframe/issues/1845
+          AirSpecDefF0(v.name, v.design, r, wvlet.airframe.LazyF0(() => body))
+        case _ =>
+          AirSpecDefF1(v.name, v.design, d1, r, body)
+      }
+      v.spec.addLocalTestDef(spec)
     }
     def addF2[D1, D2, R](d1: Surface, d2: Surface, r: Surface, body: (D1, D2) => R): Unit = {
       v.spec.addLocalTestDef(AirSpecDefF2(v.name, v.design, d1, d2, r, body))

--- a/airspec/src/test/scala/examples/F0Spec.scala
+++ b/airspec/src/test/scala/examples/F0Spec.scala
@@ -42,7 +42,7 @@ object F0Spec extends AirSpec {
     f1.incrementAndGet()
   }
 
-  def fun1: Long => Int = { s: Long =>
+  def fun1: Long => Int = { (s: Long) =>
     0
   }
 


### PR DESCRIPTION
This is for simplifying build configuration as IntelliJ IDEA cannot properly scan source code files referenced multiple times in the same projects. 
- [x] Split AirSpec as a sub project within the same GitHub repository
- [x] Use libraryDependency for AirSpec
- [ ] Tell @SethTisue that we need to change the build configuration of the scala community build to build AirSpec for Scala JVM like this:
```scala
cd airspec
sbt +airspecJVM/publishLocal
```
