### PR TITLE
Upgrade to Scala 3.1.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import xerial.sbt.pack.PackPlugin.publishPackArchiveTgz
 
 val SCALA_2_12          = "2.12.15"
 val SCALA_2_13          = "2.13.8"
-val SCALA_3_0           = "3.1.0"
+val SCALA_3_0           = "3.1.1"
 val targetScalaVersions = SCALA_2_13 :: SCALA_2_12 :: Nil
 val withDotty           = SCALA_3_0 :: targetScalaVersions
 


### PR DESCRIPTION
https://www.scala-lang.org/blog/2022/02/01/scala-3.1.1-released.html