### PR TITLE
Add RPCHttpClient to handle RPCException at client side

### DIFF
--- a/airframe-http-codegen/src/test/scala/wvlet/airframe/http/codegen/RPCClientGeneratorTest.scala
+++ b/airframe-http-codegen/src/test/scala/wvlet/airframe/http/codegen/RPCClientGeneratorTest.scala
@@ -26,9 +26,17 @@ class RPCClientGeneratorTest extends AirSpec {
     r.contains("addUser(request:CreateUserRequest): User") shouldBe true
   }
 
-  test("propagate RPCException") {
+  test("propagate RPCException in sync client") {
     val config = HttpClientGeneratorConfig("example.api.rpc:sync:MyRPCClient")
     val code   = HttpCodeGenerator.generate(router, config)
+    // TODO Use debug log level
+    info(code)
+  }
+
+  test("propagate RPCException in async client") {
+    val config = HttpClientGeneratorConfig("example.api.rpc:async:MyRPCClient")
+    val code   = HttpCodeGenerator.generate(router, config)
+    // TODO Use debug log level
     info(code)
   }
 }

--- a/airframe-http-codegen/src/test/scala/wvlet/airframe/http/codegen/RPCClientGeneratorTest.scala
+++ b/airframe-http-codegen/src/test/scala/wvlet/airframe/http/codegen/RPCClientGeneratorTest.scala
@@ -29,6 +29,6 @@ class RPCClientGeneratorTest extends AirSpec {
   test("propagate RPCException") {
     val config = HttpClientGeneratorConfig("example.api.rpc:sync:MyRPCClient")
     val code   = HttpCodeGenerator.generate(router, config)
-    debug(code)
+    info(code)
   }
 }

--- a/airframe-http-codegen/src/test/scala/wvlet/airframe/http/codegen/RPCClientGeneratorTest.scala
+++ b/airframe-http-codegen/src/test/scala/wvlet/airframe/http/codegen/RPCClientGeneratorTest.scala
@@ -30,13 +30,13 @@ class RPCClientGeneratorTest extends AirSpec {
     val config = HttpClientGeneratorConfig("example.api.rpc:sync:MyRPCClient")
     val code   = HttpCodeGenerator.generate(router, config)
     // TODO Use debug log level
-    info(code)
+    debug(code)
   }
 
   test("propagate RPCException in async client") {
     val config = HttpClientGeneratorConfig("example.api.rpc:async:MyRPCClient")
     val code   = HttpCodeGenerator.generate(router, config)
     // TODO Use debug log level
-    info(code)
+    debug(code)
   }
 }

--- a/airframe-http-finagle/src/main/scala/wvlet/airframe/http/finagle/FinagleClient.scala
+++ b/airframe-http-finagle/src/main/scala/wvlet/airframe/http/finagle/FinagleClient.scala
@@ -22,7 +22,7 @@ import wvlet.airframe.Design
 import wvlet.airframe.codec.{MessageCodec, MessageCodecFactory}
 import wvlet.airframe.control.Retry.RetryContext
 import wvlet.airframe.http._
-import wvlet.airframe.http.HttpResponseCodec
+import wvlet.airframe.http.HttpResponseBodyCodec
 import wvlet.airframe.surface.Surface
 import wvlet.log.LogSupport
 
@@ -199,7 +199,7 @@ class FinagleClient(address: ServerAddress, config: FinagleClientConfig)
 
   // make sure using Map output
   private val codecFactory  = config.codecFactory.withMapOutput
