### PR TITLE
airframe-ulid: Use SecureRandom-based generator for Scala.js

### DIFF
--- a/airframe-ulid/.js/src/main/scala/wvlet/airframe/ulid/compat.scala
+++ b/airframe-ulid/.js/src/main/scala/wvlet/airframe/ulid/compat.scala
@@ -18,7 +18,15 @@ import scala.util.Random
 /**
   */
 object compat {
-  val random: Random = scala.util.Random
+  val random: Random = {
+    try {
+      // When 'crypto' module is available
+      new scala.util.Random(new java.security.SecureRandom())
+    } catch {
+      case _: Throwable =>
+        scala.util.Random
+    }
+  }
 
   def sleep(millis: Int): Unit = {
     // no-op as Scala.js has no sleep

--- a/build.sbt
+++ b/build.sbt
@@ -503,7 +503,9 @@ lazy val ulid =
       description := "ULID: Universally Unique Lexicographically Sortable Identifier"
     )
     .jsSettings(
-      jsBuildSettings
+      jsBuildSettings,
+      // For using SecureRandom (requires `crypto` package)
+      libraryDependencies += ("org.scala-js" %%% "scalajs-java-securerandom" % "1.0.0").cross(CrossVersion.for3Use2_13)
     )
     .dependsOn(log % Test)
 

--- a/docs/airframe-ulid.md
+++ b/docs/airframe-ulid.md
@@ -1,3 +1,4 @@
+
 ---
 id: airframe-ulid
 title: airframe-ulid: ULID Generator
@@ -52,11 +53,16 @@ ULIDs can be encoded as 128-bit values, using network-byte order (big-endian, MS
 __build.sbt__
 ```scala
 libraryDependencies += "org.wvlet.airframe" %% "airframe-ulid" % "(version)"
-
-// For Scala.js
-libraryDependencies += "org.wvlet.airframe" %%% "airframe-ulid" % "(version)"
 ```
 
+For Scala.js 1.10.0 or later, add scalajs-java-securerandom for generating ULID with a Cryptographically-Secure-Pseudo-Random-Number-Generator (CSPRNG). When using Node.js environment, install npm module `crypto` as well:
+
+```scala
+libraryDependencies ++= Seq(
+  "org.wvlet.airframe" %%% "airframe-ulid" % "(version)",
+  ("org.scala-js" %%% "scalajs-java-securerandom" % "1.0.0").cross(CrossVersion.for3Use2_13)
+)
+```
 
 ULID can be generated with `ULID.newULID` method:
 


### PR DESCRIPTION
Using a secure random generator is necessary to protect the system from predicting ULID values that will be generated. This is important especially when ULID is exposed as public parameters. 

Since Scala.js 1.10.0, it provides a SecureRandom implementation https://github.com/scala-js/scala-js-java-securerandom 
https://www.scala-js.org/news/2022/04/04/announcing-scalajs-1.10.0/

For the best compatibility, if Node.js `crypto` module or Web Crypto API are not available, it will fallback to non-secure random generator. This is good for testing at jsdom environment, which doesn't support crypto module https://github.com/jsdom/jsdom/issues/1612