### PR TITLE
Slow down awssdk update

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -10,3 +10,9 @@ buildRoots = [
 updates.ignore = [
   { groupId = "com.chatwork", artifactId = "scala-ulid", prefix = "1.0." }
 ]
+dependencyOverrides = [
+  {
+    dependency = { groupId = "software.amazon.awssdk" },
+    pullRequests = { frequency = "90 days" },
+  },
+]


### PR DESCRIPTION
Scala Steward now can configure update frequency granularly.
https://github.com/scala-steward-org/scala-steward/pull/2515