### PR TITLE
AirSpec: Add async test support

### DIFF
--- a/airspec/.js/src/main/scala/wvlet/airspec/Compat.scala
+++ b/airspec/.js/src/main/scala/wvlet/airspec/Compat.scala
@@ -29,7 +29,7 @@ import scala.util.Try
 private[airspec] object Compat extends CompatApi with LogSupport {
   override def isScalaJs = true
 
-  override private[airspec] def executionContext: ExecutionContext =
+  override private[airspec] val executionContext: ExecutionContext =
     org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
 
   private[airspec] def findCompanionObjectOf(fullyQualifiedName: String, classLoader: ClassLoader): Option[Any] = {
@@ -67,9 +67,14 @@ private[airspec] object Compat extends CompatApi with LogSupport {
   }
 
   private[airspec] def withLogScanner[U](block: => U): U = {
-    Logger.setDefaultHandler(new ConsoleLogHandler(SourceCodeLogFormatter))
+    startLogScanner
     block
   }
+
+  private[airspec] def startLogScanner: Unit = {
+    Logger.setDefaultHandler(new ConsoleLogHandler(SourceCodeLogFormatter))
+  }
+  private[airspec] def stopLogScanner: Unit = {}
 
   private[airspec] def findCause(e: Throwable): Throwable = {
     // Scala.js has no InvocationTargetException

--- a/airspec/.js/src/main/scala/wvlet/airspec/Compat.scala
+++ b/airspec/.js/src/main/scala/wvlet/airspec/Compat.scala
@@ -21,12 +21,17 @@ import wvlet.airspec.spi.{Asserts, JsObjectMatcher}
 import wvlet.log.LogFormatter.SourceCodeLogFormatter
 import wvlet.log.{ConsoleLogHandler, LogSupport, Logger}
 
+import scala.concurrent.ExecutionContext
 import scala.util.Try
 
 /**
   */
 private[airspec] object Compat extends CompatApi with LogSupport {
   override def isScalaJs = true
+
+  override private[airspec] def executionContext: ExecutionContext =
+    org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
+
   private[airspec] def findCompanionObjectOf(fullyQualifiedName: String, classLoader: ClassLoader): Option[Any] = {
     val clsOpt = Reflect.lookupLoadableModuleClass(fullyQualifiedName + "$", classLoader)
     clsOpt.map {

--- a/airspec/.jvm/src/main/scala/wvlet/airspec/Compat.scala
+++ b/airspec/.jvm/src/main/scala/wvlet/airspec/Compat.scala
@@ -14,7 +14,6 @@
 package wvlet.airspec
 
 import java.lang.reflect.InvocationTargetException
-
 import sbt.testing.Fingerprint
 import wvlet.log.LogFormatter.SourceCodeLogFormatter
 import wvlet.log.Logger
@@ -25,10 +24,16 @@ import wvlet.airframe.surface.reflect.ReflectTypeUtil
 import wvlet.airspec.Framework.{AirSpecClassFingerPrint, AirSpecObjectFingerPrint}
 import wvlet.airspec.spi.{AirSpecException, Asserts}
 
+import java.util.concurrent.Executors
+import scala.concurrent.ExecutionContext
+
 /**
   */
 private[airspec] object Compat extends CompatApi {
   override def isScalaJs = false
+
+  override private[airspec] def executionContext: ExecutionContext =
+    ExecutionContext.fromExecutorService(Executors.newSingleThreadExecutor())
 
   private[airspec] def findCompanionObjectOf(fullyQualifiedName: String, classLoader: ClassLoader): Option[Any] = {
     val cls = classLoader.loadClass(fullyQualifiedName)

--- a/airspec/.jvm/src/main/scala/wvlet/airspec/Compat.scala
+++ b/airspec/.jvm/src/main/scala/wvlet/airspec/Compat.scala
@@ -73,8 +73,8 @@ private[airspec] object Compat extends CompatApi {
   }
 
   private[airspec] def withLogScanner[U](block: => U): U = {
-    startLogScanner
     try {
+      startLogScanner
       block
     } finally {
       stopLogScanner

--- a/airspec/build.sbt
+++ b/airspec/build.sbt
@@ -327,8 +327,7 @@ lazy val airspec =
         "org.scalacheck" %%% "scalacheck" % SCALACHECK_VERSION % Optional
       ),
       // A workaround for bloop, which cannot resolve Optional dependencies
-      pomPostProcess           := excludePomDependency(Seq("airspec-deps", "airspec_2.12", "airspec_2.13")),
-      Test / parallelExecution := false
+      pomPostProcess := excludePomDependency(Seq("airspec-deps", "airspec_2.12", "airspec_2.13"))
     )
     .jvmSettings(
       // Embed dependent project codes to make airspec a single jar
@@ -353,9 +352,10 @@ lazy val airspec =
         .filter(x => x._2 != "JS_DEPENDENCIES"),
       Compile / packageSrc / mappings ++= (airspecDepsJS / Compile / packageSrc / mappings).value,
       libraryDependencies ++= Seq(
-        ("org.scala-js"        %% "scalajs-test-interface"      % scalaJSVersion).cross(CrossVersion.for3Use2_13),
-        ("org.portable-scala" %%% "portable-scala-reflect"      % "1.1.2").cross(CrossVersion.for3Use2_13),
-        "org.scala-js"        %%% "scala-js-macrotask-executor" % "1.0.0"
+        ("org.scala-js"        %% "scalajs-test-interface" % scalaJSVersion).cross(CrossVersion.for3Use2_13),
+        ("org.portable-scala" %%% "portable-scala-reflect" % "1.1.2").cross(CrossVersion.for3Use2_13),
+        // Necessary for async testing
+        "org.scala-js" %%% "scala-js-macrotask-executor" % "1.0.0"
       )
     )
     // This should be Optional dependency, but using Provided dependency for bloop which doesn't support Optional.

--- a/airspec/build.sbt
+++ b/airspec/build.sbt
@@ -327,7 +327,8 @@ lazy val airspec =
         "org.scalacheck" %%% "scalacheck" % SCALACHECK_VERSION % Optional
       ),
       // A workaround for bloop, which cannot resolve Optional dependencies
-      pomPostProcess := excludePomDependency(Seq("airspec-deps", "airspec_2.12", "airspec_2.13"))
+      pomPostProcess           := excludePomDependency(Seq("airspec-deps", "airspec_2.12", "airspec_2.13")),
+      Test / parallelExecution := false
     )
     .jvmSettings(
       // Embed dependent project codes to make airspec a single jar
@@ -352,8 +353,9 @@ lazy val airspec =
         .filter(x => x._2 != "JS_DEPENDENCIES"),
       Compile / packageSrc / mappings ++= (airspecDepsJS / Compile / packageSrc / mappings).value,
       libraryDependencies ++= Seq(
-        ("org.scala-js"        %% "scalajs-test-interface" % scalaJSVersion).cross(CrossVersion.for3Use2_13),
-        ("org.portable-scala" %%% "portable-scala-reflect" % "1.1.2").cross(CrossVersion.for3Use2_13)
+        ("org.scala-js"        %% "scalajs-test-interface"      % scalaJSVersion).cross(CrossVersion.for3Use2_13),
+        ("org.portable-scala" %%% "portable-scala-reflect"      % "1.1.2").cross(CrossVersion.for3Use2_13),
+        "org.scala-js"        %%% "scala-js-macrotask-executor" % "1.0.0"
       )
     )
     // This should be Optional dependency, but using Provided dependency for bloop which doesn't support Optional.

--- a/airspec/src/main/scala/wvlet/airspec/AirSpec.scala
+++ b/airspec/src/main/scala/wvlet/airspec/AirSpec.scala
@@ -104,6 +104,11 @@ private[airspec] trait AirSpecSpi extends AirSpecSpiCompat {
   protected def inGitHubAction: Boolean = airspec.inGitHubAction
 
   protected def isScalaJS: Boolean = compat.isScalaJs
+
+  /**
+    * Provide a platform-independent execution context for async testing
+    */
+  protected def defaultExecutionContext: scala.concurrent.ExecutionContext = compat.executionContext
 }
 
 private[airspec] object AirSpecSpi {

--- a/airspec/src/main/scala/wvlet/airspec/AirSpecLauncher.scala
+++ b/airspec/src/main/scala/wvlet/airspec/AirSpecLauncher.scala
@@ -13,27 +13,39 @@
  */
 package wvlet.airspec
 
-import sbt.testing.TaskDef
+import sbt.testing._
 import wvlet.airspec.runner.AirSpecSbtRunner.AirSpecConfig
 import wvlet.airspec.runner.{AirSpecEventHandler, AirSpecLogger, AirSpecTaskRunner}
 import wvlet.log.LogSupport
+
+import scala.concurrent.Future
 
 /**
   */
 object AirSpecLauncher extends LogSupport {
   def main(args: Array[String]): Unit = {
+    execute(args)
+  }
+
+  /**
+    * Entrypoint for async testing
+    */
+  def execute(args: Array[String]): Future[Unit] = {
     args.length match {
       case 0 =>
         info(s"airspec: [command]")
+        Future.unit
       case _ =>
         val cmd = args(0)
         cmd match {
           case "-h" | "help" | "--help" =>
             printHelp
+            Future.unit
           case "test" =>
             run(args.tail)
           case _ =>
             warn(s"Unknown command: ${cmd}")
+            Future.unit
         }
     }
   }
@@ -44,10 +56,11 @@ object AirSpecLauncher extends LogSupport {
                |help       show this message""".stripMargin)
   }
 
-  private def run(args: Array[String]): Unit = {
+  private def run(args: Array[String]): Future[Unit] = {
     args.length match {
       case 0 =>
         warn(s"No test is specified")
+        Future.unit
       case _ =>
         val testClassFullName = args(0)
         info(s"Run tests in ${testClassFullName}")
@@ -74,9 +87,9 @@ object AirSpecLauncher extends LogSupport {
           new AirSpecEventHandler(),
           cl
         )
-        runner.runTask
+        val future = runner.runTask
+        future
     }
-
   }
 
 }

--- a/airspec/src/main/scala/wvlet/airspec/CompatApi.scala
+++ b/airspec/src/main/scala/wvlet/airspec/CompatApi.scala
@@ -16,6 +16,7 @@ package wvlet.airspec
 import sbt.testing.Fingerprint
 import wvlet.airframe.surface.MethodSurface
 import wvlet.airspec.spi.Asserts
+import scala.concurrent.ExecutionContext
 
 /**
   * An interface for compatibility between Scala JVM and Scala.js
@@ -23,6 +24,7 @@ import wvlet.airspec.spi.Asserts
 trait CompatApi {
   def isScalaJs: Boolean
 
+  private[airspec] def executionContext: ExecutionContext
   private[airspec] def findCompanionObjectOf(fullyQualifiedName: String, classLoader: ClassLoader): Option[Any]
   private[airspec] def getFingerprint(fullyQualifiedName: String, classLoader: ClassLoader): Option[Fingerprint]
   private[airspec] def newInstanceOf(fullyQualifiedName: String, classLoader: ClassLoader): Option[Any]

--- a/airspec/src/main/scala/wvlet/airspec/CompatApi.scala
+++ b/airspec/src/main/scala/wvlet/airspec/CompatApi.scala
@@ -29,6 +29,8 @@ trait CompatApi {
   private[airspec] def getFingerprint(fullyQualifiedName: String, classLoader: ClassLoader): Option[Fingerprint]
   private[airspec] def newInstanceOf(fullyQualifiedName: String, classLoader: ClassLoader): Option[Any]
   private[airspec] def withLogScanner[U](block: => U): U
+  private[airspec] def startLogScanner: Unit
+  private[airspec] def stopLogScanner: Unit
   private[airspec] def findCause(e: Throwable): Throwable
 
   private[airspec] def getSpecName(cls: Class[_]): String

--- a/airspec/src/main/scala/wvlet/airspec/runner/AirSpecContextImpl.scala
+++ b/airspec/src/main/scala/wvlet/airspec/runner/AirSpecContextImpl.scala
@@ -33,11 +33,15 @@ private[airspec] class AirSpecContextImpl(
 ) extends AirSpecContext
     with LogSupport {
 
-  private val childTaskResults: ListBuffer[() => Future[Unit]] = ListBuffer.empty
+  /**
+    * A list of child tests, which are not yet started. As Scala Future starts the body evaluation eagerly, wrapping
+    * Future with a no-argument function.
+    */
+  private val childTestList: ListBuffer[() => Future[Unit]] = ListBuffer.empty
 
   override def hasChildTask: Boolean = {
     synchronized {
-      childTaskResults.size > 0
+      childTestList.size > 0
     }
   }
 
@@ -47,13 +51,13 @@ private[airspec] class AirSpecContextImpl(
       taskExecutor.runSingle(Some(this), currentSession, currentSpec, testDef, isLocal = true, design = testDef.design)
     }
     synchronized {
-      childTaskResults += taskResult
+      childTestList += taskResult
     }
   }
 
-  private[airspec] override def childResults: Seq[() => Future[Unit]] = {
+  private[airspec] override def childTests: Seq[() => Future[Unit]] = {
     synchronized {
-      childTaskResults.toSeq
+      childTestList.toSeq
     }
   }
 }

--- a/airspec/src/main/scala/wvlet/airspec/runner/AirSpecTask.scala
+++ b/airspec/src/main/scala/wvlet/airspec/runner/AirSpecTask.scala
@@ -38,9 +38,8 @@ private[airspec] class AirSpecTask(
     * logger, continuation)
     */
   def execute(eventHandler: EventHandler, loggers: Array[sbt.testing.Logger]): Array[sbt.testing.Task] = {
-    val p = Promise[Unit]()
-    execute(eventHandler, loggers, _ => p.success(()))
-    Await.result(p.future, Duration.Inf)
+    execute(eventHandler, loggers, _ => ())
+    // Await.result(p.future, Duration.Inf)
     Array.empty
   }
 
@@ -58,10 +57,7 @@ private[airspec] class AirSpecTask(
       loggers: Array[sbt.testing.Logger],
       continuation: Array[sbt.testing.Task] => Unit
   ): Unit = {
-    try {
-      new AirSpecTaskRunner(taskDef, config, taskLogger, eventHandler, classLoader).runTask
-    } finally {
-      continuation(Array.empty)
-    }
+    new AirSpecTaskRunner(taskDef, config, taskLogger, eventHandler, classLoader).runTask
+      .foreach(_ => continuation(Array.empty))(wvlet.airspec.Compat.executionContext)
   }
 }

--- a/airspec/src/main/scala/wvlet/airspec/runner/AirSpecTaskRunner.scala
+++ b/airspec/src/main/scala/wvlet/airspec/runner/AirSpecTaskRunner.scala
@@ -313,7 +313,7 @@ private[airspec] class AirSpecTaskRunner(
               showTestName = !context.hasChildTask
             )
             eventHandler.handle(e)
-            Try[Unit]()
+            Try(())
           }
       }
   }

--- a/airspec/src/main/scala/wvlet/airspec/runner/AirSpecTaskRunner.scala
+++ b/airspec/src/main/scala/wvlet/airspec/runner/AirSpecTaskRunner.scala
@@ -95,6 +95,9 @@ private[airspec] class AirSpecTaskRunner(
     selectedSpecs
   }
 
+  /**
+    * Run this AirSpec task
+    */
   def runTask: Future[Unit] = {
     val startTimeNanos = System.nanoTime()
     Future

--- a/airspec/src/main/scala/wvlet/airspec/runner/AirSpecTaskRunner.scala
+++ b/airspec/src/main/scala/wvlet/airspec/runner/AirSpecTaskRunner.scala
@@ -298,7 +298,7 @@ private[airspec] class AirSpecTaskRunner(
             val childTasks = context.childResults.foldLeft(Future.unit) { case (prev, task) =>
               prev.transformWith(_ => task())
             }
-            childTasks.andThen(_ => result)
+            childTasks.transform(_ => result)
           }
           .transform { case result: Try[_] =>
             cleanup(childSession)

--- a/airspec/src/main/scala/wvlet/airspec/runner/AirSpecTaskRunner.scala
+++ b/airspec/src/main/scala/wvlet/airspec/runner/AirSpecTaskRunner.scala
@@ -19,6 +19,7 @@ import wvlet.airspec.runner.AirSpecSbtRunner.AirSpecConfig
 import wvlet.airspec.spi.{AirSpecContext, AirSpecException}
 import wvlet.log.LogSupport
 
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
 /**
@@ -38,6 +39,8 @@ private[airspec] class AirSpecTaskRunner(
     classLoader: ClassLoader
 ) extends LogSupport {
   import wvlet.airspec._
+
+  private implicit val ec: ExecutionContext = Compat.executionContext
 
   private def findTestInstance(): AirSpecSpi = {
     // Get an instance of AirSpec
@@ -69,10 +72,10 @@ private[airspec] class AirSpecTaskRunner(
   /**
     * Process test name filter and extract the target specs
     */
-  private def findTargetSpecs(parentContext: Option[AirSpecContext], spec: AirSpecSpi): Seq[AirSpecDef] = {
+  private def findTargetSpecs(spec: AirSpecSpi): Seq[AirSpecDef] = {
     val testDefs = spec.testDefinitions
     if (testDefs.isEmpty) {
-      val name = specName(parentContext, spec)
+      val name = specName(None, spec)
       warn(s"No test definition is found in ${name}. Add at least one test(...) method call.")
     }
 
@@ -82,7 +85,7 @@ private[airspec] class AirSpecTaskRunner(
           // Find matching methods
           testDefs.filter { m =>
             // Concatenate (parent class name)? + class name + method name for handy search
-            val fullName = s"${specName(parentContext, spec)}.${m.name}"
+            val fullName = s"${specName(None, spec)}.${m.name}"
             regex.findFirstIn(fullName).isDefined
           }
         case None =>
@@ -90,21 +93,6 @@ private[airspec] class AirSpecTaskRunner(
       }
 
     selectedSpecs
-  }
-
-  def runTask: Unit = {
-    val startTimeNanos = System.nanoTime()
-    try {
-      // Start a background log level scanner thread. If a thread is already running, reuse it.
-      compat.withLogScanner {
-        trace(s"Processing task: ${taskDef}")
-        val spec: AirSpecSpi = findTestInstance()
-        run(parentContext = None, spec)
-      }
-    } catch {
-      case e: Throwable =>
-        handleError(e, startTimeNanos)
-    }
   }
 
   private def handleError(e: Throwable, startTimeNanos: Long): Unit = {
@@ -118,10 +106,24 @@ private[airspec] class AirSpecTaskRunner(
     eventHandler.handle(event)
   }
 
-  private[airspec] def run(parentContext: Option[AirSpecContext], spec: AirSpecSpi): Unit = {
-    val targetSpecs = findTargetSpecs(parentContext, spec)
-    if (targetSpecs.nonEmpty) {
-      runSpec(parentContext, spec, targetSpecs)
+  def runTask: Future[Unit] = {
+    val startTimeNanos = System.nanoTime()
+    try {
+      // Start a background log level scanner thread. If a thread is already running, reuse it.
+      compat.withLogScanner {
+        trace(s"Processing task: ${taskDef}")
+        val spec: AirSpecSpi = findTestInstance()
+        val targetSpecs      = findTargetSpecs(spec)
+        if (targetSpecs.nonEmpty) {
+          runSpec(None, spec, targetSpecs)
+        } else {
+          Future.unit
+        }
+      }
+    } catch {
+      case e: Throwable =>
+        handleError(e, startTimeNanos)
+        Future.failed(e)
     }
   }
 
@@ -129,14 +131,16 @@ private[airspec] class AirSpecTaskRunner(
       parentContext: Option[AirSpecContext],
       spec: AirSpecSpi,
       targetTestDefs: Seq[AirSpecDef]
-  ): Unit = {
-    val indentLevel = parentContext.map(_.indentLevel + 1).getOrElse(0)
-    taskLogger.logSpecName(spec.leafSpecName, indentLevel = indentLevel)
+  ): Future[Unit] = {
 
-    try {
-      // Start the spec
-      spec.callBeforeAll
+    def startSpec = Future.apply[Unit] {
+      val indentLevel = parentContext.map(_.indentLevel + 1).getOrElse(0)
+      taskLogger.logSpecName(spec.leafSpecName, indentLevel = indentLevel)
+    }
 
+    def runBeforeAll: Future[Unit] = Future.apply(spec.callBeforeAll)
+
+    def runBody: Future[Unit] = Future.apply {
       // Configure the global spec design
       var d = Design.newDesign.noLifeCycleLogging
       d = d + spec.callDesign
@@ -145,17 +149,31 @@ private[airspec] class AirSpecTaskRunner(
       val globalSession =
         parentContext
           .map(_.currentSession.newChildSession(d))
-          .getOrElse { d.newSessionBuilder.noShutdownHook.build } // Do not register JVM shutdown hooks
+          .getOrElse {
+            d.newSessionBuilder.noShutdownHook.build
+          } // Do not register JVM shutdown hooks
 
       val localDesign = spec.callLocalDesign
+      var taskFuture  = Future.unit
       globalSession.start {
-        for (m <- targetTestDefs) {
-          runSingle(parentContext, globalSession, spec, m, isLocal = false, design = localDesign)
+        taskFuture = targetTestDefs.foldLeft(Future.unit) { (prev, m) =>
+          prev.map[Unit](_ => runSingle(parentContext, globalSession, spec, m, isLocal = false, design = localDesign))
         }
       }
-    } finally {
-      spec.callAfterAll
+      taskFuture
     }
+
+    def runAfterAll: Future[Unit] = Future.apply(spec.callAfterAll)
+
+    startSpec
+      .flatMap(_ => runBeforeAll)
+      .flatMap(_ => runBody)
+      .transformWith {
+        case Success(result) =>
+          runAfterAll
+        case Failure(e) =>
+          runAfterAll.flatMap(_ => Future.failed(e))
+      }
   }
 
   private var displayedContext = Set.empty[String]

--- a/airspec/src/main/scala/wvlet/airspec/runner/AirSpecTaskRunner.scala
+++ b/airspec/src/main/scala/wvlet/airspec/runner/AirSpecTaskRunner.scala
@@ -295,8 +295,9 @@ private[airspec] class AirSpecTaskRunner(
         runTest(childSession, context)
           .transformWith { case result: Try[_] =>
             // Await the child task completion, then report the current spec result
-            val childTasks = context.childResults.foldLeft(Future.unit) { case (prev, task) =>
-              prev.transformWith(_ => task())
+            val childTasks = context.childTests.foldLeft(Future.unit) { case (prev, childTest) =>
+              // After the previos test finishes, start the next child test
+              prev.transformWith(_ => childTest())
             }
             childTasks.transform(_ => result)
           }

--- a/airspec/src/main/scala/wvlet/airspec/runner/AirSpecTaskRunner.scala
+++ b/airspec/src/main/scala/wvlet/airspec/runner/AirSpecTaskRunner.scala
@@ -66,6 +66,9 @@ private[airspec] class AirSpecTaskRunner(
     s"${parentName}${spec.leafSpecName}"
   }
 
+  /**
+    * Process test name filter and extract the target specs
+    */
   private def findTargetSpecs(parentContext: Option[AirSpecContext], spec: AirSpecSpi): Seq[AirSpecDef] = {
     val testDefs = spec.testDefinitions
     if (testDefs.isEmpty) {

--- a/airspec/src/main/scala/wvlet/airspec/spi/AirSpecContext.scala
+++ b/airspec/src/main/scala/wvlet/airspec/spi/AirSpecContext.scala
@@ -57,5 +57,5 @@ trait AirSpecContext {
 
   protected[airspec] def runSingle(testDef: AirSpecDef): Unit
 
-  private[airspec] def childResults: Seq[Future[Unit]]
+  private[airspec] def childResults: Seq[() => Future[Unit]]
 }

--- a/airspec/src/main/scala/wvlet/airspec/spi/AirSpecContext.scala
+++ b/airspec/src/main/scala/wvlet/airspec/spi/AirSpecContext.scala
@@ -57,5 +57,5 @@ trait AirSpecContext {
 
   protected[airspec] def runSingle(testDef: AirSpecDef): Unit
 
-  private[airspec] def childResults: Seq[() => Future[Unit]]
+  private[airspec] def childTests: Seq[() => Future[Unit]]
 }

--- a/airspec/src/main/scala/wvlet/airspec/spi/AirSpecContext.scala
+++ b/airspec/src/main/scala/wvlet/airspec/spi/AirSpecContext.scala
@@ -16,6 +16,8 @@ package wvlet.airspec.spi
 import wvlet.airframe.Session
 import wvlet.airspec.{AirSpecDef, AirSpecSpi}
 
+import scala.concurrent.Future
+
 /**
   * AirSpecContext is an interface to pass the test environment data to individual test methods.
   *
@@ -54,4 +56,6 @@ trait AirSpecContext {
   }
 
   protected[airspec] def runSingle(testDef: AirSpecDef): Unit
+
+  private[airspec] def childResults: Seq[Future[Unit]]
 }

--- a/airspec/src/test/scala/examples/AsyncTest.scala
+++ b/airspec/src/test/scala/examples/AsyncTest.scala
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package examples
+
+import wvlet.airspec.AirSpec
+
+import scala.collection.mutable.ListBuffer
+import scala.concurrent.Future
+
+class AsyncTest extends AirSpec {
+
+  private implicit val ec = defaultExecutionContext
+
+  private val completedTests = ListBuffer.empty[String]
+
+  private def reportCompletion(name: String): Unit = {
+    synchronized {
+      completedTests += name
+    }
+  }
+
+  override def afterAll: Unit = {
+    val completionOrders = completedTests.toSeq
+
+    // The execution order within the same level tests is guaranteed
+    completionOrders.indexOf("0") < completionOrders.indexOf("1") shouldBe true
+    completionOrders.indexOf("1.1") < completionOrders.indexOf("1.2") shouldBe true
+    completionOrders.indexOf("1.1.1") < completionOrders.indexOf("1.1.2") shouldBe true
+  }
+
+  test("return Future[_]") {
+    Future { reportCompletion("0") }
+  }
+
+  test("nested async test") {
+    test("test1.1") {
+      test("test1.1.1") {
+        Future { reportCompletion("1.1.1") }
+      }
+      test("test1.1.2") {
+        Future { reportCompletion("1.1.2") }
+      }
+
+      Future { reportCompletion("1.1") }
+    }
+
+    test("test1.2") {
+      Future { reportCompletion("1.2") }
+    }
+    Future { reportCompletion("1") }
+  }
+
+}

--- a/airspec/src/test/scala/examples/AsyncTest.scala
+++ b/airspec/src/test/scala/examples/AsyncTest.scala
@@ -16,11 +16,11 @@ package examples
 import wvlet.airspec.AirSpec
 
 import scala.collection.mutable.ListBuffer
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 class AsyncTest extends AirSpec {
 
-  private implicit val ec = defaultExecutionContext
+  private implicit val ec: ExecutionContext = defaultExecutionContext
 
   private val completedTests = ListBuffer.empty[String]
 

--- a/airspec/src/test/scala/examples/TestSyntaxSpec.scala
+++ b/airspec/src/test/scala/examples/TestSyntaxSpec.scala
@@ -54,6 +54,10 @@ class TestSyntaxSpec extends AirSpec {
   }
 
   test("nested tests") {
+    if (isScalaJS) {
+      pending("nested tests have a bug in async processing")
+    }
+
     test("test1") {
       debug("hello test1")
     }

--- a/airspec/src/test/scala/examples/TestSyntaxSpec.scala
+++ b/airspec/src/test/scala/examples/TestSyntaxSpec.scala
@@ -54,10 +54,6 @@ class TestSyntaxSpec extends AirSpec {
   }
 
   test("nested tests") {
-    if (isScalaJS) {
-      pending("nested tests have a bug in async processing")
-    }
-
     test("test1") {
       debug("hello test1")
     }

--- a/airspec/src/test/scala/wvlet/airspec/AirSpecLauncherTest.scala
+++ b/airspec/src/test/scala/wvlet/airspec/AirSpecLauncherTest.scala
@@ -17,23 +17,23 @@ package wvlet.airspec
   */
 class AirSpecLauncherTest extends AirSpec {
   test("run main") {
-    AirSpecLauncher.main(Array.empty)
+    AirSpecLauncher.execute(Array.empty)
   }
 
   test("run --help") {
-    AirSpecLauncher.main(Array("--help"))
+    AirSpecLauncher.execute(Array("--help"))
   }
 
   test("run test without arg") {
-    AirSpecLauncher.main(Array("test"))
+    AirSpecLauncher.execute(Array("test"))
   }
 
   test("run test") {
-    AirSpecLauncher.main(Array("test", "examples.CommonSpec"))
+    AirSpecLauncher.execute(Array("test", "examples.CommonSpec"))
   }
 
   test("run tests with args") {
-    AirSpecLauncher.main(Array("test", "examples.CommonSpec", "hello"))
+    AirSpecLauncher.execute(Array("test", "examples.CommonSpec", "hello"))
   }
 
   test("try to run test with non-exisiting test") {

--- a/docs/airspec.md
+++ b/docs/airspec.md
@@ -19,7 +19,7 @@ AirSpec uses just `test("...") { ... }` syntax for writing test cases. This styl
 - Support basic assertion syntaxes: `assert(cond)`, `x shouldBe y`, etc.
   - No need to learn other complex DSLs.
 - Nesting and reusing test cases with `test(...)`
-- Asyc testing support for `scala.concurrent.Future[ ]`
+- Async testing support for `scala.concurrent.Future[ ]`
 - Lifecycle management with [Airframe DI](airframe-di.md):
   - DI will inject the arguments of test methods based on your custom Design.
   - The lifecycle (e.g., start and shutdown) of the injected services will be properly managed.

--- a/docs/airspec.md
+++ b/docs/airspec.md
@@ -19,12 +19,13 @@ AirSpec uses just `test("...") { ... }` syntax for writing test cases. This styl
 - Support basic assertion syntaxes: `assert(cond)`, `x shouldBe y`, etc.
   - No need to learn other complex DSLs.
 - Nesting and reusing test cases with `test(...)`
+- Asyc testing support for `scala.concurrent.Future[ ]`
 - Lifecycle management with [Airframe DI](airframe-di.md):
   - DI will inject the arguments of test methods based on your custom Design.
   - The lifecycle (e.g., start and shutdown) of the injected services will be properly managed.
 - Handy keyword search for _sbt_: `> testOnly -- (a pattern for class or method names)`
 - Property-based testing integrated with [ScalaCheck](https://www.scalacheck.org/)
-- Scala 2.11, 2.12, 2.13, 3.0, and Scala.js support
+- Scala 2.12, 2.13, 3.0, and Scala.js support
 
 To start using AirSpec, read [Quick Start](#quick-start).
 
@@ -209,6 +210,30 @@ org.mydomain.myapp.MyTest=trace
 As you modify this property file, a background thread automatically reads this log file and refreshes the log level accordingly.
 
 For more details, see the [documentation](https://wvlet.org/airframe/docs/airframe-log.html) of airframe-log.
+
+
+## Async Testing
+
+Since the version 22.5.0, AirSpec supports tests returning `Future[_]` values. Such async tests are useful, especially if your application needs to wait the completion of network requests, such as Ajax responses in Scala.js, RPC responses from a server, etc. If test specs returns `Future` values, AirSpec awaits the completion of async tests, so you don't need to write synchronization steps in your test code.
+
+
+```scala
+import wvlet.airspec._
+import scala.concurrent.{Future,ExecutionContext}
+
+class AsyncTest extends AirSpec {
+  // Use the default ExecutionContext for running Future tasks.
+  private implicit val ec: ExecutionContext = defaultExecutionContext
+
+  // AirSpec awaits the completion of the returned Future value
+  test("async test") {
+    Future.apply {
+       println("hello async test")
+    }
+  }
+}
+
+```
 
 
 ## Dependency Injection with Airframe DI


### PR DESCRIPTION
Added support for running AirSpec tests returning Future values. 

- [x] Refactor AirSpecTaskRunner
- [x] Return Future from AirSpecTaskRunner
- [x] concatenate to continuation in Scala.js
- [x] Manage Future objects generated at nested tests