### PR TITLE
[build] Make it easier on cross-build while working on Scala 3 support

### DIFF
--- a/airspec/build.sbt
+++ b/airspec/build.sbt
@@ -83,7 +83,7 @@ val buildSettings = Seq[Setting[_]](
     "-feature",
     "-deprecation"
   ) ++ {
-    if (DOTTY) {
+    if (scalaVersion.value.startsWith("3.")) {
       Seq.empty
     } else {
       Seq(
@@ -94,7 +94,7 @@ val buildSettings = Seq[Setting[_]](
   },
   testFrameworks += new TestFramework("wvlet.airspec.Framework"),
   libraryDependencies ++= {
-    if (DOTTY)
+    if (scalaVersion.value.startsWith("3."))
       Seq.empty
     else
       Seq("org.scala-lang.modules" %%% "scala-collection-compat" % "2.6.0")
@@ -209,7 +209,7 @@ lazy val airspecLog =
       description := "airframe-log for AirSpec",
       libraryDependencies ++= {
         scalaVersion.value match {
-          case s if DOTTY =>
+          case s if s.startsWith("3.") =>
             Seq.empty
           case v =>
             Seq("org.scala-lang" % "scala-reflect" % v % Provided)

--- a/build.sbt
+++ b/build.sbt
@@ -1022,3 +1022,5 @@ lazy val dottyTest =
       crossScalaVersions := List(SCALA_3_0)
     )
     .dependsOn(logJVM, surfaceJVM, diJVM, codecJVM)
+    // Allow dottyTest/test to run all tests in these projects
+    .aggregate(logJVM, surfaceJVM, diJVM, codecJVM)

--- a/build.sbt
+++ b/build.sbt
@@ -1016,11 +1016,9 @@ lazy val dottyTest =
     .settings(buildSettings)
     .settings(noPublish)
     .settings(
-      name        := "airframe-dotty-test",
-      description := "test for dotty",
-      crossScalaVersions := {
-        if (DOTTY) withDotty
-        else targetScalaVersions
-      }
+      name               := "airframe-dotty-test",
+      description        := "test for dotty",
+      scalaVersion       := SCALA_3_0,
+      crossScalaVersions := List(SCALA_3_0)
     )
     .dependsOn(logJVM, surfaceJVM, diJVM, codecJVM)

--- a/build.sbt
+++ b/build.sbt
@@ -95,7 +95,7 @@ val buildSettings = Seq[Setting[_]](
     "-feature",
     "-deprecation"
   ) ++ {
-    if (DOTTY) {
+    if (scalaVersion.value.startsWith("3.")) {
       Seq.empty
     } else {
       Seq(
@@ -109,7 +109,7 @@ val buildSettings = Seq[Setting[_]](
     "org.wvlet.airframe" %%% "airspec"    % AIRSPEC_VERSION    % Test,
     "org.scalacheck"     %%% "scalacheck" % SCALACHECK_VERSION % Test
   ) ++ {
-    if (DOTTY)
+    if (scalaVersion.value.startsWith("3."))
       Seq.empty
     else
       Seq("org.scala-lang.modules" %%% "scala-collection-compat" % "2.6.0")
@@ -530,7 +530,7 @@ lazy val launcher =
 
 val logDependencies = { scalaVersion: String =>
   scalaVersion match {
-    case s if DOTTY =>
+    case s if s.startsWith("3.") =>
       Seq.empty
     case _ =>
       Seq("org.scala-lang" % "scala-reflect" % scalaVersion % Provided)
@@ -553,7 +553,7 @@ lazy val log: sbtcrossproject.CrossProject =
       name        := "airframe-log",
       description := "Fancy logger for Scala",
       scalacOptions ++= {
-        if (DOTTY) Seq("-source:3.0-migration")
+        if (scalaVersion.value.startsWith("3.")) Seq("-source:3.0-migration")
         else Nil
       },
       libraryDependencies ++= logDependencies(scalaVersion.value)
@@ -953,7 +953,7 @@ lazy val rxHtml =
       name        := "airframe-rx-html",
       description := "Reactive HTML elements for Scala and Scala.js",
       libraryDependencies ++= {
-        if (DOTTY)
+        if (scalaVersion.value.startsWith("3."))
           Seq.empty
         else
           Seq("org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided)

--- a/build.sbt
+++ b/build.sbt
@@ -1022,5 +1022,3 @@ lazy val dottyTest =
       crossScalaVersions := List(SCALA_3_0)
     )
     .dependsOn(logJVM, surfaceJVM, diJVM, codecJVM)
-    // Allow dottyTest/test to run all tests in these projects
-    .aggregate(logJVM, surfaceJVM, diJVM, codecJVM)


### PR DESCRIPTION
When working on Scala 3 support, I often need to run tests over Scala 3 and 2, like:
```
$ DOTTY=1 sbt 
sbt> ++surfaceJVM/test
```
to confirm behaviours both on Scala 3 and 2.
However, `++COMMAND` is failing on Scala 2 right now, because settings are only configured for Scala 3 due to hard-coded `if (DOTTY)`.

This PR replaces `DOTTY` criteria as much as possible to `scalaVersion.value.startsWith("3.")` so cross-build can be

<del>And, `dottyTest/test` now runs all tests on dotty-support-ongoing project.</del>
`projectDotty` already exists for that purpose.


