### PR TITLE
[surface] Scala 3: Handle case fields as method arguments

### DIFF
--- a/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
+++ b/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
@@ -330,7 +330,9 @@ private[surface] class CompileTimeSurfaceFactory[Q <: Quotes](using quotes: Q) {
               td.name -> classTypeParams(i)
           }.toMap[String, TypeRepr]
         // println(s"type args: ${typeArgTable}")
-        methodArgs.map(_.tree).collect { case v: ValDef =>
+        // tpeArgs for case fields, methodArgs for method arguments
+        // E.g. case class Foo(a: String)(implicit b: Int)
+        (tpeArgs ++ methodArgs).map(_.tree).collect { case v: ValDef =>
           // Substitue type param to actual types
           val resolved: TypeRepr = v.tpt.tpe match {
             case a: AppliedType =>


### PR DESCRIPTION
The below tests now passes on JVM + Scala 3

- wvlet.airframe.surface.MultipleConstructorArgsTest
- wvlet.airframe.surface.ClassSurfaceTest

# before

✅ 95

```
$ DOTTY=1 sbt surfaceJVM/test:clean;surfaceJVM/test 

[error] Failed: Total 101, Failed 6, Errors 0, Passed 95
[error] Failed tests:
[error]         wvlet.airframe.surface.RecursiveSurfaceTest
[error]         wvlet.airframe.surface.MultipleConstructorArgsTest
[error]         wvlet.airframe.surface.RecursiveHigherKindTypeTest
[error]         wvlet.airframe.surface.reflect.RuntimeSurfaceTest
[error]         wvlet.airframe.surface.ClassSurfaceTest
[error]         wvlet.airframe.surface.SurfaceTest
```

# after

✅ 97(+2)

```
$ DOTTY=1 sbt surfaceJVM/test:clean;surfaceJVM/test ​

[error] Failed: Total 101, Failed 4, Errors 0, Passed 97
[error] Failed tests:
[error]         wvlet.airframe.surface.RecursiveSurfaceTest
[error]         wvlet.airframe.surface.RecursiveHigherKindTypeTest
[error]         wvlet.airframe.surface.reflect.RuntimeSurfaceTest
[error]         wvlet.airframe.surface.SurfaceTest
```
