### PR TITLE
Drop Java8 support and use Java11 http client by default

### DIFF
--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/Compat.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/Compat.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.http
 import java.net.URLEncoder
-import wvlet.airframe.http.client.{HttpClientBackend, URLConnectionClientBackend}
+import wvlet.airframe.http.client.{HttpClientBackend, JavaHttpClientBackend, URLConnectionClientBackend}
 
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.{Executors, ThreadFactory}
@@ -26,8 +26,7 @@ object Compat extends CompatApi {
     URLEncoder.encode(s, "UTF-8")
   }
   override def defaultHttpClientBackend: HttpClientBackend = {
-    // TODO: Use JDK11's HttpClient backend
-    URLConnectionClientBackend
+    JavaHttpClientBackend
   }
 
   private val threadFactoryId = new AtomicInteger()

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/client/JavaAsyncClient.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/client/JavaAsyncClient.scala
@@ -22,7 +22,7 @@ import scala.concurrent.{ExecutionContext, Future}
   * An wrapper of JavaHttpSyncClient for supporting async response
   * @param syncClient
   */
-class JavaAsyncClient(syncClient: JavaHttpSyncClient) extends AsyncClient {
+class JavaAsyncClient(syncClient: JavaSyncClient) extends AsyncClient {
 
   private[http] def config: HttpClientConfig           = syncClient.config
   private[http] val executionContext: ExecutionContext = syncClient.executionContext

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/client/JavaHttpClientBackend.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/client/JavaHttpClientBackend.scala
@@ -14,15 +14,15 @@
 package wvlet.airframe.http.client
 import wvlet.airframe.http.{HttpClientConfig, ServerAddress}
 
-object JVMHttpClientBackend extends HttpClientBackend {
+object JavaHttpClientBackend extends HttpClientBackend {
   override def newSyncClient(serverAddress: ServerAddress, clientConfig: HttpClientConfig): SyncClient = {
-    new JavaHttpSyncClient(serverAddress, clientConfig)
+    new JavaSyncClient(serverAddress, clientConfig)
   }
 
   override def newAsyncClient(
       serverAddress: ServerAddress,
       clientConfig: HttpClientConfig
   ): AsyncClient = {
-    new JavaHttpSyncClient(serverAddress, clientConfig).toAsyncClient
+    new JavaSyncClient(serverAddress, clientConfig).toAsyncClient
   }
 }

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/client/JavaSyncClient.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/client/JavaSyncClient.scala
@@ -36,7 +36,7 @@ import scala.util.control.NonFatal
   * @param serverAddress
   * @param config
   */
-class JavaHttpSyncClient(serverAddress: ServerAddress, private[client] val config: HttpClientConfig)
+class JavaSyncClient(serverAddress: ServerAddress, private[client] val config: HttpClientConfig)
     extends client.SyncClient {
 
   private val javaHttpClient: HttpClient                          = newClient(config)

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/client/JavaAsyncClientTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/client/JavaAsyncClientTest.scala
@@ -32,7 +32,7 @@ class JavaAsyncClientTest extends AirSpec {
   override def design: Design =
     Design.newDesign
       .bind[AsyncClient].toInstance {
-        new JavaHttpSyncClient(
+        new JavaSyncClient(
           ServerAddress(PUBLIC_REST_SERVICE),
           Http.client.withRetryContext(_.withMaxRetry(1))
         ).toAsyncClient

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/client/JavaSyncClientTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/client/JavaSyncClientTest.scala
@@ -29,7 +29,7 @@ class JavaSyncClientTest extends AirSpec {
   override def design: Design =
     Design.newDesign
       .bind[SyncClient].toInstance {
-        new JavaHttpSyncClient(ServerAddress(PUBLIC_REST_SERVICE), Http.client.withRetryContext(_.withMaxRetry(1)))
+        new JavaSyncClient(ServerAddress(PUBLIC_REST_SERVICE), Http.client.withRetryContext(_.withMaxRetry(1)))
       }
 
   test("java http sync client") { (client: SyncClient) =>
@@ -95,7 +95,7 @@ class JavaSyncClientTest extends AirSpec {
 
   test("circuit breaker") {
     withResource(
-      new JavaHttpSyncClient(
+      new JavaSyncClient(
         ServerAddress(PUBLIC_REST_SERVICE),
         Http.client.withCircuitBreaker(_ => CircuitBreaker.withConsecutiveFailures(1))
       )

--- a/airframe-http/src/main/scala/wvlet/airframe/http/Http.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/Http.scala
@@ -15,6 +15,7 @@ package wvlet.airframe.http
 
 import wvlet.airframe.http.HttpBackend.DefaultBackend
 import wvlet.airframe.http.HttpMessage.{Request, Response}
+import wvlet.airframe.http.client.SyncClient
 
 import java.time.{Instant, ZoneId, ZoneOffset}
 import java.time.format.DateTimeFormatter
@@ -43,12 +44,6 @@ object Http {
     * An entry point for building a new HttpClient
     */
   def client: HttpClientConfig = HttpClientConfig()
-
-  /**
-    * Create the default HTTP sync client for the target server address
-    */
-  def clientFor(serverAddress: String): wvlet.airframe.http.client.SyncClient =
-    client.newSyncClient(serverAddress)
 
   /**
     * Create a new request

--- a/build.sbt
+++ b/build.sbt
@@ -93,7 +93,7 @@ val buildSettings = Seq[Setting[_]](
   crossScalaVersions := targetScalaVersions,
   crossPaths         := true,
   publishMavenStyle  := true,
-  javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
+  javacOptions ++= Seq("-source", "11", "-target", "11"),
   scalacOptions ++= Seq(
     "-feature",
     "-deprecation"


### PR DESCRIPTION
As we no longer have projects that require Java8, I'd like to drop Java8 support for ease of maintenance. And also, dropping Java8 support enables us to use the standard Java11 HttpClient (#2188), which can be used without dependency like Finagle/OkHttp. 

Note: airframe-http-finagle/okhttp can be used without any change. There is no plan to drop the HTTP clients in these modules.

cc: @wvlet/airframe-dev @exoego 
