### PR TITLE
Revert "Update sbt-scalajs, scalajs-compiler, ... to 1.10.0"

### DIFF
--- a/examples/rpc-examples/rpc-scalajs/project/plugins.sbt
+++ b/examples/rpc-examples/rpc-scalajs/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("org.wvlet.airframe" % "sbt-airframe"             % "22.3.0")
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.10.0")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.9.0")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.2.0")
 addSbtPlugin("io.spray"           % "sbt-revolver"             % "0.9.1")

--- a/examples/rx-demo/gallery/project/plugins.sbt
+++ b/examples/rx-demo/gallery/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.10.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.9.0")


### PR DESCRIPTION
Reverts wvlet/airframe#2112

#2118 must be released for AirSpec before upgrading to Scala.js 1.10.0, where UUID.randomUUID() requires crypto module, which is not supported in jsdom.