-  private val responseCodec = new HttpResponseCodec[Response]
+  private val responseCodec = new HttpResponseBodyCodec[Response]
 
   private def convert[A: ru.TypeTag](response: Future[Response]): Future[A] = {
     if (implicitly[ru.TypeTag[A]] == ru.typeTag[Response]) {

--- a/airframe-http-finagle/src/main/scala/wvlet/airframe/http/finagle/FinagleServer.scala
+++ b/airframe-http-finagle/src/main/scala/wvlet/airframe/http/finagle/FinagleServer.scala
@@ -26,7 +26,7 @@ import wvlet.airframe.control.MultipleExceptions
 import wvlet.airframe.http.finagle.FinagleServer.FinagleService
 import wvlet.airframe.http.finagle.filter.HttpAccessLogFilter
 import wvlet.airframe.http.router.{ControllerProvider, ResponseHandler}
-import wvlet.airframe.http.{HttpBackend, HttpMessage, HttpServerException, RPCException, Router}
+import wvlet.airframe.http.{HttpBackend, HttpHeader, HttpMessage, HttpServerException, RPCException, Router}
 import wvlet.airframe.surface.Surface
 import wvlet.log.LogSupport
 import wvlet.log.io.IOUtil
@@ -252,7 +252,7 @@ object FinagleServer extends LogSupport {
               var resp = wvlet.airframe.http.Http
                 .response(e.status.httpStatus)
                 // Add RPC status header to handle errors in clients
-                .addHeader("x-airframe-rpc-status", e.status.code.toString)
+                .addHeader(HttpHeader.xAirframeRPCStatus, e.status.code.toString)
               try {
                 val errorResponseJson = e.toJson
                 resp = resp.withJson(errorResponseJson)

--- a/airframe-http-finagle/src/main/scala/wvlet/airframe/http/finagle/FinagleServer.scala
+++ b/airframe-http-finagle/src/main/scala/wvlet/airframe/http/finagle/FinagleServer.scala
@@ -256,7 +256,7 @@ object FinagleServer extends LogSupport {
 
               try {
                 // Embed RPCError into the response body
-                if (request.acceptJson) {
+                if (request.acceptsJson) {
                   resp = resp.withJson(e.toJson)
                 } else {
                   // Use MessagePack encoding by default

--- a/airframe-http-finagle/src/main/scala/wvlet/airframe/http/finagle/FinagleServer.scala
+++ b/airframe-http-finagle/src/main/scala/wvlet/airframe/http/finagle/FinagleServer.scala
@@ -253,9 +253,15 @@ object FinagleServer extends LogSupport {
                 .response(e.status.httpStatus)
                 // Add RPC status header to handle errors in clients
                 .addHeader(HttpHeader.xAirframeRPCStatus, e.status.code.toString)
+
               try {
-                val errorResponseJson = e.toJson
-                resp = resp.withJson(errorResponseJson)
+                // Embed RPCError into the response body
+                if (request.acceptJson) {
+                  resp = resp.withJson(e.toJson)
+                } else {
+                  // Use MessagePack encoding by default
+                  resp = resp.withMsgPack(e.toMsgPack)
+                }
               } catch {
                 case ex: Throwable =>
                   // Show warning

--- a/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/RPCErrorHandlingTest.scala
+++ b/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/RPCErrorHandlingTest.scala
@@ -15,7 +15,7 @@ package wvlet.airframe.http.finagle
 
 import com.twitter.finagle.http.{Method, Request}
 import wvlet.airframe.http.finagle.RPCErrorHandlingTest.DemoApi
-import wvlet.airframe.http.{RPC, RPCException, RPCStatus, Router}
+import wvlet.airframe.http.{HttpHeader, RPC, RPCException, RPCStatus, Router}
 import wvlet.airspec.AirSpec
 
 import java.io.{PrintWriter, StringWriter}
@@ -47,7 +47,7 @@ class RPCErrorHandlingTest extends AirSpec {
 
     test("with stack trace") {
       val req = Request(Method.Post, "/wvlet.airframe.http.finagle.RPCErrorHandlingTest.DemoApi/permissionCheck")
-      req.setContentTypeJson()
+      req.accept = HttpHeader.MediaType.ApplicationJson
       val resp = client.sendSafe(req)
 
       val errorJson = resp.getContentString()
@@ -68,7 +68,7 @@ class RPCErrorHandlingTest extends AirSpec {
 
     test("without stack trace") {
       val req = Request(Method.Post, "/wvlet.airframe.http.finagle.RPCErrorHandlingTest.DemoApi/authCheck")
-      req.setContentTypeJson()
+      req.accept = HttpHeader.MediaType.ApplicationJson
       val resp = client.sendSafe(req)
 
       val errorJson = resp.getContentString()

--- a/airframe-http-okhttp/src/main/scala/wvlet/airframe/http/okhttp/OkHttpClient.scala
+++ b/airframe-http-okhttp/src/main/scala/wvlet/airframe/http/okhttp/OkHttpClient.scala
@@ -7,7 +7,7 @@ import wvlet.airframe.codec.{MessageCodec, MessageCodecFactory}
 import wvlet.airframe.control.Retry.RetryContext
 import wvlet.airframe.http.HttpClient.urlEncode
 import wvlet.airframe.http._
-import wvlet.airframe.http.HttpResponseCodec
+import wvlet.airframe.http.HttpResponseBodyCodec
 import wvlet.airframe.json.JSON.{JSONArray, JSONObject}
 import wvlet.log.LogSupport
 
@@ -59,7 +59,7 @@ class OkHttpClient(address: ServerAddress, config: OkHttpClientConfig)
   }
 
   private val codecFactory  = MessageCodecFactory.defaultFactoryForJSON
-  private val responseCodec = new HttpResponseCodec[Response]
+  private val responseCodec = new HttpResponseBodyCodec[Response]
 
   private def convert[A: ru.TypeTag](response: Response): A = {
     if (implicitly[ru.TypeTag[A]] == ru.typeTag[Response]) {

--- a/airframe-http/.js/src/main/scala/wvlet/airframe/http/Compat.scala
+++ b/airframe-http/.js/src/main/scala/wvlet/airframe/http/Compat.scala
@@ -13,6 +13,8 @@
  */
 package wvlet.airframe.http
 
+import wvlet.airframe.http.js.JSHttpClientBackend
+
 /**
   * Scala.js specific implementation
   */
@@ -20,5 +22,5 @@ private object Compat extends CompatApi {
   override def urlEncode(s: String): String = {
     scala.scalajs.js.URIUtils.encodeURI(s)
   }
-  override def defaultHttpClientBackend: HttpClientBackend = ???
+  override def defaultHttpClientBackend: HttpClientBackend = JSHttpClientBackend
 }

--- a/airframe-http/.js/src/main/scala/wvlet/airframe/http/js/JSHttpClient.scala
+++ b/airframe-http/.js/src/main/scala/wvlet/airframe/http/js/JSHttpClient.scala
@@ -42,20 +42,31 @@ object JSHttpClient {
 
   // An http client for production-use
   def defaultClient = {
-    val protocol = window.location.protocol.stripSuffix(":")
-    val hostname = window.location.hostname
-    if (hostname == "localhost" && protocol == "http") {
-      // Use local client for testing
-      localClient
-    } else {
-      val port    = Option(window.location.port).map(x => if (x.isEmpty) "" else s":${x}").getOrElse("")
-      val address = ServerAddress(s"${protocol}://${hostname}${port}")
-      JSHttpClient(JSHttpClientConfig(serverAddress = Some(address)))
+    resolveServerAddress match {
+      case None =>
+        // Use local client for testing
+        localClient
+      case Some(address) =>
+        JSHttpClient(JSHttpClientConfig(serverAddress = Some(ServerAddress(address))))
     }
   }
 
   // An http client that can be used for local testing
   def localClient = JSHttpClient()
+
+  /**
+    * Find the host server address from the browser context
+    */
+  def resolveServerAddress: Option[String] = {
+    val protocol = window.location.protocol.stripSuffix(":")
+    val hostname = window.location.hostname
+    if (hostname == "localhost" && protocol == "http") {
+      None
+    } else {
+      val port = Option(window.location.port).map(x => if (x.isEmpty) "" else s":${x}").getOrElse("")
+      Some(s"${protocol}://${hostname}${port}")
+    }
+  }
 
   def defaultHttpClientRetryer: RetryContext = {
     Retry

--- a/airframe-http/.js/src/main/scala/wvlet/airframe/http/js/JSHttpClient.scala
+++ b/airframe-http/.js/src/main/scala/wvlet/airframe/http/js/JSHttpClient.scala
@@ -77,6 +77,9 @@ object JSHttpClient {
   }
 }
 
+/**
+  * TODO: We can use HttpClientConfig instead. This config is left here for the compatibility
+  */
 case class JSHttpClientConfig(
     serverAddress: Option[ServerAddress] = None,
     requestEncoding: MessageEncoding = MessageEncoding.MessagePackEncoding,

--- a/airframe-http/.js/src/main/scala/wvlet/airframe/http/js/JSHttpClient.scala
+++ b/airframe-http/.js/src/main/scala/wvlet/airframe/http/js/JSHttpClient.scala
@@ -33,6 +33,7 @@ import scala.util.{Failure, Success, Try}
 
 object JSHttpClient {
 
+  @deprecated("Use RPCEncoding instead", "21.5.0")
   sealed trait MessageEncoding
   object MessageEncoding {
     object MessagePackEncoding extends MessageEncoding
@@ -253,16 +254,15 @@ case class JSHttpClient(config: JSHttpClientConfig = JSHttpClientConfig()) exten
             codecFactory.of(operationResponseSurface).asInstanceOf[MessageCodec[OperationResponse]]
           // Read the response body as MessagePack or JSON
           val ct = resp.contentType
-          resp.contentType match {
-            case Some("application/x-msgpack") =>
-              responseCodec.fromMsgPack(resp.contentBytes)
-            case _ =>
-              val json = resp.contentString
-              if (json.nonEmpty) {
-                responseCodec.fromJson(json)
-              } else {
-                throw new HttpClientException(resp, resp.status, "Empty response from the server")
-              }
+          if (resp.isContentTypeMsgPack) {
+            responseCodec.fromMsgPack(resp.contentBytes)
+          } else {
+            val json = resp.contentString
+            if (json.nonEmpty) {
+              responseCodec.fromJson(json)
+            } else {
+              throw new HttpClientException(resp, resp.status, "Empty response from the server")
+            }
           }
       }
     }

--- a/airframe-http/.js/src/main/scala/wvlet/airframe/http/js/JSHttpClientAdaptor.scala
+++ b/airframe-http/.js/src/main/scala/wvlet/airframe/http/js/JSHttpClientAdaptor.scala
@@ -1,0 +1,130 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.http.js
+
+import wvlet.airframe.http.{Http, HttpMessage}
+
+import scala.concurrent.Future
+import scala.reflect.runtime.universe
+
+/**
+  * An http client for Scala.js that implements only sendSafe for supporting RPC
+  * @param client
+  */
+class JSHttpClientAdaptor(client: JSHttpClient) extends Http.AsyncClient {
+  override def close(): Unit = {
+    // Nothing to do
+  }
+
+  override def sendSafe(
+      req: HttpMessage.Request,
+      requestFilter: HttpMessage.Request => HttpMessage.Request
+  ): Future[HttpMessage.Response] = {
+    client.sendRaw(req, requestFilter)
+  }
+
+  override def send(
+      req: HttpMessage.Request,
+      requestFilter: HttpMessage.Request => HttpMessage.Request
+  ): Future[HttpMessage.Response] = ???
+
+  override private[http] def awaitF[A](f: Future[A]) = ???
+
+  override def get[Resource: universe.TypeTag](
+      resourcePath: String,
+      requestFilter: HttpMessage.Request => HttpMessage.Request
+  ): Future[Resource] = ???
+
+  override def getResource[ResourceRequest: universe.TypeTag, Resource: universe.TypeTag](
+      resourcePath: String,
+      resourceRequest: ResourceRequest,
+      requestFilter: HttpMessage.Request => HttpMessage.Request
+  ): Future[Resource] = ???
+
+  override def list[OperationResponse: universe.TypeTag](
+      resourcePath: String,
+      requestFilter: HttpMessage.Request => HttpMessage.Request
+  ): Future[OperationResponse] = ???
+
+  override def post[Resource: universe.TypeTag](
+      resourcePath: String,
+      resource: Resource,
+      requestFilter: HttpMessage.Request => HttpMessage.Request
+  ): Future[Resource] = ???
+
+  override def postRaw[Resource: universe.TypeTag](
+      resourcePath: String,
+      resource: Resource,
+      requestFilter: HttpMessage.Request => HttpMessage.Request
+  ): Future[HttpMessage.Response] = ???
+
+  override def postOps[Resource: universe.TypeTag, OperationResponse: universe.TypeTag](
+      resourcePath: String,
+      resource: Resource,
+      requestFilter: HttpMessage.Request => HttpMessage.Request
+  ): Future[OperationResponse] = ???
+
+  override def put[Resource: universe.TypeTag](
+      resourcePath: String,
+      resource: Resource,
+      requestFilter: HttpMessage.Request => HttpMessage.Request
+  ): Future[Resource] = ???
+
+  override def putRaw[Resource: universe.TypeTag](
+      resourcePath: String,
+      resource: Resource,
+      requestFilter: HttpMessage.Request => HttpMessage.Request
+  ): Future[HttpMessage.Response] = ???
+
+  override def putOps[Resource: universe.TypeTag, OperationResponse: universe.TypeTag](
+      resourcePath: String,
+      resource: Resource,
+      requestFilter: HttpMessage.Request => HttpMessage.Request
+  ): Future[OperationResponse] = ???
+
+  override def delete[OperationResponse: universe.TypeTag](
+      resourcePath: String,
+      requestFilter: HttpMessage.Request => HttpMessage.Request
+  ): Future[OperationResponse] = ???
+
+  override def deleteRaw(
+      resourcePath: String,
+      requestFilter: HttpMessage.Request => HttpMessage.Request
+  ): Future[HttpMessage.Response] = ???
+
+  override def deleteOps[Resource: universe.TypeTag, OperationResponse: universe.TypeTag](
+      resourcePath: String,
+      resource: Resource,
+      requestFilter: HttpMessage.Request => HttpMessage.Request
+  ): Future[OperationResponse] = ???
+
+  override def patch[Resource: universe.TypeTag](
+      resourcePath: String,
+      resource: Resource,
+      requestFilter: HttpMessage.Request => HttpMessage.Request
+  ): Future[Resource] = ???
+
+  override def patchRaw[Resource: universe.TypeTag](
+      resourcePath: String,
+      resource: Resource,
+      requestFilter: HttpMessage.Request => HttpMessage.Request
+  ): Future[HttpMessage.Response] = ???
+
+  override def patchOps[Resource: universe.TypeTag, OperationResponse: universe.TypeTag](
+      resourcePath: String,
+      resource: Resource,
+      requestFilter: HttpMessage.Request => HttpMessage.Request
+  ): Future[OperationResponse] = ???
+
+}

--- a/airframe-http/.js/src/main/scala/wvlet/airframe/http/js/JSHttpClientBackend.scala
+++ b/airframe-http/.js/src/main/scala/wvlet/airframe/http/js/JSHttpClientBackend.scala
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.http.js
+
+import wvlet.airframe.control.Retry
+import wvlet.airframe.http.{HttpClient, HttpClientBackend, HttpClientConfig, HttpMessage, HttpSyncClient}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+object JSHttpClientBackend extends HttpClientBackend {
+
+  override def defaultExecutionContext: ExecutionContext = {
+    scala.scalajs.concurrent.JSExecutionContext.queue
+  }
+  override def defaultRequestRetryer: Retry.RetryContext = {
+    // Use this for compatibility. We may be able to use HttpClient.defaultHttpClientRetry in future
+    JSHttpClient.defaultHttpClientRetryer
+  }
+
+  override def newSyncClient(
+      severAddress: String,
+      clientConfig: HttpClientConfig
+  ): HttpSyncClient[HttpMessage.Request, HttpMessage.Response] = {
+    throw new UnsupportedOperationException("sync client is not supported in Scala.js")
+  }
+
+  override def newAsyncClient(
+      serverAddress: String,
+      clientConfig: HttpClientConfig
+  ): HttpClient[Future, HttpMessage.Request, HttpMessage.Response] = {
+    new JSHttpClientAdaptor(JSHttpClient())
+  }
+
+}

--- a/airframe-http/.js/src/main/scala/wvlet/airframe/http/js/JSHttpClientBackend.scala
+++ b/airframe-http/.js/src/main/scala/wvlet/airframe/http/js/JSHttpClientBackend.scala
@@ -21,7 +21,7 @@ import wvlet.airframe.http.{
   HttpClientConfig,
   HttpMessage,
   HttpSyncClient,
-  RPCClient,
+  RPCHttpClient,
   RPCEncoding,
   ServerAddress
 }
@@ -66,8 +66,8 @@ object JSHttpClientBackend extends HttpClientBackend {
     new JSHttpClientAdaptor(JSHttpClient(config))
   }
 
-  override def newRPCClientForScalaJS(clientConfig: HttpClientConfig): RPCClient = {
+  override def newRPCClientForScalaJS(clientConfig: HttpClientConfig): RPCHttpClient = {
     val asyncClient = newAsyncClient(JSHttpClient.resolveServerAddress.getOrElse(""), clientConfig)
-    new RPCClient(clientConfig, asyncClient)
+    new RPCHttpClient(clientConfig, asyncClient)
   }
 }

--- a/airframe-http/.js/src/test/scala/wvlet/airframe/http/js/JSRPCClientTest.scala
+++ b/airframe-http/.js/src/test/scala/wvlet/airframe/http/js/JSRPCClientTest.scala
@@ -11,27 +11,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.airframe.http
+package wvlet.airframe.http.js
 
+import wvlet.airframe.http.{Http, HttpClientConfig, RPCClient, RPCSyncClient}
 import wvlet.airspec.AirSpec
 
-object RPCClientTest extends AirSpec {
+class JSRPCClientTest extends AirSpec {
 
   // Use a public REST test server
   private val PUBLIC_REST_SERVICE = "https://httpbin.org/"
-
   case class TestRequest(id: Int, name: String)
   case class TestResponse(url: String, headers: Map[String, Any])
 
-  test("Create an RPCSyncClient") {
-    val config    = HttpClientConfig()
-    val client    = Http.client.newSyncClient(PUBLIC_REST_SERVICE)
-    val rpcClient = new RPCSyncClient(config, client)
-    val response  = rpcClient.send[TestRequest, TestResponse]("/post", TestRequest(1, "test"), identity)
+  test("Create an Async RPCClient") {
+    val config = HttpClientConfig()
+    val client = Http.client.newAsyncClient(PUBLIC_REST_SERVICE)
 
-    // Test message
-    debug(response)
-    response.headers.get("Content-Type") shouldBe Some("application/msgpack")
+    // TODO: This test will be effective after the async test support in AirSpec 22.5.0
+    val rpcClient = new RPCClient(config, client)
+    rpcClient
+      .send[TestRequest, TestResponse]("/post", TestRequest(1, "test"), identity)
+      .map { response =>
+        debug(response)
+        response.headers.get("Content-Type") shouldBe Some("application/msgpack")
+      }(config.backend.defaultExecutionContext)
   }
 
 }

--- a/airframe-http/.js/src/test/scala/wvlet/airframe/http/js/JSRPCClientTest.scala
+++ b/airframe-http/.js/src/test/scala/wvlet/airframe/http/js/JSRPCClientTest.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.http.js
 
-import wvlet.airframe.http.{Http, HttpClientConfig, RPCClient, RPCSyncClient}
+import wvlet.airframe.http.{Http, HttpClientConfig, RPCHttpClient, RPCHttpSyncClient}
 import wvlet.airspec.AirSpec
 
 class JSRPCClientTest extends AirSpec {
@@ -28,13 +28,20 @@ class JSRPCClientTest extends AirSpec {
     val client = Http.client.newAsyncClient(PUBLIC_REST_SERVICE)
 
     // TODO: This test will be effective after the async test support in AirSpec 22.5.0
-    val rpcClient = new RPCClient(config, client)
+    val rpcClient = new RPCHttpClient(config, client)
     rpcClient
       .send[TestRequest, TestResponse]("/post", TestRequest(1, "test"), identity)
       .map { response =>
         debug(response)
         response.headers.get("Content-Type") shouldBe Some("application/msgpack")
       }(config.backend.defaultExecutionContext)
+  }
+
+  test("create RPC client") {
+    val config = HttpClientConfig()
+
+    // Sanity test for client creation
+    val client = config.newRPCClientForScalaJS
   }
 
 }

--- a/airframe-http/.jvm/src/main/scala-2/wvlet/airframe/http/client/URLConnectionClientBase.scala
+++ b/airframe-http/.jvm/src/main/scala-2/wvlet/airframe/http/client/URLConnectionClientBase.scala
@@ -16,7 +16,7 @@ package wvlet.airframe.http.client
 import wvlet.airframe.codec.MessageCodec
 import wvlet.airframe.http.HttpClient.urlEncode
 import wvlet.airframe.http.HttpMessage.{Request, Response}
-import wvlet.airframe.http.{Http, HttpResponseCodec, HttpSyncClient}
+import wvlet.airframe.http.{Http, HttpResponseBodyCodec, HttpSyncClient}
 import wvlet.airframe.json.JSON.{JSONArray, JSONObject}
 import wvlet.airframe.surface.Surface
 
@@ -34,7 +34,7 @@ trait URLConnectionClientBase extends HttpSyncClient[Request, Response] { self: 
       // Can return the response as is
       response.asInstanceOf[A]
     } else {
-      val standardResponseCodec = new HttpResponseCodec[Response]
+      val standardResponseCodec = new HttpResponseBodyCodec[Response]
       // Need a conversion
       val codec   = MessageCodec.of[A]
       val msgpack = standardResponseCodec.toMsgPack(response)

--- a/airframe-http/.jvm/src/main/scala-3/wvlet/airframe/http/client/URLConnectionClientBase.scala
+++ b/airframe-http/.jvm/src/main/scala-3/wvlet/airframe/http/client/URLConnectionClientBase.scala
@@ -17,7 +17,7 @@ import wvlet.airframe.codec.MessageCodec
 import wvlet.airframe.http.HttpClient.urlEncode
 import wvlet.airframe.http.HttpMessage.Response
 import wvlet.airframe.http.HttpMessage.{Request, Response}
-import wvlet.airframe.http.{Http, HttpResponseCodec, HttpSyncClient}
+import wvlet.airframe.http.{Http, HttpResponseBodyCodec, HttpSyncClient}
 import wvlet.airframe.json.JSON.{JSONArray, JSONObject}
 import wvlet.airframe.surface.Surface
 
@@ -32,7 +32,7 @@ trait URLConnectionClientBase extends HttpSyncClient[Request, Response] { self: 
       response.asInstanceOf[A]
     } else {
       // Need a conversion
-      val standardResponseCodec = new HttpResponseCodec[Response]
+      val standardResponseCodec = new HttpResponseBodyCodec[Response]
       val codec                 = MessageCodec.of[A]
       val msgpack               = standardResponseCodec.toMsgPack(response)
       codec.unpack(msgpack)

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/client/URLConnectionClientBackend.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/client/URLConnectionClientBackend.scala
@@ -14,7 +14,14 @@
 package wvlet.airframe.http.client
 import wvlet.airframe.control.Retry
 import wvlet.airframe.http.HttpMessage.{Request, Response}
-import wvlet.airframe.http.{HttpClient, HttpClientBackend, HttpClientConfig, HttpSyncClient, RPCClient, ServerAddress}
+import wvlet.airframe.http.{
+  HttpClient,
+  HttpClientBackend,
+  HttpClientConfig,
+  HttpSyncClient,
+  RPCHttpClient,
+  ServerAddress
+}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -45,5 +52,5 @@ object URLConnectionClientBackend extends HttpClientBackend {
     throw new UnsupportedOperationException("Default async client is not supported.")
   }
 
-  override def newRPCClientForScalaJS(clientConfig: HttpClientConfig): RPCClient = ???
+  override def newRPCClientForScalaJS(clientConfig: HttpClientConfig): RPCHttpClient = ???
 }

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/client/URLConnectionClientBackend.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/client/URLConnectionClientBackend.scala
@@ -12,12 +12,21 @@
  * limitations under the License.
  */
 package wvlet.airframe.http.client
+import wvlet.airframe.control.Retry
 import wvlet.airframe.http.HttpMessage.{Request, Response}
-import wvlet.airframe.http.{HttpClientBackend, HttpClientConfig, HttpSyncClient, ServerAddress}
+import wvlet.airframe.http.{HttpClient, HttpClientBackend, HttpClientConfig, HttpSyncClient, ServerAddress}
+
+import scala.concurrent.{ExecutionContext, Future}
 
 /**
   */
 object URLConnectionClientBackend extends HttpClientBackend {
+  override def defaultExecutionContext: ExecutionContext = ???
+
+  override def defaultRequestRetryer: Retry.RetryContext = {
+    HttpClient.defaultHttpClientRetry[Request, Response]
+  }
+
   def newSyncClient(serverAddress: String, clientConfig: HttpClientConfig): HttpSyncClient[Request, Response] = {
     new URLConnectionClient(
       ServerAddress(serverAddress),
@@ -28,4 +37,12 @@ object URLConnectionClientBackend extends HttpClientBackend {
       )
     )
   }
+
+  override def newAsyncClient(
+      serverAddress: String,
+      clientConfig: HttpClientConfig
+  ): HttpClient[Future, Request, Response] = {
+    throw new UnsupportedOperationException("Default async client is not supported.")
+  }
+
 }

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/client/URLConnectionClientBackend.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/client/URLConnectionClientBackend.scala
@@ -14,7 +14,7 @@
 package wvlet.airframe.http.client
 import wvlet.airframe.control.Retry
 import wvlet.airframe.http.HttpMessage.{Request, Response}
-import wvlet.airframe.http.{HttpClient, HttpClientBackend, HttpClientConfig, HttpSyncClient, ServerAddress}
+import wvlet.airframe.http.{HttpClient, HttpClientBackend, HttpClientConfig, HttpSyncClient, RPCClient, ServerAddress}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -45,4 +45,5 @@ object URLConnectionClientBackend extends HttpClientBackend {
     throw new UnsupportedOperationException("Default async client is not supported.")
   }
 
+  override def newRPCClientForScalaJS(clientConfig: HttpClientConfig): RPCClient = ???
 }

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/HttpMessageTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/HttpMessageTest.scala
@@ -156,7 +156,7 @@ class HttpMessageTest extends AirSpec {
   test("msgpack request") {
     val r = Http.request("/v1/info").withAcceptMsgPack
 
-    r.accept shouldBe Seq("application/x-msgpack")
+    r.accept shouldBe Seq(HttpHeader.MediaType.ApplicationMsgPack)
     r.acceptsMsgPack shouldBe true
     r.acceptsJson shouldBe false
   }

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/RPCClientTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/RPCClientTest.scala
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.http
+
+import wvlet.airspec.AirSpec
+
+object RPCClientTest extends AirSpec {
+
+  // Use a public REST test server
+  private val PUBLIC_REST_SERVICE = "https://httpbin.org/"
+
+  case class TestRequest(id: Int, name: String)
+  case class TestResponse(url: String, headers: Map[String, Any])
+
+  test("Create RPC Client") {
+    val config    = RPCClientConfig()
+    val client    = Http.client.newSyncClient(PUBLIC_REST_SERVICE)
+    val rpcClient = new RPCSyncClient(config, client)
+    val response  = rpcClient.send[TestRequest, TestResponse]("/post", TestRequest(1, "test"), identity)
+
+    // Test message
+    debug(response)
+    response.headers.get("Content-Type") shouldBe Some("application/msgpack")
+  }
+
+}

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/RPCClientTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/RPCClientTest.scala
@@ -24,9 +24,7 @@ object RPCClientTest extends AirSpec {
   case class TestResponse(url: String, headers: Map[String, Any])
 
   test("Create an RPCSyncClient") {
-    val config    = HttpClientConfig()
-    val client    = Http.client.newSyncClient(PUBLIC_REST_SERVICE)
-    val rpcClient = new RPCSyncClient(config, client)
+    val rpcClient = Http.client.newRPCSyncClient(PUBLIC_REST_SERVICE)
     val response  = rpcClient.send[TestRequest, TestResponse]("/post", TestRequest(1, "test"), identity)
 
     // Test message

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/RPCClientTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/RPCClientTest.scala
@@ -23,7 +23,19 @@ object RPCClientTest extends AirSpec {
   case class TestRequest(id: Int, name: String)
   case class TestResponse(url: String, headers: Map[String, Any])
 
-  test("Create RPC Client") {
+  test("Create an RPCSyncClient") {
+    val config    = RPCClientConfig()
+    val client    = Http.client.newSyncClient(PUBLIC_REST_SERVICE)
+    val rpcClient = new RPCSyncClient(config, client)
+    val response  = rpcClient.send[TestRequest, TestResponse]("/post", TestRequest(1, "test"), identity)
+
+    // Test message
+    debug(response)
+    response.headers.get("Content-Type") shouldBe Some("application/msgpack")
+  }
+
+  test("Create an Async RPCClient") {
+
     val config    = RPCClientConfig()
     val client    = Http.client.newSyncClient(PUBLIC_REST_SERVICE)
     val rpcClient = new RPCSyncClient(config, client)

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/RPCHttpClientTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/RPCHttpClientTest.scala
@@ -15,7 +15,7 @@ package wvlet.airframe.http
 
 import wvlet.airspec.AirSpec
 
-object RPCClientTest extends AirSpec {
+object RPCHttpClientTest extends AirSpec {
 
   // Use a public REST test server
   private val PUBLIC_REST_SERVICE = "https://httpbin.org/"

--- a/airframe-http/src/main/scala-2/wvlet/airframe/http/RPCClientBase.scala
+++ b/airframe-http/src/main/scala-2/wvlet/airframe/http/RPCClientBase.scala
@@ -16,6 +16,7 @@ package wvlet.airframe.http
 import wvlet.airframe.http.HttpMessage.Request
 import wvlet.airframe.http.impl.HttpMacros
 
+import scala.concurrent.{ExecutionContext, Future}
 import scala.language.experimental.macros
 
 /**
@@ -27,4 +28,12 @@ trait RPCSyncClientBase { self: RPCSyncClient =>
       request: RequestType,
       requestFilter: Request => Request
   ): ResponseType = macro HttpMacros.rpcSend[RequestType, ResponseType]
+}
+
+trait RPCClientBase { self: RPCClient =>
+  def send[RequestType, ResponseType](
+      resourcePath: String,
+      request: RequestType,
+      requestFilter: Request => Request
+  )(implicit ec: ExecutionContext): Future[ResponseType] = macro HttpMacros.rpcSendAsync[Request, ResponseType]
 }

--- a/airframe-http/src/main/scala-2/wvlet/airframe/http/RPCClientBase.scala
+++ b/airframe-http/src/main/scala-2/wvlet/airframe/http/RPCClientBase.scala
@@ -22,7 +22,7 @@ import scala.language.experimental.macros
 /**
   * Scala 2 specific helper method to make an RPC request
   */
-trait RPCSyncClientBase { self: RPCSyncClient =>
+trait RPCSyncClientBase { self: RPCHttpSyncClient =>
   def send[RequestType, ResponseType](
       resourcePath: String,
       request: RequestType,
@@ -30,7 +30,7 @@ trait RPCSyncClientBase { self: RPCSyncClient =>
   ): ResponseType = macro HttpMacros.rpcSend[RequestType, ResponseType]
 }
 
-trait RPCClientBase { self: RPCClient =>
+trait RPCClientBase { self: RPCHttpClient =>
   def send[RequestType, ResponseType](
       resourcePath: String,
       request: RequestType,

--- a/airframe-http/src/main/scala-2/wvlet/airframe/http/RPCClientBase.scala
+++ b/airframe-http/src/main/scala-2/wvlet/airframe/http/RPCClientBase.scala
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.http
+
+import wvlet.airframe.http.HttpMessage.Request
+import wvlet.airframe.http.impl.HttpMacros
+
+import scala.language.experimental.macros
+
+/**
+  * Scala 2 specific helper method to make an RPC request
+  */
+trait RPCSyncClientBase { self: RPCSyncClient =>
+  def send[RequestType, ResponseType](
+      resourcePath: String,
+      request: RequestType,
+      requestFilter: Request => Request
+  ): ResponseType = macro HttpMacros.rpcSend[RequestType, ResponseType]
+}

--- a/airframe-http/src/main/scala-2/wvlet/airframe/http/RPCClientBase.scala
+++ b/airframe-http/src/main/scala-2/wvlet/airframe/http/RPCClientBase.scala
@@ -35,5 +35,5 @@ trait RPCClientBase { self: RPCClient =>
       resourcePath: String,
       request: RequestType,
       requestFilter: Request => Request
-  )(implicit ec: ExecutionContext): Future[ResponseType] = macro HttpMacros.rpcSendAsync[Request, ResponseType]
+  ): Future[ResponseType] = macro HttpMacros.rpcSendAsync[RequestType, ResponseType]
 }

--- a/airframe-http/src/main/scala-2/wvlet/airframe/http/impl/HttpMacros.scala
+++ b/airframe-http/src/main/scala-2/wvlet/airframe/http/impl/HttpMacros.scala
@@ -37,6 +37,23 @@ object HttpMacros {
        }"""
   }
 
+  def rpcSendAsync[RequestType: c.WeakTypeTag, ResponseType: c.WeakTypeTag](
+      c: sm.Context
+  )(resourcePath: c.Tree, request: c.Tree, requestFilter: c.Tree)(ec: c.Tree): c.Tree = {
+    import c.universe._
+    val t1 = implicitly[c.WeakTypeTag[RequestType]]
+    val t2 = implicitly[c.WeakTypeTag[ResponseType]]
+    q"""{
+          ${c.prefix}.sendRaw(
+            ${resourcePath},
+            wvlet.airframe.surface.Surface.of[${t1}],
+            ${request},
+            wvlet.airframe.surface.Surface.of[${t2}],
+            ${requestFilter}
+          )(${ec}).asInstanceOf[${t2}]
+       }"""
+  }
+
   def toJsonWithCodecFactory[A: c.WeakTypeTag](c: sm.Context)(a: c.Tree, codecFactory: c.Tree): c.Tree = {
     import c.universe._
 

--- a/airframe-http/src/main/scala-2/wvlet/airframe/http/impl/HttpMacros.scala
+++ b/airframe-http/src/main/scala-2/wvlet/airframe/http/impl/HttpMacros.scala
@@ -19,6 +19,24 @@ import scala.reflect.macros.{blackbox => sm}
 /**
   */
 object HttpMacros {
+
+  def rpcSend[RequestType: c.WeakTypeTag, ResponseType: c.WeakTypeTag](
+      c: sm.Context
+  )(resourcePath: c.Tree, request: c.Tree, requestFilter: c.Tree): c.Tree = {
+    import c.universe._
+    val t1 = implicitly[c.WeakTypeTag[RequestType]]
+    val t2 = implicitly[c.WeakTypeTag[ResponseType]]
+    q"""{
+          ${c.prefix}.sendRaw(
+            ${resourcePath},
+            wvlet.airframe.surface.Surface.of[${t1}],
+            ${request},
+            wvlet.airframe.surface.Surface.of[${t2}],
+            ${requestFilter}
+          ).asInstanceOf[${t2}]
+       }"""
+  }
+
   def toJsonWithCodecFactory[A: c.WeakTypeTag](c: sm.Context)(a: c.Tree, codecFactory: c.Tree): c.Tree = {
     import c.universe._
 

--- a/airframe-http/src/main/scala-2/wvlet/airframe/http/impl/HttpMacros.scala
+++ b/airframe-http/src/main/scala-2/wvlet/airframe/http/impl/HttpMacros.scala
@@ -39,7 +39,7 @@ object HttpMacros {
 
   def rpcSendAsync[RequestType: c.WeakTypeTag, ResponseType: c.WeakTypeTag](
       c: sm.Context
-  )(resourcePath: c.Tree, request: c.Tree, requestFilter: c.Tree)(ec: c.Tree): c.Tree = {
+  )(resourcePath: c.Tree, request: c.Tree, requestFilter: c.Tree): c.Tree = {
     import c.universe._
     val t1 = implicitly[c.WeakTypeTag[RequestType]]
     val t2 = implicitly[c.WeakTypeTag[ResponseType]]
@@ -50,7 +50,7 @@ object HttpMacros {
             ${request},
             wvlet.airframe.surface.Surface.of[${t2}],
             ${requestFilter}
-          )(${ec}).asInstanceOf[${t2}]
+          ).asInstanceOf[scala.concurrent.Future[${t2}]]
        }"""
   }
 

--- a/airframe-http/src/main/scala-3/wvlet/airframe/http/RPCClientBase.scala
+++ b/airframe-http/src/main/scala-3/wvlet/airframe/http/RPCClientBase.scala
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.http
+
+import wvlet.airframe.surface.Surface
+import wvlet.airframe.http.HttpMessage.{Response,Request}
+/**
+  * Scala 3 specific helper method to make an RPC request
+  */
+trait RPCSyncClientBase { self: RPCSyncClient =>
+  inline def send[RequestType, ResponseType](
+      resourcePath: String,
+      request: RequestType,
+      requestFilter: Request => Request
+  ): ResponseType = {
+    self.sendRaw(resourcePath, Surface.of[RequestType], request, Surface.of[ResponseType], requestFilter).asInstanceOf[ResponseType]
+  }
+}

--- a/airframe-http/src/main/scala-3/wvlet/airframe/http/RPCClientBase.scala
+++ b/airframe-http/src/main/scala-3/wvlet/airframe/http/RPCClientBase.scala
@@ -20,7 +20,7 @@ import scala.concurrent.Future
 /**
   * Scala 3 specific helper method to make an RPC request
   */
-trait RPCSyncClientBase { self: RPCSyncClient =>
+trait RPCSyncClientBase { self: RPCHttpSyncClient =>
   inline def send[RequestType, ResponseType](
       resourcePath: String,
       request: RequestType,
@@ -31,7 +31,7 @@ trait RPCSyncClientBase { self: RPCSyncClient =>
 }
 
 
-trait RPCClientBase { self: RPCClient =>
+trait RPCClientBase { self: RPCHttpClient =>
   inline def send[RequestType, ResponseType](
     resourcePath: String,
     request: RequestType,

--- a/airframe-http/src/main/scala-3/wvlet/airframe/http/RPCClientBase.scala
+++ b/airframe-http/src/main/scala-3/wvlet/airframe/http/RPCClientBase.scala
@@ -15,6 +15,8 @@ package wvlet.airframe.http
 
 import wvlet.airframe.surface.Surface
 import wvlet.airframe.http.HttpMessage.{Response,Request}
+import scala.concurrent.Future
+
 /**
   * Scala 3 specific helper method to make an RPC request
   */
@@ -25,5 +27,16 @@ trait RPCSyncClientBase { self: RPCSyncClient =>
       requestFilter: Request => Request
   ): ResponseType = {
     self.sendRaw(resourcePath, Surface.of[RequestType], request, Surface.of[ResponseType], requestFilter).asInstanceOf[ResponseType]
+  }
+}
+
+
+trait RPCClientBase { self: RPCClient =>
+  inline def send[RequestType, ResponseType](
+    resourcePath: String,
+    request: RequestType,
+    requestFilter: Request => Request
+  ): Future[ResponseType] = {
+    self.sendRaw(resourcePath, Surface.of[RequestType], request, Surface.of[ResponseType], requestFilter).asInstanceOf[Future[ResponseType]]
   }
 }

--- a/airframe-http/src/main/scala/wvlet/airframe/http/Http.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/Http.scala
@@ -156,10 +156,17 @@ trait HttpRequest[Req] {
   def contentString: String        = adapter.contentStringOf(toRaw)
   def accept: Seq[String] =
     Http.parseAcceptHeader(header.get(HttpHeader.Accept))
-  def acceptsMsgPack: Boolean =
-    accept.contains(HttpHeader.MediaType.ApplicationMsgPack)
-  def acceptJson: Boolean =
-    accept.contains(HttpHeader.MediaType.ApplicationJson)
+  def acceptsMsgPack: Boolean = {
+    accept.contains(HttpHeader.MediaType.ApplicationMsgPack) ||
+    // legacy header
+    accept.contains("application/x-msgpack")
+  }
+
+  def acceptsJson: Boolean = {
+    accept.contains(HttpHeader.MediaType.ApplicationJson) ||
+    // Plain JSON header without encoding type
+    accept.contains("application/json")
+  }
 }
 
 /**

--- a/airframe-http/src/main/scala/wvlet/airframe/http/Http.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/Http.scala
@@ -158,6 +158,8 @@ trait HttpRequest[Req] {
     Http.parseAcceptHeader(header.get(HttpHeader.Accept))
   def acceptsMsgPack: Boolean =
     accept.contains(HttpHeader.MediaType.ApplicationMsgPack)
+  def acceptJson: Boolean =
+    accept.contains(HttpHeader.MediaType.ApplicationJson)
 }
 
 /**

--- a/airframe-http/src/main/scala/wvlet/airframe/http/HttpClient.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/HttpClient.scala
@@ -75,16 +75,17 @@ trait HttpSyncClient[Req, Resp] extends HttpSyncClientBase[Req, Resp] with AutoC
 
   def sendSafe(req: Req, requestFilter: Req => Req = identity): Resp
 
+  private val standardResponseCodec = new HttpResponseCodec[Response]
+
   protected def convertAs[A](response: Response, surface: Surface): A = {
     if (classOf[Response].isAssignableFrom(surface.rawType)) {
       // Can return the response as is
       response.asInstanceOf[A]
     } else {
       // Need a conversion
-      val standardResponseCodec = new HttpResponseCodec[Response]
-      val codec                 = MessageCodec.ofSurface(surface)
-      val msgpack               = standardResponseCodec.toMsgPack(response)
-      val obj                   = codec.unpack(msgpack)
+      val codec   = MessageCodec.ofSurface(surface)
+      val msgpack = standardResponseCodec.toMsgPack(response)
+      val obj     = codec.unpack(msgpack)
       obj.asInstanceOf[A]
     }
   }

--- a/airframe-http/src/main/scala/wvlet/airframe/http/HttpClient.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/HttpClient.scala
@@ -75,7 +75,7 @@ trait HttpSyncClient[Req, Resp] extends HttpSyncClientBase[Req, Resp] with AutoC
 
   def sendSafe(req: Req, requestFilter: Req => Req = identity): Resp
 
-  private val standardResponseCodec = new HttpResponseCodec[Response]
+  private val standardResponseCodec = new HttpResponseBodyCodec[Response]
 
   protected def convertAs[A](response: Response, surface: Surface): A = {
     if (classOf[Response].isAssignableFrom(surface.rawType)) {

--- a/airframe-http/src/main/scala/wvlet/airframe/http/HttpClientBackend.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/HttpClientBackend.scala
@@ -12,11 +12,20 @@
  * limitations under the License.
  */
 package wvlet.airframe.http
+import wvlet.airframe.control.Retry.RetryContext
 import wvlet.airframe.http.HttpMessage.{Request, Response}
+
+import scala.concurrent.{ExecutionContext, Future}
 
 /**
   */
 trait HttpClientBackend {
+  def defaultExecutionContext: ExecutionContext
+  def defaultRequestRetryer: RetryContext
+
   def newSyncClient(severAddress: String, clientConfig: HttpClientConfig): HttpSyncClient[Request, Response]
-  // def newClient(serverAddress: ServerAddress, clientConfig: HttpClientConfig): HttpClient[F, Request, Response] = ???
+  def newAsyncClient(
+      serverAddress: String,
+      clientConfig: HttpClientConfig
+  ): HttpClient[Future, Request, Response]
 }

--- a/airframe-http/src/main/scala/wvlet/airframe/http/HttpClientBackend.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/HttpClientBackend.scala
@@ -30,5 +30,5 @@ trait HttpClientBackend {
       clientConfig: HttpClientConfig
   ): HttpClient[Future, Request, Response]
 
-  def newRPCClientForScalaJS(clientConfig: HttpClientConfig): RPCClient
+  def newRPCClientForScalaJS(clientConfig: HttpClientConfig): RPCHttpClient
 }

--- a/airframe-http/src/main/scala/wvlet/airframe/http/HttpClientBackend.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/HttpClientBackend.scala
@@ -24,8 +24,11 @@ trait HttpClientBackend {
   def defaultRequestRetryer: RetryContext
 
   def newSyncClient(severAddress: String, clientConfig: HttpClientConfig): HttpSyncClient[Request, Response]
+
   def newAsyncClient(
       serverAddress: String,
       clientConfig: HttpClientConfig
   ): HttpClient[Future, Request, Response]
+
+  def newRPCClientForScalaJS(clientConfig: HttpClientConfig): RPCClient
 }

--- a/airframe-http/src/main/scala/wvlet/airframe/http/HttpClientConfig.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/HttpClientConfig.scala
@@ -38,11 +38,15 @@ case class HttpClientConfig(
       Rx.future(f)(Compat.defaultHttpClientBackend.defaultExecutionContext)
     }
 ) {
-  def newSyncClient(serverAddress: String): HttpSyncClient[Request, Response] =
+  def newSyncClient(serverAddress: String): Http.SyncClient =
     backend.newSyncClient(serverAddress, this)
 
-  def newAsyncClient(serverAddress: String): HttpClient[Future, Request, Response] =
+  def newAsyncClient(serverAddress: String): Http.AsyncClient =
     backend.newAsyncClient(serverAddress, this)
+
+  def newRPCClientForScalaJS: RPCClient = {
+    backend.newRPCClientForScalaJS(this)
+  }
 
   def withBackend(newBackend: HttpClientBackend): HttpClientConfig =
     this.copy(backend = newBackend)

--- a/airframe-http/src/main/scala/wvlet/airframe/http/HttpClientConfig.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/HttpClientConfig.scala
@@ -34,7 +34,7 @@ case class HttpClientConfig(
       * For converting Future[A] to Rx[A]. Use this method when you need to add a common error handler for Rx (e.g.,
       * with Rx.recover)
       */
-    rxConverter: Future[_] => RxStream[_] = { f: Future[_] =>
+    rxConverter: Future[_] => RxStream[_] = { (f: Future[_]) =>
       Rx.future(f)(Compat.defaultHttpClientBackend.defaultExecutionContext)
     }
 ) {
@@ -43,6 +43,10 @@ case class HttpClientConfig(
 
   def newAsyncClient(serverAddress: String): Http.AsyncClient =
     backend.newAsyncClient(serverAddress, this)
+
+  def newRPCSyncClient(serverAddress: String): RPCSyncClient = {
+    new RPCSyncClient(this, newSyncClient(serverAddress))
+  }
 
   def newRPCClientForScalaJS: RPCClient = {
     backend.newRPCClientForScalaJS(this)

--- a/airframe-http/src/main/scala/wvlet/airframe/http/HttpClientConfig.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/HttpClientConfig.scala
@@ -44,11 +44,11 @@ case class HttpClientConfig(
   def newAsyncClient(serverAddress: String): Http.AsyncClient =
     backend.newAsyncClient(serverAddress, this)
 
-  def newRPCSyncClient(serverAddress: String): RPCSyncClient = {
-    new RPCSyncClient(this, newSyncClient(serverAddress))
+  def newRPCSyncClient(serverAddress: String): RPCHttpSyncClient = {
+    new RPCHttpSyncClient(this, newSyncClient(serverAddress))
   }
 
-  def newRPCClientForScalaJS: RPCClient = {
+  def newRPCClientForScalaJS: RPCHttpClient = {
     backend.newRPCClientForScalaJS(this)
   }
 

--- a/airframe-http/src/main/scala/wvlet/airframe/http/HttpHeader.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/HttpHeader.scala
@@ -85,6 +85,6 @@ object HttpHeader {
 
   object MediaType {
     final val ApplicationJson    = "application/json;charset=utf-8"
-    final val ApplicationMsgPack = "application/x-msgpack"
+    final val ApplicationMsgPack = "application/msgpack"
   }
 }

--- a/airframe-http/src/main/scala/wvlet/airframe/http/HttpHeader.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/HttpHeader.scala
@@ -80,6 +80,9 @@ object HttpHeader {
   final val xForwardedFor                 = "X-Forwarded-For"
   final val xForwardedProto               = "X-Forwarded-Proto"
 
+  // Airframe RPC specific status code
+  final val xAirframeRPCStatus = "x-airframe-rpc-status"
+
   object MediaType {
     final val ApplicationJson    = "application/json;charset=utf-8"
     final val ApplicationMsgPack = "application/x-msgpack"

--- a/airframe-http/src/main/scala/wvlet/airframe/http/HttpMessage.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/HttpMessage.scala
@@ -112,13 +112,13 @@ trait HttpMessage[Raw] extends HttpMessageBase[Raw] {
     contentType.exists(_.startsWith("application/json"))
   }
   def isContentTypeMsgPack: Boolean = {
-    contentType.exists(x => x == HttpHeader.MediaType.ApplicationMsgPack || x == "application/msgpack")
+    contentType.exists(x => x == HttpHeader.MediaType.ApplicationMsgPack || x == "application/x-msgpack")
   }
   def acceptsJson: Boolean = {
     accept.exists(x => x == HttpHeader.MediaType.ApplicationJson || x.startsWith("application/json"))
   }
   def acceptsMsgPack: Boolean = {
-    accept.exists(x => x == HttpHeader.MediaType.ApplicationMsgPack || x == "application/msgpack")
+    accept.exists(x => x == HttpHeader.MediaType.ApplicationMsgPack || x == "application/x-msgpack")
   }
 }
 

--- a/airframe-http/src/main/scala/wvlet/airframe/http/HttpMessage.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/HttpMessage.scala
@@ -91,6 +91,7 @@ trait HttpMessage[Raw] extends HttpMessageBase[Raw] {
   // HTTP header setting utility methods
   def withAccept(acceptType: String): Raw = withHeader(HttpHeader.Accept, acceptType)
   def withAcceptMsgPack: Raw              = withHeader(HttpHeader.Accept, HttpHeader.MediaType.ApplicationMsgPack)
+  def withAcceptJson: Raw                 = withHeader(HttpHeader.Accept, HttpHeader.MediaType.ApplicationJson)
   def withAllow(allow: String): Raw       = withHeader(HttpHeader.Allow, allow)
   def withAuthorization(authorization: String): Raw     = withHeader(HttpHeader.Authorization, authorization)
   def withCacheControl(cacheControl: String): Raw       = withHeader(HttpHeader.CacheControl, cacheControl)

--- a/airframe-http/src/main/scala/wvlet/airframe/http/HttpResponseBodyCodec.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/HttpResponseBodyCodec.scala
@@ -18,7 +18,7 @@ import wvlet.airframe.msgpack.spi.{Packer, Unpacker}
 
 /**
   */
-class HttpResponseCodec[Resp: HttpResponseAdapter] extends MessageCodec[HttpResponse[_]] {
+class HttpResponseBodyCodec[Resp: HttpResponseAdapter] extends MessageCodec[HttpResponse[_]] {
   override def pack(p: Packer, v: HttpResponse[_]): Unit = {
     v.contentType match {
       case Some("application/msgpack") | Some("application/x-msgpack") =>

--- a/airframe-http/src/main/scala/wvlet/airframe/http/HttpResponseCodec.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/HttpResponseCodec.scala
@@ -21,7 +21,7 @@ import wvlet.airframe.msgpack.spi.{Packer, Unpacker}
 class HttpResponseCodec[Resp: HttpResponseAdapter] extends MessageCodec[HttpResponse[_]] {
   override def pack(p: Packer, v: HttpResponse[_]): Unit = {
     v.contentType match {
-      case Some("application/x-msgpack") =>
+      case Some("application/msgpack") | Some("application/x-msgpack") =>
         // Raw msgpack response
         val b = v.contentBytes
         p.writePayload(b)

--- a/airframe-http/src/main/scala/wvlet/airframe/http/RPCClient.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/RPCClient.scala
@@ -1,5 +1,5 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the vLicense");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -13,10 +13,12 @@
  */
 package wvlet.airframe.http
 
-import wvlet.airframe.codec.{MessageCodec, MessageCodecFactory}
+import wvlet.airframe.codec.{MessageCodec, MessageCodecException, MessageCodecFactory}
 import wvlet.airframe.control.Retry.RetryContext
 import wvlet.airframe.http.HttpMessage.{Request, Response}
 import wvlet.airframe.surface.Surface
+
+import scala.util.Try
 
 /**
   * Configuration for RPC clients
@@ -43,24 +45,78 @@ class RPCSyncClient(config: RPCClientConfig, httpSyncClient: Http.SyncClient) ex
     httpSyncClient.close()
   }
 
-  def sendRequest(
+  def send(
       path: String,
       requestSurface: Surface,
       requestContent: Any,
+      responseSurface: Surface,
       requestFilter: Request => Request = identity
-  ): HttpMessage.Response = {
-
+  ): Any = {
     val requestEncoder: MessageCodec[Any] =
       config.codecFactory.ofSurface(requestSurface).asInstanceOf[MessageCodec[Any]]
 
     val request: Request =
-      Http
-        .POST(path)
-        .withContentType(config.rpcEncoding.applicationType)
-        .withContent(config.rpcEncoding.encodeWithCodec[Any](requestContent, requestEncoder))
+      try {
+        Http
+          .POST(path)
+          .withContentType(config.rpcEncoding.applicationType)
+          .withContent(config.rpcEncoding.encodeWithCodec[Any](requestContent, requestEncoder))
+      } catch {
+        case e: MessageCodecException =>
+          throw RPCStatus.INVALID_ARGUMENT_U2.newException(
+            message = s"Failed to encode RPC request arguments: ${requestContent}",
+            cause = e
+          )
+      }
 
-    val response = httpSyncClient.sendSafe(request, config.requestFilter.andThen(requestFilter))
-    response
+    // sendSafe handles HttpClientException and return the response
+    val response: Response = httpSyncClient.sendSafe(request, config.requestFilter.andThen(requestFilter))
+
+    // Parse the RPC response
+    if (response.status.isSuccessful) {
+      parseResponse(response, responseSurface)
+    } else {
+      // Parse the RPC error message
+      val ex = parseRPCException(response)
+      throw ex
+    }
   }
 
+  private val standardResponseCodec = new HttpResponseCodec[Response]
+
+  private def parseResponse(response: Response, responseSurface: Surface): Any = {
+    if (classOf[Response].isAssignableFrom(responseSurface.rawType)) {
+      response
+    } else {
+      try {
+        val msgpack        = standardResponseCodec.toMsgPack(response)
+        val codec          = config.codecFactory.ofSurface(responseSurface)
+        val responseObject = codec.fromMsgPack(msgpack)
+        responseObject
+      } catch {
+        case e: MessageCodecException =>
+          throw RPCStatus.DATA_LOSS_I8.newException(s"Failed to parse the RPC response from the server: ${response}", e)
+      }
+    }
+  }
+
+  private def parseRPCException(response: Response): RPCException = {
+    response
+      .getHeader(HttpHeader.xAirframeRPCStatus)
+      .flatMap(x => Try(x.toInt).toOption) match {
+      case Some(rpcStatus) =>
+        try {
+          if (response.isContentTypeJson) {
+            RPCException.fromJson(response.contentString)
+          } else {
+            RPCException.fromMsgPack(response.contentBytes)
+          }
+        } catch {
+          case e: MessageCodecException =>
+            RPCStatus.ofCode(rpcStatus).newException(s"N/A", e)
+        }
+      case None =>
+        RPCStatus.DATA_LOSS_I8.newException(s"Invalid RPC response: ${response}")
+    }
+  }
 }

--- a/airframe-http/src/test/scala/wvlet/airframe/http/HttpRequestTest.scala
+++ b/airframe-http/src/test/scala/wvlet/airframe/http/HttpRequestTest.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.http
+
+import wvlet.airspec.AirSpec
+
+class HttpRequestTest extends AirSpec {
+
+  test("accept application/msgpack") {
+    val r = Http.POST("/").withAcceptMsgPack
+    r.acceptsMsgPack shouldBe true
+    r.acceptsJson shouldBe false
+  }
+
+  test("accept application/x-msgpack") {
+    val r = Http.POST("/").withAccept("application/x-msgpack")
+    r.acceptsMsgPack shouldBe true
+    r.acceptsJson shouldBe false
+  }
+
+  test("accept application/json;encoding=utf-8") {
+    val r = Http.POST("/").withAcceptJson
+    r.acceptsJson shouldBe true
+    r.acceptsMsgPack shouldBe false
+  }
+
+  test("accept application/json") {
+    val r = Http.POST("/").withAccept("application/json")
+    r.acceptsJson shouldBe true
+    r.acceptsMsgPack shouldBe false
+  }
+
+  test("content-type application/msgpack") {
+    val r = Http.POST("/").withContentTypeMsgPack
+    r.isContentTypeMsgPack shouldBe true
+    r.isContentTypeJson shouldBe false
+  }
+
+  test("content-type application/x-msgpack") {
+    val r = Http.POST("/").withContentType("application/x-msgpack")
+    r.isContentTypeMsgPack shouldBe true
+    r.isContentTypeJson shouldBe false
+  }
+
+  test("content-type application/json;encoding=utf-8") {
+    val r = Http.POST("/").withContentTypeJson
+    r.isContentTypeJson shouldBe true
+    r.isContentTypeMsgPack shouldBe false
+  }
+
+  test("content-type application/json") {
+    val r = Http.POST("/").withContentType("application/json")
+    r.isContentTypeJson shouldBe true
+    r.isContentTypeMsgPack shouldBe false
+  }
+
+}

--- a/docs/airframe-rpc.md
+++ b/docs/airframe-rpc.md
@@ -720,7 +720,7 @@ case class HelloResponse(message: String)
 - __Method__: POST
 - __Path__: `/(package name).(RPC interface name)/(method name)`
   - ex. `POST /hello.api.v1.MyService/hello`
-- __Content-Type__: `application/x-msgpack` (default), `application/json`, or `application/grpc` (
+- __Content-Type__: `application/msgpack` (default), `application/json`, or `application/grpc` (
   gRPC backend with HTTP/2)
 - __Request body__: JSON or MessagePack (default) representation of the method arguments. Each
   method parameter names and arguments need to be a key-value pair in the JSON object.
@@ -736,7 +736,7 @@ case class HelloResponse(message: String)
 }
 ```
 
-- __Accept__: "application/json" or "application/x-msgpack" (default)
+- __Accept__: "application/json" or "application/msgpack" (default)
 - __Response body__: JSON or MessagePack (default) representation of the method return type:
 
 ```json


### PR DESCRIPTION
- [x] Use application/msgpack
- [x] Add RPCHttpClient base implementation
- [x] Read RPC error response from the http response body
- [x] Throw RPCException upon errors 
- [x] Async RPC client
- [x] Scala.js client
- [x] Add RPC specific parameters to HttpClientConfig 

I'll change the http client generator in a separate PR so as not to mixup adding RPCClient and its migration 