### PR TITLE
airframe-http: Add JSHttpAsyncClient

### DIFF
--- a/airframe-http/.js/src/main/scala/wvlet/airframe/http/client/JSHttpAsyncClient.scala
+++ b/airframe-http/.js/src/main/scala/wvlet/airframe/http/client/JSHttpAsyncClient.scala
@@ -1,0 +1,187 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.http.client
+import org.scalajs.dom
+import org.scalajs.dom.ext.Ajax.InputData
+import wvlet.airframe.control.Retry.RetryContext
+import wvlet.airframe.control.{CircuitBreaker, CircuitBreakerOpenException, ResultClass}
+import wvlet.airframe.http.HttpMessage.{Request, Response}
+import wvlet.airframe.http._
+import wvlet.log.LogSupport
+
+import java.nio.ByteBuffer
+import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.scalajs.js.typedarray.{ArrayBuffer, TypedArrayBuffer}
+import scala.util.{Failure, Success, Try}
+
+class JSHttpAsyncClient(config: HttpClientConfig, serverAddress: Option[ServerAddress] = None)
+    extends HttpAsyncClient
+    with LogSupport {
+
+  private implicit val ec: ExecutionContext  = config.newExecutionContext
+  private val circuitBreaker: CircuitBreaker = config.circuitBreaker.withName(s"${serverAddress}")
+
+  /**
+    * Provide the underlying ExecutionContext. This is only for internal-use
+    * @return
+    */
+  private[http] def getExecutionContext: ExecutionContext = ec
+
+  override def close(): Unit = {
+    // nothing to do
+  }
+
+  override def send(
+      req: HttpMessage.Request,
+      requestFilter: HttpMessage.Request => HttpMessage.Request
+  ): Future[HttpMessage.Response] = {
+    val request = buildRequest(req, requestFilter)
+    dispatch(config.retryContext, request)
+  }
+
+  override def sendSafe(
+      req: HttpMessage.Request,
+      requestFilter: HttpMessage.Request => HttpMessage.Request
+  ): Future[HttpMessage.Response] = {
+    send(req, requestFilter).transform { ret =>
+      ret match {
+        case Failure(e: HttpClientException) =>
+          Success(e.response.toHttpResponse)
+        case _ =>
+          ret
+      }
+    }
+  }
+
+  private def buildRequest(request: Request, requestFilter: Request => Request): Request = {
+    request
+      // Apply the default filter first
+      .withFilter(config.requestFilter)
+      // Apply RPC encoding filter
+      .withFilter { r =>
+        config.rpcEncoding match {
+          case RPCEncoding.MsgPack =>
+            r.withContentTypeMsgPack.withAcceptMsgPack
+          case RPCEncoding.JSON =>
+            r.withContentTypeJson.withAcceptJson
+        }
+      }
+      // Lastly, apply the user-provided filter
+      .withFilter(requestFilter)
+  }
+
+  /**
+    * Send the request. If necessary, retry the request
+    * @param retryContext
+    * @param request
+    * @return
+    */
+  private def dispatch(retryContext: RetryContext, request: Request): Future[Response] = {
+    try {
+      // This will throw CircuitBreakerException if the circuit is open
+      circuitBreaker.verifyConnection
+      dispatchInternal(retryContext, request)
+    } catch {
+      case e: CircuitBreakerOpenException =>
+        Future.failed(e)
+    }
+  }
+
+  private def dispatchInternal(retryContext: RetryContext, request: Request): Future[Response] = {
+    val xhr = new dom.XMLHttpRequest()
+    val uri = serverAddress.map(address => s"${address.uri}${request.uri}").getOrElse(request.uri)
+
+    trace(s"Sending request: ${request}")
+    xhr.open(request.method, uri)
+    xhr.responseType = "arraybuffer"
+    xhr.timeout = 0
+    xhr.withCredentials = false
+    // Setting the header must be called after xhr.open(...)
+    request.header.entries.foreach { x => xhr.setRequestHeader(x.key, x.value) }
+
+    val promise           = Promise[Response]()
+    val data: Array[Byte] = request.contentBytes
+    if (data.isEmpty) {
+      xhr.send()
+    } else {
+      val input: InputData = ByteBuffer.wrap(data)
+      xhr.send(input)
+    }
+
+    xhr.onreadystatechange = { (e: dom.Event) =>
+      if (xhr.readyState == 4) { // Ajax request is DONE
+        // Prepare HttpMessage.Response
+        var resp = Http.response(HttpStatus.ofCode(xhr.status))
+
+        // This part needs to be exception-free
+        Try {
+          // Set response headers
+          val header = HttpMultiMap.newBuilder
+          xhr
+            .getAllResponseHeaders()
+            .split("\n")
+            .foreach { line =>
+              line.split(":") match {
+                case Array(k, v) => header += k.trim -> v.trim
+                case _           =>
+              }
+            }
+          resp = resp.withHeader(header.result())
+        }
+
+        // This part also needs to be exception-free
+        Try {
+          // Read response content
+          Option(xhr.response).foreach { r =>
+            val arrayBuffer = r.asInstanceOf[ArrayBuffer]
+            val dst         = new Array[Byte](arrayBuffer.byteLength)
+            TypedArrayBuffer.wrap(arrayBuffer).get(dst, 0, arrayBuffer.byteLength)
+            resp = resp.withContent(dst)
+          }
+        }
+        trace(s"Get response: ${resp}")
+
+        retryContext.resultClassifier(resp) match {
+          case ResultClass.Succeeded =>
+            circuitBreaker.recordSuccess
+            // if ((xhr.status >= 200 && xhr.status < 300) || xhr.status == 304)
+            promise.success(resp)
+          case ResultClass.Failed(isRetryable, cause, extraWait) =>
+            circuitBreaker.recordFailure(cause)
+            if (!retryContext.canContinue) {
+              promise.failure(HttpClientMaxRetryException(resp, retryContext, cause))
+            } else if (!isRetryable) {
+              promise.failure(cause)
+            } else {
+              val nextRetry  = retryContext.nextRetry(cause)
+              val waitMillis = retryContext.nextWaitMillis
+              // Wait before the next request
+              scalajs.js.timers.setTimeout(waitMillis) {
+                dispatch(nextRetry, request).onComplete {
+                  case Success(resp) =>
+                    promise.success(resp)
+                  case Failure(e) =>
+                    promise.failure(e)
+                }
+              }
+            }
+        }
+      }
+    }
+
+    val future = promise.future
+    future
+  }
+
+}

