### PR TITLE
Use munit temporarily to avoid airspec <-> surface circular reference

### DIFF
--- a/airframe-surface/.js/src/test/scala/wvlet/airframe/surface/AirSpecBridgeCompat.scala
+++ b/airframe-surface/.js/src/test/scala/wvlet/airframe/surface/AirSpecBridgeCompat.scala
@@ -13,21 +13,6 @@
  */
 package wvlet.airframe.surface
 
-class RecordSurfaceTest extends munit.FunSuite {
-  test("build custom surface") {
-    val p1 = RecordParameter(0, "p1", Primitive.Int)
-    val p2 = RecordParameter(1, "p2", Primitive.String)
-    val p3 = RecordParameter(2, "p3", OptionSurface(classOf[Option[Long]], Primitive.Long))
-    val s = RecordSurface
-      .newSurface("myrecord")
-      .addParam(p1)
-      .addParam(p2)
-      .addParam(p3)
-
-    assertEquals(s.typeArgs, Seq.empty)
-    assertEquals(s.params.length, 3)
-    assertEquals(s.params(0), p1)
-    assertEquals(s.params(1), p2)
-    assertEquals(s.params(2), p3)
-  }
+object AirSpecBridgeCompat {
+  val isScalaJS: Boolean = true
 }

--- a/airframe-surface/.jvm/src/test/scala-3/wvlet/airframe/surface/reflect/TastySurfaceFactoryTest.scala
+++ b/airframe-surface/.jvm/src/test/scala-3/wvlet/airframe/surface/reflect/TastySurfaceFactoryTest.scala
@@ -1,12 +1,13 @@
 package wvlet.airframe.surface.reflect
 
-import wvlet.airspec.AirSpec
+import wvlet.log.LogSupport
+import wvlet.airframe.surface.AirSpecBridge
 
 case class Person(id: Int, name: String) {
   def hello: String = "hello"
 }
 
-object TastySurfaceFactoryTest extends AirSpec {
+class TastySurfaceFactoryTest extends munit.FunSuite with AirSpecBridge with LogSupport {
 
   test("of[A]") {
     val s = TastySurfaceFactory.of[Person]

--- a/airframe-surface/.jvm/src/test/scala/wvlet/airframe/surface/AbstractTypeTest.scala
+++ b/airframe-surface/.jvm/src/test/scala/wvlet/airframe/surface/AbstractTypeTest.scala
@@ -1,8 +1,6 @@
 package wvlet.airframe.surface
 
-import wvlet.airspec.AirSpec
-
-object AbstractTypeTest extends AirSpec {
+class AbstractTypeTest extends munit.FunSuite {
 
   trait Abst {
     def hello = "hello abst"
@@ -13,9 +11,9 @@ object AbstractTypeTest extends AirSpec {
 
   test("object factory of an abstract type impl") {
     val s = Surface.of[AbstImpl]
-    s.objectFactory shouldBe defined
+    assert(s.objectFactory.isDefined)
 
     val a = s.objectFactory.get.newInstance(Seq.empty).asInstanceOf[Abst]
-    a.hello shouldBe "hello impl"
+    assertEquals(a.hello, "hello impl")
   }
 }

--- a/airframe-surface/.jvm/src/test/scala/wvlet/airframe/surface/AirSpecBridgeCompat.scala
+++ b/airframe-surface/.jvm/src/test/scala/wvlet/airframe/surface/AirSpecBridgeCompat.scala
@@ -13,21 +13,6 @@
  */
 package wvlet.airframe.surface
 
-class RecordSurfaceTest extends munit.FunSuite {
-  test("build custom surface") {
-    val p1 = RecordParameter(0, "p1", Primitive.Int)
-    val p2 = RecordParameter(1, "p2", Primitive.String)
-    val p3 = RecordParameter(2, "p3", OptionSurface(classOf[Option[Long]], Primitive.Long))
-    val s = RecordSurface
-      .newSurface("myrecord")
-      .addParam(p1)
-      .addParam(p2)
-      .addParam(p3)
-
-    assertEquals(s.typeArgs, Seq.empty)
-    assertEquals(s.params.length, 3)
-    assertEquals(s.params(0), p1)
-    assertEquals(s.params(1), p2)
-    assertEquals(s.params(2), p3)
-  }
+object AirSpecBridgeCompat {
+  val isScalaJS: Boolean = false
 }

--- a/airframe-surface/.jvm/src/test/scala/wvlet/airframe/surface/InnerClassTest.scala
+++ b/airframe-surface/.jvm/src/test/scala/wvlet/airframe/surface/InnerClassTest.scala
@@ -13,26 +13,25 @@
  */
 package wvlet.airframe.surface
 
-import wvlet.airspec.AirSpec
 import wvlet.airframe.surface.reflect.RuntimeGenericSurface
 
 /**
   */
-class InnerClassTest extends AirSpec {
+class InnerClassTest extends munit.FunSuite {
   case class A(id: Int, name: String)
 
   test("pass inner class context to Surface") {
     val s = Surface.of[A]
-    debug(s.asInstanceOf[RuntimeGenericSurface].outer.get.getClass())
+    println(s.asInstanceOf[RuntimeGenericSurface].outer.get.getClass())
     val a = s.objectFactory.map { x => x.newInstance(Seq(1, "leo")) }
-    a shouldBe Some(A(1, "leo"))
+    assertEquals(a, Some(A(1, "leo")))
   }
 
   test("find an inner class inside a code block") {
     new {
       val s = Surface.of[A]
       val a = s.objectFactory.map { x => x.newInstance(Seq(1, "leo")) }
-      a shouldBe Some(A(1, "leo"))
+      assertEquals(a, Some(A(1, "leo")))
     }
   }
 }

--- a/airframe-surface/.jvm/src/test/scala/wvlet/airframe/surface/reflect/NamedParameterTest.scala
+++ b/airframe-surface/.jvm/src/test/scala/wvlet/airframe/surface/reflect/NamedParameterTest.scala
@@ -12,15 +12,13 @@
  * limitations under the License.
  */
 package wvlet.airframe.surface.reflect
-import wvlet.airspec.AirSpec
 
-import scala.concurrent.Future
 import scala.language.higherKinds
 import wvlet.airframe.surface.Surface
 
 /**
   */
-object NamedParameterTest extends AirSpec {
+class NamedParameterTest extends munit.FunSuite {
 
   trait MyService[F[_]] {
     def hello: F[String]
@@ -30,13 +28,13 @@ object NamedParameterTest extends AirSpec {
 
   test("read F[_]") {
     val s = Surface.of[MyService[A]]
-    s.toString shouldBe "MyService[A]"
+    assertEquals(s.toString, "MyService[A]")
 
     val m = Surface.methodsOf[MyService[A]]
-    m.headOption shouldBe defined
+    assert(m.headOption.isDefined)
 
     val m1 = m.head
     // info(m1.returnType.getClass())
-    m1.returnType.toString shouldBe "F[String]"
+    assertEquals(m1.returnType.toString, "F[String]")
   }
 }

--- a/airframe-surface/.jvm/src/test/scala/wvlet/airframe/surface/reflect/RuntimeSurfaceTest.scala
+++ b/airframe-surface/.jvm/src/test/scala/wvlet/airframe/surface/reflect/RuntimeSurfaceTest.scala
@@ -61,14 +61,14 @@ class RuntimeSurfaceTest extends SurfaceSpec {
 
   test("resolve trait type") {
     val s = RuntimeSurface.of[TraitOnly]
-    s.isAlias shouldBe false
-    s.rawType shouldBe classOf[TraitOnly]
+    assertEquals(s.isAlias, false)
+    assert(s.rawType == classOf[TraitOnly])
 
     val m = Surface.methodsOf[TraitOnly].head
-    m.owner.isAlias shouldNotBe true
-    m.owner.rawType shouldBe classOf[TraitOnly]
+    assertEquals(m.owner.isAlias, false)
+    assert(m.owner.rawType == classOf[TraitOnly])
 
-    m.findAnnotationOf[secret] shouldBe defined
+    assert(m.findAnnotationOf[secret].isDefined)
   }
 
   test("Find surface from Class[_]") {

--- a/airframe-surface/src/test/scala/wvlet/airframe/surface/AirSpecBridge.scala
+++ b/airframe-surface/src/test/scala/wvlet/airframe/surface/AirSpecBridge.scala
@@ -13,21 +13,15 @@
  */
 package wvlet.airframe.surface
 
-class RecordSurfaceTest extends munit.FunSuite {
-  test("build custom surface") {
-    val p1 = RecordParameter(0, "p1", Primitive.Int)
-    val p2 = RecordParameter(1, "p2", Primitive.String)
-    val p3 = RecordParameter(2, "p3", OptionSurface(classOf[Option[Long]], Primitive.Long))
-    val s = RecordSurface
-      .newSurface("myrecord")
-      .addParam(p1)
-      .addParam(p2)
-      .addParam(p3)
-
-    assertEquals(s.typeArgs, Seq.empty)
-    assertEquals(s.params.length, 3)
-    assertEquals(s.params(0), p1)
-    assertEquals(s.params(1), p2)
-    assertEquals(s.params(2), p3)
+/**
+  * Provide AirSpec-like helper
+  */
+trait AirSpecBridge extends munit.Assertions {
+  def isScalaJS: Boolean = AirSpecBridgeCompat.isScalaJS
+  def pendingUntil(msg: String): Unit = {
+    assume(false, msg)
+  }
+  def pending(msg: String): Unit = {
+    assume(false, msg)
   }
 }

--- a/airframe-surface/src/test/scala/wvlet/airframe/surface/AliasSurfaceTest.scala
+++ b/airframe-surface/src/test/scala/wvlet/airframe/surface/AliasSurfaceTest.scala
@@ -12,11 +12,12 @@
  * limitations under the License.
  */
 package wvlet.airframe.surface
-import wvlet.airspec.AirSpec
+
+import wvlet.log.LogSupport
 
 /**
   */
-object AliasSurfaceTest extends AirSpec {
+class AliasSurfaceTest extends munit.FunSuite with LogSupport {
 
   case class Holder[A](v: A)
   type MyInt = Holder[Int]

--- a/airframe-surface/src/test/scala/wvlet/airframe/surface/CNameTest.scala
+++ b/airframe-surface/src/test/scala/wvlet/airframe/surface/CNameTest.scala
@@ -13,9 +13,7 @@
  */
 package wvlet.airframe.surface
 
-import wvlet.airspec.AirSpec
-
-class CNameTest extends AirSpec {
+class CNameTest extends munit.FunSuite {
   test("convert to snakeCase") {
     assert(CName("AirframeSurface").snakeCase == "airframe_surface")
     assert(CName("airframe_surface").snakeCase == "airframe_surface")
@@ -50,16 +48,16 @@ class CNameTest extends AirSpec {
 
   test("null values") {
     val nullName = CName(null)
-    nullName.canonicalName shouldBe ""
-    nullName.naturalName shouldBe ""
+    assertEquals(nullName.canonicalName, "")
+    assertEquals(nullName.naturalName, "")
   }
 
   test("comparison") {
     val a = CName("Apple")
     val b = CName("Banana")
-    a.compareTo(b) < 0 shouldBe true
-    a shouldBe a
-    a shouldNotBe b
-    a.hashCode shouldNotBe b.hashCode
+    assertEquals(a.compareTo(b) < 0, true)
+    assertEquals(a, a)
+    assertNotEquals(a, b)
+    assertNotEquals(a.hashCode, b.hashCode)
   }
 }

--- a/airframe-surface/src/test/scala/wvlet/airframe/surface/EnumTest.scala
+++ b/airframe-surface/src/test/scala/wvlet/airframe/surface/EnumTest.scala
@@ -12,12 +12,10 @@
  * limitations under the License.
  */
 package wvlet.airframe.surface
-import wvlet.airspec.AirSpec
-import wvlet.log.Logger
 
 /**
   */
-object EnumTest extends AirSpec {
+object EnumTest {
 
   sealed trait Color
   case object Blue extends Color
@@ -29,14 +27,18 @@ object EnumTest extends AirSpec {
       values.find(_.toString == s)
     }
   }
+}
+
+class EnumTest extends munit.FunSuite {
+  import EnumTest._
 
   test("Find Surface.stringExtractor") {
     Surface.of[Color] match {
       case s: EnumSurface =>
         val f = s.stringExtractor
-        f(classOf[Color], "Blue") shouldBe Some(Blue)
-        f(classOf[Color], "Red") shouldBe Some(Red)
-        f(classOf[Color], "White") shouldBe empty
+        assertEquals(f(classOf[Color], "Blue"), Some(Blue))
+        assertEquals(f(classOf[Color], "Red"), Some(Red))
+        assertEquals(f(classOf[Color], "White"), None)
       case other =>
         fail(s"EnumSurface should be used: ${other.getClass}")
     }

--- a/airframe-surface/src/test/scala/wvlet/airframe/surface/MethodSurfaceTest.scala
+++ b/airframe-surface/src/test/scala/wvlet/airframe/surface/MethodSurfaceTest.scala
@@ -71,8 +71,8 @@ class MethodSurfaceTest extends SurfaceSpec {
     assert(arg2.isStatic == false)
 
     // Hide protected/private methods
-    m.find(_.name == "helloProtected") shouldBe empty
-    m.find(_.name == "helloPrivate") shouldBe empty
+    assert(m.find(_.name == "helloProtected").isEmpty)
+    assert(m.find(_.name == "helloPrivate").isEmpty)
 
     val f = m.find(_.name == "helloFinal").get
     assert(f.isAbstract == false)
@@ -88,28 +88,28 @@ class MethodSurfaceTest extends SurfaceSpec {
 
   test("inherit parent methods") {
     val m = Surface.methodsOf[B]
-    m.find(_.name == "helloParent") shouldBe defined
+    assert(m.find(_.name == "helloParent").isDefined)
   }
 
   test("support generic methods") {
     val m = Surface.methodsOf[C]
-    m.find(_.name == "generic") shouldBe defined
+    assert(m.find(_.name == "generic").isDefined)
   }
 
   test("find method default parameter") {
     val ms = Surface.methodsOf[D]
     val m  = ms.find(_.name == "hello").get
-    m.args.headOption shouldBe defined
+    assert(m.args.headOption.isDefined)
     val h = m.args.head
 
     val d = new D
     val v = h.getMethodArgDefaultValue(d)
     if (!isScalaJS) {
       // Scala.js doesn't support reading default method arguments
-      v shouldBe Some("hello")
+      assertEquals(v, Some("hello"))
     }
 
     val msg = m.call(d, "world")
-    msg shouldBe "world"
+    assertEquals(msg, "world")
   }
 }

--- a/airframe-surface/src/test/scala/wvlet/airframe/surface/ParamTest.scala
+++ b/airframe-surface/src/test/scala/wvlet/airframe/surface/ParamTest.scala
@@ -43,8 +43,8 @@ class ParamTest extends SurfaceSpec {
     val p2 = s.params(1)
     val p3 = s.params(2)
     val v  = ParamTest.B(1, 2, 3)
-    p1.get(v) shouldBe 1
-    p2.get(v) shouldBe 2
-    p3.get(v) shouldBe 3
+    assertEquals(p1.get(v), 1)
+    assertEquals(p2.get(v), 2)
+    assertEquals(p3.get(v), 3)
   }
 }

--- a/airframe-surface/src/test/scala/wvlet/airframe/surface/RecursiveHigherKindTypeTest.scala
+++ b/airframe-surface/src/test/scala/wvlet/airframe/surface/RecursiveHigherKindTypeTest.scala
@@ -40,12 +40,12 @@ class RecursiveHigherKindTypeTest extends SurfaceSpec {
     // ....
 
     val s = Surface.of[Holder[BySkinny]]
-    s.name shouldBe "Holder[BySkinny]"
-    s.isAlias shouldBe false
-    s.isPrimitive shouldBe false
-    s.isOption shouldBe false
-    s.dealias.toString shouldBe "Holder[BySkinny]"
+    assertEquals(s.name, "Holder[BySkinny]")
+    assertEquals(s.isAlias, false)
+    assertEquals(s.isPrimitive, false)
+    assertEquals(s.isOption, false)
+    assertEquals(s.dealias.toString, "Holder[BySkinny]")
 
-    s.typeArgs(0).dealias.name shouldBe "MyTask[A]"
+    assertEquals(s.typeArgs(0).dealias.name, "MyTask[A]")
   }
 }

--- a/airframe-surface/src/test/scala/wvlet/airframe/surface/RecursiveSurfaceTest.scala
+++ b/airframe-surface/src/test/scala/wvlet/airframe/surface/RecursiveSurfaceTest.scala
@@ -52,16 +52,16 @@ class RecursiveSurfaceTest extends SurfaceSpec {
   test("support generic recursive type") {
     val c: Surface = Surface.of[TypedCons[String]]
     debug(s"TypeCons[String] ${c.getClass}")
-    c.toString shouldBe "TypedCons[String]"
+    assertEquals(c.toString, "TypedCons[String]")
 
-    c.params.length shouldBe 2
-    c.params(0).surface shouldBe Primitive.Int
+    assertEquals(c.params.length, 2)
+    assertEquals(c.params(0).surface, Primitive.Int)
 
     val lazyC: Surface = c.params(1).surface
     debug(s"lazyC surface: ${lazyC.getClass}...")
-    lazyC.toString shouldBe "TypedCons[String]"
-    lazyC.params.length shouldBe 2
-    lazyC.isPrimitive shouldBe false
-    lazyC.isOption shouldBe false
+    assertEquals(lazyC.toString, "TypedCons[String]")
+    assertEquals(lazyC.params.length, 2)
+    assertEquals(lazyC.isPrimitive, false)
+    assertEquals(lazyC.isOption, false)
   }
 }

--- a/airframe-surface/src/test/scala/wvlet/airframe/surface/RequiredParamTest.scala
+++ b/airframe-surface/src/test/scala/wvlet/airframe/surface/RequiredParamTest.scala
@@ -13,30 +13,28 @@
  */
 package wvlet.airframe.surface
 
-import wvlet.airspec.AirSpec
-
 case class ModelWithRequiredParam(@required id: String, name: String) {
   def method(a: String, @required b: Int): Unit = {}
 }
 
 /**
   */
-class RequiredParamTest extends AirSpec {
+class RequiredParamTest extends munit.FunSuite {
   test("find required annotation") {
     val s      = Surface.of[ModelWithRequiredParam]
     val p_id   = s.params(0)
     val p_name = s.params(1)
 
-    p_id.isRequired shouldBe true
-    p_name.isRequired shouldBe false
+    assertEquals(p_id.isRequired, true)
+    assertEquals(p_name.isRequired, false)
   }
 
   test("find required method param annotation") {
     val ms = Surface.methodsOf[ModelWithRequiredParam]
     val m  = ms.find(_.name == "method").get
 
-    m.args(0).isRequired shouldBe false
-    m.args(1).isRequired shouldBe true
+    assertEquals(m.args(0).isRequired, false)
+    assertEquals(m.args(1).isRequired, true)
   }
 
   case class LocalA(@required id: String, name: String)
@@ -44,6 +42,6 @@ class RequiredParamTest extends AirSpec {
   test("find required annotation from local classes") {
     val s    = Surface.of[LocalA]
     val p_id = s.params.find(_.name == "id").get
-    p_id.isRequired shouldBe true
+    assertEquals(p_id.isRequired, true)
   }
 }

--- a/airframe-surface/src/test/scala/wvlet/airframe/surface/SecretParamTest.scala
+++ b/airframe-surface/src/test/scala/wvlet/airframe/surface/SecretParamTest.scala
@@ -12,11 +12,10 @@
  * limitations under the License.
  */
 package wvlet.airframe.surface
-import wvlet.airspec.AirSpec
 
 /**
   */
-object SecretParamTest extends AirSpec {
+class SecretParamTest extends munit.FunSuite {
 
   case class WithSecretParam(
       user: String,
@@ -28,7 +27,7 @@ object SecretParamTest extends AirSpec {
     val p_user     = s.params(0)
     val p_password = s.params(1)
 
-    p_user.isSecret shouldBe false
-    p_password.isSecret shouldBe true
+    assertEquals(p_user.isSecret, false)
+    assertEquals(p_password.isSecret, true)
   }
 }

--- a/airframe-surface/src/test/scala/wvlet/airframe/surface/SurfaceSpec.scala
+++ b/airframe-surface/src/test/scala/wvlet/airframe/surface/SurfaceSpec.scala
@@ -14,16 +14,15 @@
 
 package wvlet.airframe.surface
 
-import wvlet.airspec.AirSpec
 import wvlet.log.LogSupport
 
 import scala.language.implicitConversions
 
-trait SurfaceSpec extends AirSpec with LogSupport {
+trait SurfaceSpec extends munit.FunSuite with LogSupport with AirSpecBridge {
   protected def check(body: => Surface, expectedName: String): Surface = {
     val surface = body
     debug(s"[${surface.getClass.getSimpleName}] $surface, ${surface.fullName}")
-    surface.toString shouldBe expectedName
+    assertEquals(surface.toString, expectedName)
     surface
   }
 

--- a/airframe-surface/src/test/scala/wvlet/airframe/surface/SurfaceTest.scala
+++ b/airframe-surface/src/test/scala/wvlet/airframe/surface/SurfaceTest.scala
@@ -78,7 +78,7 @@ class SurfaceTest extends SurfaceSpec {
   }
 
   test("find primitive Surfaces") {
-    Primitive(classOf[Int]) shouldBe Primitive.Int
+    assertEquals(Primitive(classOf[Int]), Primitive.Int)
   }
 
   test("resolve surface from class") {
@@ -176,7 +176,7 @@ class SurfaceTest extends SurfaceSpec {
   test("resolve generic type") {
     val d1 = check(Surface.of[D[String]], "D[String]")
     val d2 = check(Surface.of[D[A]], "D[A]")
-    d1 shouldNotBeTheSameInstanceAs d2
+    assert(d1 ne d2, "should not be the same instance")
   }
 
   test("resolve recursive type") {
@@ -185,7 +185,7 @@ class SurfaceTest extends SurfaceSpec {
 
   test("resolve generic abstract type") {
     val d = check(Surface.of[D[_]], "D[_]")
-    d.typeArgs.length shouldBe 1
+    assertEquals(d.typeArgs.length, 1)
     check(Surface.of[Map[_, _]], "Map[_,_]")
   }
 
@@ -230,9 +230,9 @@ class SurfaceTest extends SurfaceSpec {
 
   test("object factory") {
     val s = Surface.of[F]
-    s.objectFactory shouldBe defined
+    assert(s.objectFactory.isDefined)
     val f = s.objectFactory.map(_.newInstance(Seq(100)))
-    f shouldBe Some(F(100))
+    assertEquals(f, Some(F(100)))
   }
 
   test("bigint") {

--- a/airframe-surface/src/test/scala/wvlet/airframe/surface/ZeroTest.scala
+++ b/airframe-surface/src/test/scala/wvlet/airframe/surface/ZeroTest.scala
@@ -29,7 +29,7 @@ class ZeroTest extends SurfaceSpec {
       case s: ArraySurface =>
         pendingUntil("array comparison")
       case _ =>
-        z shouldBe v
+        assertEquals(z, v)
     }
     z
   }

--- a/build.sbt
+++ b/build.sbt
@@ -437,6 +437,7 @@ lazy val surface =
       name        := "airframe-surface",
       description := "A library for extracting object structure surface",
       libraryDependencies -= "org.wvlet.airframe" %%% "airspec" % AIRSPEC_VERSION % Test,
+      // TODO: This is a temporaly solution. Use AirSpec after Scala 3 support of Surface is completed
       libraryDependencies += "org.scalameta" %%% "munit" % "0.7.29" % Test,
       libraryDependencies ++= surfaceDependencies(scalaVersion.value)
     )

--- a/build.sbt
+++ b/build.sbt
@@ -436,6 +436,8 @@ lazy val surface =
     .settings(
       name        := "airframe-surface",
       description := "A library for extracting object structure surface",
+      libraryDependencies -= "org.wvlet.airframe" %%% "airspec" % AIRSPEC_VERSION % Test,
+      libraryDependencies += "org.scalameta" %%% "munit" % "0.7.29" % Test,
       libraryDependencies ++= surfaceDependencies(scalaVersion.value)
     )
     .jvmSettings(


### PR DESCRIPTION
When working on Scala 3 support in `surface` module, I found `DOTTY=1 sbt surfaceJVM/test` raises errors like:
<details>
<pre><codE>
[error] Test suite wvlet.airframe.surface.ZeroTest failed with java.lang.NoClassDefFoundError: Could not initialize class wvlet.airframe.metrics.ElapsedTime$.
[error] This may be due to the ClassLoaderLayeringStrategy (ScalaLibrary) used by your task.
[error] To improve performance and reduce memory, sbt attempts to cache the class loaders used to load the project dependencies.
[error] The project class files are loaded in a separate class loader that is created for each test run.
[error] The test class loader accesses the project dependency classes using the cached project dependency classloader.
[error] With this approach, class loading may fail under the following conditions:
[error] 
[error]  * Dependencies use reflection to access classes in your project's classpath.
[error]    Java serialization/deserialization may cause this.
[error]  * An open package is accessed across layers. If the project's classes access or extend
[error]    jvm package private classes defined in a project dependency, it may cause an IllegalAccessError
[error]    because the jvm enforces package private at the classloader level.
[error] 
[error] These issues, along with others that were not enumerated above, may be resolved by changing the class loader layering strategy.
[error] The Flat and ScalaLibrary strategies bundle the full project classpath in the same class loader.
[error] To use one of these strategies, set the  ClassLoaderLayeringStrategy key
[error] in your configuration, for example:
[error] 
[error] set surfaceJVM / Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.ScalaLibrary
[error] set surfaceJVM / Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat
[error] 
[error] See ClassLoaderLayeringStrategy.scala for the full list of options.
</code></pre>
</details>

I assume this is because 
1. `surface` is currently tested with `airspec`
2. `airspec` depends on `surface` (circular reference)
3. Adding missing classes for Scala 3, already used in `airspec`, brakes `airspec`

This error makes it difficult to work on Scala 3 support.
So I propose temporal usage of [munit](https://github.com/scalameta/munit) for testing `surface`.
When `surface` get Scala 3 support, go back to `airspec`.

This PR is tested with `DOTTY=1 sbt surfaceJVM/test`.