### PR TITLE
More dotty support

### DIFF
--- a/airframe-di/src/test/scala/wvlet/airframe/DesignTest.scala
+++ b/airframe-di/src/test/scala/wvlet/airframe/DesignTest.scala
@@ -84,7 +84,7 @@ object DesignTest extends AirSpec {
 
   test("bind providers") {
     val d = newSilentDesign
-      .bind[Hello].toProvider { (m: ProductionString) => Hello(m) }
+      .bind[Hello].toProvider[ProductionString] { m => Hello(m) }
       .bind[ProductionString].toInstance("hello production")
 
     d.build[Hello] { h => h.message shouldBe "hello production" }

--- a/airframe-di/src/test/scala/wvlet/airframe/DesignTest.scala
+++ b/airframe-di/src/test/scala/wvlet/airframe/DesignTest.scala
@@ -83,6 +83,7 @@ object DesignTest extends AirSpec {
   }
 
   test("bind providers") {
+    // TODO: Remove type argument when https://github.com/wvlet/airframe/issues/2200 fixed
     val d = newSilentDesign
       .bind[Hello].toProvider[ProductionString] { m => Hello(m) }
       .bind[ProductionString].toInstance("hello production")

--- a/airframe-surface/.jvm/src/main/scala-3/wvlet/airframe/surface/reflect/TastySurfaceFactory.scala
+++ b/airframe-surface/.jvm/src/main/scala-3/wvlet/airframe/surface/reflect/TastySurfaceFactory.scala
@@ -27,9 +27,17 @@ object TastySurfaceFactory extends LogSupport {
           import quotes.reflect._
           val tastyType = quotes.reflect.TypeRepr.typeConstructorOf(cl)
           debug(tastyType)
-          val f    = new CompileTimeSurfaceFactory(using quotes)
-          val expr = f.surfaceOf(tastyType.asType)
-          expr
+          val f = new CompileTimeSurfaceFactory(using quotes)
+          tastyType match {
+            case t if t.show == "<none>.<none>" =>
+              val name = cl.getName
+              // FIXME: A workaround for runtime surface generation.
+              // Example use case is MessageCodec.of[Any].
+              // `GenericSurface(${ Expr(cl) }) `causes `scala.MatchError: NoType` ¯\_(ツ)_/¯
+              '{ new wvlet.airframe.surface.GenericSurface(${ Expr(cl) }) }
+            case _ =>
+              f.surfaceOf(tastyType.asType)
+          }
         }
       }
     )

--- a/airframe-surface/.jvm/src/main/scala-3/wvlet/airframe/surface/reflect/TastySurfaceFactory.scala
+++ b/airframe-surface/.jvm/src/main/scala-3/wvlet/airframe/surface/reflect/TastySurfaceFactory.scala
@@ -30,11 +30,8 @@ object TastySurfaceFactory extends LogSupport {
           val f = new CompileTimeSurfaceFactory(using quotes)
           tastyType match {
             case t if t.show == "<none>.<none>" =>
-              val name = cl.getName
-              // FIXME: A workaround for runtime surface generation.
               // Example use case is MessageCodec.of[Any].
-              // `GenericSurface(${ Expr(cl) }) `causes `scala.MatchError: NoType` ¯\_(ツ)_/¯
-              '{ new wvlet.airframe.surface.GenericSurface(${ Expr(cl) }) }
+              f.surfaceFromClass(cl)
             case _ =>
               f.surfaceOf(tastyType.asType)
           }

--- a/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
+++ b/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
@@ -106,7 +106,6 @@ private[surface] class CompileTimeSurfaceFactory[Q <: Quotes](using quotes: Q) {
         '{ wvlet.airframe.surface.surfaceCache.getOrElseUpdate(${ Expr(cacheKey) }, ${ expr }) }
       }
       val surface = generator(t)
-      // println(s"--- ${surface.show}")
       memo += (t -> surface)
       surface
     }
@@ -300,7 +299,7 @@ private[surface] class CompileTimeSurfaceFactory[Q <: Quotes](using quotes: Q) {
       val typeArgs = a.args.map(surfaceOf(_))
       '{ new GenericSurface(${ clsOf(a) }, typeArgs = ${ Expr.ofSeq(typeArgs) }.toIndexedSeq) }
     // special treatment for type Foo = Foo[Buz]
-    case TypeBounds(a1:AppliedType, a2:AppliedType) if a1 == a2 =>
+    case TypeBounds(a1: AppliedType, a2: AppliedType) if a1 == a2 =>
       val typeArgs = a1.args.map(surfaceOf(_))
       '{ new GenericSurface(${ clsOf(a1) }, typeArgs = ${ Expr.ofSeq(typeArgs) }.toIndexedSeq) }
     case r: Refinement =>

--- a/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
+++ b/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
@@ -207,6 +207,9 @@ private[surface] class CompileTimeSurfaceFactory[Q <: Quotes](using quotes: Q) {
     t match {
       case a: AppliedType =>
         a.args
+      // TODO: Dealiasing should be done before ?
+      case DottyTypes.TypeAlias(DottyTypes.HKTypeLambda(_, a: AppliedType)) =>
+        a.args
       case other =>
         List.empty
     }

--- a/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
+++ b/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
@@ -214,7 +214,13 @@ private[surface] class CompileTimeSurfaceFactory[Q <: Quotes](using quotes: Q) {
   }
 
   private def elementTypeSurfaceOf(t: TypeRepr): Expr[Surface] = {
-    typeArgsOf(t).map(surfaceOf(_)).head
+    typeArgsOf(t).map(surfaceOf(_)).headOption match {
+      case Some(expr) =>
+        expr
+      case None =>
+        // FIXME: Is this right ?
+        '{ AnyRefSurface }
+    }
   }
 
   private def arrayFactory: Factory = {

--- a/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
+++ b/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
@@ -299,6 +299,10 @@ private[surface] class CompileTimeSurfaceFactory[Q <: Quotes](using quotes: Q) {
     case a: AppliedType =>
       val typeArgs = a.args.map(surfaceOf(_))
       '{ new GenericSurface(${ clsOf(a) }, typeArgs = ${ Expr.ofSeq(typeArgs) }.toIndexedSeq) }
+    // special treatment for type Foo = Foo[Buz]
+    case TypeBounds(a1:AppliedType, a2:AppliedType) if a1 == a2 =>
+      val typeArgs = a1.args.map(surfaceOf(_))
+      '{ new GenericSurface(${ clsOf(a1) }, typeArgs = ${ Expr.ofSeq(typeArgs) }.toIndexedSeq) }
     case r: Refinement =>
       newGenericSurfaceOf(r.info)
     case t if hasStringUnapply(t) =>

--- a/airframe-surface/src/test/scala/wvlet/airframe/surface/RecursiveHigherKindTypeTest.scala
+++ b/airframe-surface/src/test/scala/wvlet/airframe/surface/RecursiveHigherKindTypeTest.scala
@@ -46,6 +46,7 @@ class RecursiveHigherKindTypeTest extends SurfaceSpec {
     assertEquals(s.isOption, false)
     assertEquals(s.dealias.toString, "Holder[BySkinny]")
 
+    assertEquals(s.typeArgs(0).name, "BySkinny")
     assertEquals(s.typeArgs(0).dealias.name, "MyTask[A]")
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -626,6 +626,10 @@ lazy val codec =
     .settings(buildSettings)
     .settings(dottyCrossBuildSettings)
     .settings(
+      // TODO: #1698 Avoid "illegal multithreaded access to ContextBase error" on Scala 3
+      // Tests in this project are sequentially executed
+      Test / parallelExecution := false,
+
       name        := "airframe-codec",
       description := "Airframe MessagePack-based codec"
     )


### PR DESCRIPTION
# Summary

module | Before | After 
---|---|---
diJVM | Passed 84 | Passed 89 (+5) All ✅ 
surfaceJVM | Passed 100 |  Passed 101 (+1) All ✅ 
codecJVM | Passed 107 |  Passed 107 (-) 😑 

# Raw results

## Before

```
$ DOTTY=1 sbt  projectDotty/test | grep '\[error\]' > error.txt
$ cat error.txt
[error] Error: Total 89, Failed 0, Errors 5, Passed 84, Pending 1
[error] Error during tests:
[error] 	wvlet.airframe.DesignSerializationTest
[error] 	wvlet.airframe.ProviderSerializationTest
[error] 	wvlet.airframe.DesignTest
[error] Error: Total 109, Failed 0, Errors 2, Passed 107, Pending 1
[error] Error during tests:
[error] 	wvlet.airframe.codec.PrimitiveCodecTest
[error] Failed: Total 101, Failed 1, Errors 0, Passed 100
[error] Failed tests:
[error] 	wvlet.airframe.surface.RecursiveHigherKindTypeTest
[error] (codecJVM / Test / test) sbt.TestsFailedException: Tests unsuccessful
[error] (diJVM / Test / test) sbt.TestsFailedException: Tests unsuccessful
[error] (surfaceJVM / Test / test) sbt.TestsFailedException: Tests unsuccessful
[error] Total time: 19 s, completed 7 May 2022, 19:16:03
```


## After

```
$ DOTTY=1 sbt  projectDotty/test | grep '\[error\]' > error.txt
$ cat error.txt
[error] Failed: Total 109, Failed 1, Errors 0, Passed 108, Pending 1
[error] Failed tests:
[error]         wvlet.airframe.codec.PrimitiveCodecTest
[error] (codecJVM / Test / test) sbt.TestsFailedException: Tests unsuccessful
[error] Total time: 36 s, completed May 28, 2022, 10:32:27 PM
``` 