--- a/airframe-http/.js/src/main/scala/wvlet/airframe/http/js/JSHttpClient.scala
+++ b/airframe-http/.js/src/main/scala/wvlet/airframe/http/js/JSHttpClient.scala
@@ -12,24 +12,20 @@
  * limitations under the License.
  */
 package wvlet.airframe.http.js
-import java.nio.ByteBuffer
-import org.scalajs.dom
-import org.scalajs.dom.ext.Ajax.InputData
 import org.scalajs.dom.window
 import wvlet.airframe.codec.{MessageCodec, MessageCodecFactory}
 import wvlet.airframe.control.Retry.RetryContext
-import wvlet.airframe.control.{CircuitBreaker, CircuitBreakerOpenException, ResultClass, Retry}
+import wvlet.airframe.control.{CircuitBreaker, Retry}
 import wvlet.airframe.http.HttpClient.defaultBeforeRetryAction
 import wvlet.airframe.http.HttpMessage._
 import wvlet.airframe.http._
+import wvlet.airframe.http.client.JSHttpAsyncClient
 import wvlet.airframe.http.js.JSHttpClient.MessageEncoding
 import wvlet.airframe.rx.{Rx, RxStream}
 import wvlet.airframe.surface.{Primitive, Surface}
 import wvlet.log.LogSupport
 
