### PR TITLE
Share same scalafmt config between airframe and airspec

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 3.3.3
+version = 3.4.0
 project.layout = StandardConvention
 runner.dialect = scala213source3
 maxColumn = 120

--- a/airspec/.scalafmt.conf
+++ b/airspec/.scalafmt.conf
@@ -1,7 +1,0 @@
-version = 3.3.1
-project.layout = StandardConvention
-runner.dialect = scala213source3
-maxColumn = 120
-style = defaultWithAlign
-optIn.breaksInsideChains = true
-docstrings.blankFirstLine = yes

--- a/airspec/build.sbt
+++ b/airspec/build.sbt
@@ -47,6 +47,9 @@ ThisBuild / publishTo           := sonatypePublishToBundle.value
 ThisBuild / sonatypeProfileName := "org.wvlet"
 ThisBuild / sonatypeSessionName := s"${sonatypeSessionName.value} for AirSpec"
 
+// Share
+ThisBuild / scalafmtConfig := file("../.scalafmt.conf")
+
 val noPublish = Seq(
   publish / skip  := true,
   publishArtifact := false,

--- a/airspec/src/main/scala/wvlet/airspec/spi/AirSpecContext.scala
+++ b/airspec/src/main/scala/wvlet/airspec/spi/AirSpecContext.scala
@@ -20,7 +20,6 @@ import wvlet.airspec.{AirSpecDef, AirSpecSpi}
   * AirSpecContext is an interface to pass the test environment data to individual test methods.
   *
   * Spec: global
-  * -
   */
 trait AirSpecContext {
   def hasChildTask: Boolean


### PR DESCRIPTION
Supersedes #2042 

I think this makes easy to version up scalafmt