-import scala.concurrent.{Future, Promise}
-import scala.scalajs.js.typedarray.{ArrayBuffer, TypedArrayBuffer}
-import scala.util.{Failure, Success, Try}
+import scala.concurrent.{ExecutionContext, Future}
 
 object JSHttpClient {
 
@@ -92,6 +88,21 @@ case class JSHttpClientConfig(
       Rx.future(f)(scala.scalajs.concurrent.JSExecutionContext.queue)
     }
 ) {
+  def toHttpClientConfig: HttpClientConfig = {
+    Http.client
+      .withRPCEncoding {
+        requestEncoding match {
+          case MessageEncoding.MessagePackEncoding => RPCEncoding.MsgPack
+          case MessageEncoding.JsonEncoding        => RPCEncoding.JSON
+        }
+      }
+      .withRequestFilter(requestFilter)
+      .withRetryContext(_ => retryContext)
+      .withCodecFactory(codecFactory)
+      .withCircuitBreaker(_ => circuitBreaker)
+      .withRxConverter(rxConverter)
+  }
+
   def withServerAddress(newServerAddress: ServerAddress): JSHttpClientConfig = {
     this.copy(serverAddress = Some(newServerAddress))
   }
@@ -130,10 +141,13 @@ case class JSHttpClientConfig(
   * We do not implement HttpClient[F, Request, Response] interface as no TypeTag is available in Scala.js
   */
 case class JSHttpClient(config: JSHttpClientConfig = JSHttpClientConfig()) extends LogSupport {
-  import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+  private def codecFactory = config.codecFactory.withMapOutput
 
-  private def codecFactory   = config.codecFactory.withMapOutput
-  private def circuitBreaker = config.circuitBreaker
+  private val client = new JSHttpAsyncClient(
+    config = config.toHttpClientConfig,
+    serverAddress = config.serverAddress
+  )
+  private implicit val ec: ExecutionContext = client.getExecutionContext
 
   /**
     * Modify the configuration based on the current configuration
@@ -144,120 +158,16 @@ case class JSHttpClient(config: JSHttpClientConfig = JSHttpClientConfig()) exten
     this.copy(config = configFilter(config))
   }
 
-  /**
-    * Send the request. If necessary, retry the request
-    * @param retryContext
-    * @param request
-    * @return
-    */
-  private def dispatch(retryContext: RetryContext, request: Request): Future[Response] = {
-    try {
-      // This will throw CircuitBreakerException if the circuit is open
-      circuitBreaker.verifyConnection
-      dispatchInternal(retryContext, request)
-    } catch {
-      case e: CircuitBreakerOpenException =>
-        Future.failed(e)
-    }
-  }
-
-  private def dispatchInternal(retryContext: RetryContext, request: Request): Future[Response] = {
-    val xhr = new dom.XMLHttpRequest()
-    val uri = config.serverAddress.map(address => s"${address.uri}${request.uri}").getOrElse(request.uri)
-    trace(s"Sending request: ${request}")
-    xhr.open(request.method, uri)
-    xhr.responseType = "arraybuffer"
-    xhr.timeout = 0
-    xhr.withCredentials = false
-    // Setting the header must be called after xhr.open(...)
-    request.header.entries.foreach { x => xhr.setRequestHeader(x.key, x.value) }
-
-    val promise           = Promise[Response]()
-    val data: Array[Byte] = request.contentBytes
-    if (data.isEmpty) {
-      xhr.send()
-    } else {
-      val input: InputData = ByteBuffer.wrap(data)
-      xhr.send(input)
-    }
-
-    xhr.onreadystatechange = { (e: dom.Event) =>
-      if (xhr.readyState == 4) { // Ajax request is DONE
-        // Prepare HttpMessage.Response
-        var resp = Http.response(HttpStatus.ofCode(xhr.status))
-
-        // This part needs to be exception-free
-        Try {
-          // Set response headers
-          val header = HttpMultiMap.newBuilder
-          xhr
-            .getAllResponseHeaders()
-            .split("\n")
-            .foreach { line =>
-              line.split(":") match {
-                case Array(k, v) => header += k.trim -> v.trim
-                case _           =>
-              }
-            }
-          resp = resp.withHeader(header.result())
-        }
-
-        // This part also needs to be exception-free
-        Try {
-          // Read response content
-          Option(xhr.response).foreach { r =>
-            val arrayBuffer = r.asInstanceOf[ArrayBuffer]
-            val dst         = new Array[Byte](arrayBuffer.byteLength)
-            TypedArrayBuffer.wrap(arrayBuffer).get(dst, 0, arrayBuffer.byteLength)
-            resp = resp.withContent(dst)
-          }
-        }
-        trace(s"Get response: ${resp}")
-
-        retryContext.resultClassifier(resp) match {
-          case ResultClass.Succeeded =>
-            circuitBreaker.recordSuccess
-            // if ((xhr.status >= 200 && xhr.status < 300) || xhr.status == 304)
-            promise.success(resp)
-          case ResultClass.Failed(isRetryable, cause, extraWait) =>
-            circuitBreaker.recordFailure(cause)
-            if (!retryContext.canContinue) {
-              promise.failure(HttpClientMaxRetryException(resp, retryContext, cause))
-            } else if (!isRetryable) {
-              promise.failure(cause)
-            } else {
-              val nextRetry  = retryContext.nextRetry(cause)
-              val waitMillis = retryContext.nextWaitMillis
-              // Wait before the next request
-              scalajs.js.timers.setTimeout(waitMillis) {
-                dispatch(nextRetry, request).onComplete {
-                  case Success(resp) =>
-                    promise.success(resp)
-                  case Failure(e) =>
-                    promise.failure(e)
-                }
-              }
-            }
-        }
-      }
-    }
-
-    val future = promise.future
-    future
-  }
-
   def sendRaw(request: Request, requestFilter: Request => Request = identity): Future[Response] = {
-    dispatch(config.retryContext, finalizeRequest(request, requestFilter))
+    client.send(request, requestFilter)
   }
 
   def send[OperationResponse](
-      originalRequest: Request,
+      request: Request,
       operationResponseSurface: Surface,
       requestFilter: Request => Request = identity
   ): Future[OperationResponse] = {
-    // Apply the default request filter first, and then apply the custom filter
-    val request = finalizeRequest(originalRequest, requestFilter)
-    dispatch(config.retryContext, request).map { resp =>
+    sendRaw(request, requestFilter).map { resp =>
       operationResponseSurface match {
         case s if s.rawType == classOf[HttpMessage.Response] =>
           resp.asInstanceOf[OperationResponse]
@@ -295,20 +205,6 @@ case class JSHttpClient(config: JSHttpClientConfig = JSHttpClientConfig()) exten
       case MessageEncoding.JsonEncoding =>
         request.withContentTypeJson.withContent(resourceCodec.toJson(resource))
     }
-  }
-
-  private def finalizeRequest(request: Request, requestFilter: Request => Request): Request = {
-    request
-      .withFilter(config.requestFilter)
-      .withFilter { r =>
-        config.requestEncoding match {
-          case MessageEncoding.MessagePackEncoding =>
-            r.withContentTypeMsgPack.withAcceptMsgPack
-          case MessageEncoding.JsonEncoding =>
-            r.withContentTypeJson
-        }
-      }
-      .withFilter(requestFilter)
   }
 
   def sendResource[Resource](

--- a/airframe-http/.js/src/test/scala/wvlet/airframe/http/client/JSHttpAsyncClientTest.scala
+++ b/airframe-http/.js/src/test/scala/wvlet/airframe/http/client/JSHttpAsyncClientTest.scala
@@ -63,6 +63,19 @@ class JSHttpAsyncClientTest extends AirSpec {
       }
     }
 
+    test("404") {
+      client.sendSafe(Http.GET("/status/404")).transform { ret =>
+        ret match {
+          case Success(resp) =>
+            resp.status shouldBe HttpStatus.NotFound_404
+            ret
+          case _ =>
+            fail(s"Cannot reach here")
+            ret
+        }
+      }
+    }
+
     test("404 with HttpClientException") {
       client.send(Http.GET("/status/404")).transform { ret =>
         ret match {

--- a/airframe-http/.js/src/test/scala/wvlet/airframe/http/client/JSHttpAsyncClientTest.scala
+++ b/airframe-http/.js/src/test/scala/wvlet/airframe/http/client/JSHttpAsyncClientTest.scala
@@ -1,0 +1,111 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.http.client
+
+import wvlet.airframe.Design
+import wvlet.airframe.codec.MessageCodec
+import wvlet.airframe.control.{CircuitBreaker, CircuitBreakerOpenException}
+import wvlet.airframe.http.{Http, HttpClientException, HttpClientMaxRetryException, HttpStatus, ServerAddress}
+import wvlet.airframe.json.JSON
+import wvlet.airspec.AirSpec
+
+import scala.concurrent.ExecutionContext
+import scala.util.{Failure, Success}
+
+class JSHttpAsyncClientTest extends AirSpec {
+  private implicit val ec: ExecutionContext = defaultExecutionContext
+
+  // Use a public REST test server
+  private val PUBLIC_REST_SERVICE = "https://httpbin.org/"
+
+  override def design: Design =
+    Design.newDesign
+      .bind[HttpAsyncClient].toInstance {
+        new JSHttpAsyncClient(
+          Http.client.withRetryContext(_.withMaxRetry(1)),
+          Some(ServerAddress(PUBLIC_REST_SERVICE))
+        )
+      }
+
+  test("java http sync client") { (client: HttpAsyncClient) =>
+    test("GET") {
+      client
+        .send(Http.GET("/get?id=1&name=leo"))
+        .map { resp =>
+          resp.status shouldBe HttpStatus.Ok_200
+          resp.isContentTypeJson shouldBe true
+          val json = JSON.parse(resp.message.toContentString).toJSON
+          val m    = MessageCodec.of[Map[String, Any]].fromJson(json)
+          m("args") shouldBe Map("id" -> "1", "name" -> "leo")
+        }
+    }
+
+    test("POST") {
+      val data = """{"id":1,"name":"leo"}"""
+      client.send(Http.POST("/post").withContent(data)).map { resp =>
+        resp.status shouldBe HttpStatus.Ok_200
+        resp.isContentTypeJson shouldBe true
+        val json = JSON.parse(resp.message.toContentString).toJSON
+        val m    = MessageCodec.of[Map[String, Any]].fromJson(json)
+        m("data") shouldBe data
+        m("json") shouldBe Map("id" -> 1, "name" -> "leo")
+      }
+    }
+
+    test("404 with HttpClientException") {
+      client.send(Http.GET("/status/404")).transform { ret =>
+        ret match {
+          case Success(_) =>
+            Failure(new IllegalStateException("should not reach here"))
+          case Failure(e: HttpClientException) =>
+            e.status shouldBe HttpStatus.NotFound_404
+            Success(())
+          case Failure(e: Throwable) =>
+            ret
+        }
+      }
+    }
+
+    test("handle max retry") {
+      client.send(Http.GET("/status/500")).transform { ret =>
+        ret match {
+          case Success(_) =>
+            Failure(new IllegalStateException("should not reach here"))
+          case Failure(e: HttpClientMaxRetryException) =>
+            e.status.isServerError shouldBe true
+            Success(())
+          case _ =>
+            ret
+        }
+      }
+    }
+  }
+
+  test("circuit breaker test") {
+    val client = new JSHttpAsyncClient(
+      Http.client.withCircuitBreaker(_ => CircuitBreaker.withConsecutiveFailures(1)),
+      Some(ServerAddress(PUBLIC_REST_SERVICE))
+    )
+    client.send(Http.GET("/status/500")).transform { ret =>
+      ret match {
+        case Failure(e: CircuitBreakerOpenException) =>
+          // ok
+          Success(())
+        case other =>
+          fail(s"Unexpected response: ${other}")
+          ret
+      }
+    }
+  }
+}

--- a/airframe-http/.js/src/test/scala/wvlet/airframe/http/js/JSRPCClientTest.scala
+++ b/airframe-http/.js/src/test/scala/wvlet/airframe/http/js/JSRPCClientTest.scala
@@ -34,7 +34,7 @@ class JSRPCClientTest extends AirSpec {
       .map { response =>
         debug(response)
         response.headers.get("Content-Type") shouldBe Some("application/msgpack")
-      }(config.executionContextProvider(config))
+      }(config.newExecutionContext)
   }
 
   test("create RPC client") {

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/client/JavaHttpAsyncClient.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/client/JavaHttpAsyncClient.scala
@@ -33,6 +33,5 @@ class JavaHttpAsyncClient(syncClient: JavaHttpSyncClient) extends HttpAsyncClien
 
   override def sendSafe(req: Request, requestFilter: Request => Request): Future[Response] = {
     syncClient.sendSafeAsync(req, requestFilter)
-
   }
 }

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/client/JavaHttpSyncClient.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/client/JavaHttpSyncClient.scala
@@ -40,7 +40,7 @@ class JavaHttpSyncClient(serverAddress: ServerAddress, config: HttpClientConfig)
 
   private val javaHttpClient: HttpClient     = newClient(config)
   private val circuitBreaker: CircuitBreaker = config.circuitBreaker.withName(s"${serverAddress}")
-  private implicit val ec: ExecutionContext  = config.executionContextProvider(config)
+  private implicit val ec: ExecutionContext  = config.newExecutionContext
 
   override def close(): Unit = {
     // It seems Java Http Client has no close method

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/client/JavaHttpAsyncClientTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/client/JavaHttpAsyncClientTest.scala
@@ -63,6 +63,19 @@ class JavaHttpAsyncClientTest extends AirSpec {
       }
     }
 
+    test("404") {
+      client.sendSafe(Http.GET("/status/404")).transform { ret =>
+        ret match {
+          case Success(resp) =>
+            resp.status shouldBe HttpStatus.NotFound_404
+            ret
+          case _ =>
+            fail(s"Cannot reach here")
+            ret
+        }
+      }
+    }
+
     test("404 with HttpClientException") {
       client.send(Http.GET("/status/404")).transform { ret =>
         ret match {

--- a/airframe-http/src/main/scala/wvlet/airframe/http/HttpClientConfig.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/HttpClientConfig.scala
@@ -84,6 +84,8 @@ case class HttpClientConfig(
     this.copy(executionContextProvider = provider)
   }
 
+  def newExecutionContext: ExecutionContext = executionContextProvider(this)
+
   def withConnectTimeout(duration: Duration): HttpClientConfig = {
     this.copy(connectTimeout = duration)
   }


### PR DESCRIPTION
Add a new JS http client using the new interface added in #2188. 

The previous JSHttpClient implementation will be preserved for compatibility, but its internal will be replaced to the new JSHttpAsyncClient. 