### PR TITLE
airframe-http-codegen: Scala 3 support (part 1)

### DIFF
--- a/airframe-http-codegen/src/main/scala/wvlet/airframe/http/codegen/RouteAnalyzer.scala
+++ b/airframe-http-codegen/src/main/scala/wvlet/airframe/http/codegen/RouteAnalyzer.scala
@@ -13,9 +13,10 @@
  */
 package wvlet.airframe.http.codegen
 
-import wvlet.airframe.http.{HttpContext, HttpMessage, HttpRequest}
+import wvlet.airframe.http.{HttpContext, HttpContextBase, HttpMessage, HttpRequest}
 import wvlet.airframe.http.router.Route
 import wvlet.airframe.surface.{CName, MethodParameter}
+
 import scala.language.higherKinds
 
 /**
@@ -42,8 +43,7 @@ object RouteAnalyzer {
   private def isClientSideArg(x: MethodParameter): Boolean = {
     !classOf[HttpMessage.Request].isAssignableFrom(x.surface.rawType) &&
     !classOf[HttpRequest[_]].isAssignableFrom(x.surface.rawType) &&
-    !classOf[HttpContext[_, _, F] forSome { type F[_] }]
-      .isAssignableFrom(x.surface.rawType) &&
+    !classOf[HttpContextBase].isAssignableFrom(x.surface.rawType) &&
     x.surface.fullName != "com.twitter.finagle.http.Request"
   }
 

--- a/airframe-http-codegen/src/main/scala/wvlet/airframe/http/openapi/OpenAPI.scala
+++ b/airframe-http-codegen/src/main/scala/wvlet/airframe/http/openapi/OpenAPI.scala
@@ -86,7 +86,7 @@ object OpenAPI {
       tags: Option[Seq[String]] = None
   )
 
-  abstract class ParameterOrRef extends Union2[Parameter, ParameterRef]
+  type ParameterOrRef = Union2[Parameter, ParameterRef]
 
   case class Parameter(
       name: String,
@@ -96,13 +96,13 @@ object OpenAPI {
       schema: Option[SchemaOrRef] = None,
       deprecated: Option[Boolean] = None,
       allowEmptyValue: Option[Boolean] = None
-  ) extends ParameterOrRef {
+  ) extends Union2[Parameter, ParameterRef] {
     override def getElementClass = classOf[Parameter]
   }
 
   case class ParameterRef(
       `$ref`: String
-  ) extends ParameterOrRef {
+  ) extends Union2[Parameter, ParameterRef] {
     override def getElementClass = classOf[ParameterRef]
   }
 
@@ -129,7 +129,7 @@ object OpenAPI {
   )
 
   // type SchemaOrRef = Union3[Schema, SchemaRef, OneOf]
-  abstract class SchemaOrRef extends Union3[Schema, SchemaRef, OneOf]
+  type SchemaOrRef = Union3[Schema, SchemaRef, OneOf]
 
   case class MediaType(
       // Scheme or SchemaRef,
@@ -138,13 +138,13 @@ object OpenAPI {
   )
   case class OneOf(
       oneOf: Seq[SchemaOrRef]
-  ) extends SchemaOrRef {
+  ) extends Union3[Schema, SchemaRef, OneOf] {
     override def getElementClass = classOf[OneOf]
   }
 
   case class SchemaRef(
       `$ref`: String
-  ) extends SchemaOrRef {
+  ) extends Union3[Schema, SchemaRef, OneOf] {
     override def getElementClass = classOf[SchemaRef]
   }
 
@@ -160,7 +160,7 @@ object OpenAPI {
       items: Option[SchemaOrRef] = None,
       nullable: Option[Boolean] = None,
       `enum`: Option[Seq[String]] = None
-  ) extends SchemaOrRef {
+  ) extends Union3[Schema, SchemaRef, OneOf] {
     override def getElementClass = classOf[Schema]
 
     def withDescription(description: Option[String]) = {

--- a/airframe-http-codegen/src/main/scala/wvlet/airframe/http/openapi/OpenAPI.scala
+++ b/airframe-http-codegen/src/main/scala/wvlet/airframe/http/openapi/OpenAPI.scala
@@ -86,7 +86,7 @@ object OpenAPI {
       tags: Option[Seq[String]] = None
   )
 
-  type ParameterOrRef = Union2[Parameter, ParameterRef]
+  abstract class ParameterOrRef extends Union2[Parameter, ParameterRef]
 
   case class Parameter(
       name: String,
@@ -128,7 +128,8 @@ object OpenAPI {
       required: Boolean = false
   )
 
-  type SchemaOrRef = Union3[Schema, SchemaRef, OneOf]
+  // type SchemaOrRef = Union3[Schema, SchemaRef, OneOf]
+  abstract class SchemaOrRef extends Union3[Schema, SchemaRef, OneOf]
 
   case class MediaType(
       // Scheme or SchemaRef,

--- a/airframe-http-codegen/src/test/scala/example/openapi/OpenAPIExample.scala
+++ b/airframe-http-codegen/src/test/scala/example/openapi/OpenAPIExample.scala
@@ -122,3 +122,8 @@ object OpenAPIEndpointExample {
   )
   case class EndpointResponse(y1: String, y2: Boolean)
 }
+
+trait OpenAPISmallExample {
+  @Endpoint(method = HttpMethod.GET, path = "/v1/get/:id")
+  def getWithParam(id: Int): Unit
+}

--- a/airframe-http-codegen/src/test/scala/wvlet/airframe/http/openapi/OpenAPITest.scala
+++ b/airframe-http-codegen/src/test/scala/wvlet/airframe/http/openapi/OpenAPITest.scala
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 package wvlet.airframe.http.openapi
-import example.openapi.{OpenAPIEndpointExample, OpenAPIRPCExample}
+import example.openapi.{OpenAPIEndpointExample, OpenAPIRPCExample, OpenAPISmallExample}
 import io.swagger.v3.parser.OpenAPIV3Parser
 import wvlet.airframe.http.Router
 import wvlet.airframe.http.codegen.HttpCodeGenerator
@@ -209,6 +209,24 @@ class OpenAPITest extends AirSpec {
         packageNames = Seq("example.openapi")
       )
     }
+  }
+
+  test("Get with param") {
+    val openAPI = OpenAPI
+      .ofRouter(Router.of[OpenAPISmallExample])
+    val yaml = openAPI.toYAML
+    yaml.contains("""  /v1/get/{id}:
+                    |    get:
+                    |      summary: getWithParam
+                    |      description: getWithParam
+                    |      operationId: getWithParam
+                    |      parameters:
+                    |        - name: id
+                    |          in: path
+                    |          required: true
+                    |          schema:
+                    |            type: integer
+                    |            format: int32""".stripMargin) shouldBe true
   }
 
   test("Generate OpenAPI spec from @Endpoint") {
@@ -510,11 +528,9 @@ class OpenAPITest extends AirSpec {
         |      operationId: multi2""".stripMargin
     )
 
-    // For the ease of testing at https://editor.swagger.io/
+    // Use this code snippet for ease of testing at https://editor.swagger.io/
     // java.awt.Toolkit.getDefaultToolkit.getSystemClipboard
     //      .setContents(new java.awt.datatransfer.StringSelection(yaml), null)
-
-    debug(endpointRouter)
 
     fragments.foreach { x =>
       debug(x)

--- a/airframe-http-codegen/src/test/scala/wvlet/airframe/http/openapi/OpenAPITest.scala
+++ b/airframe-http-codegen/src/test/scala/wvlet/airframe/http/openapi/OpenAPITest.scala
@@ -514,7 +514,10 @@ class OpenAPITest extends AirSpec {
     // java.awt.Toolkit.getDefaultToolkit.getSystemClipboard
     //      .setContents(new java.awt.datatransfer.StringSelection(yaml), null)
 
+    debug(endpointRouter)
+
     fragments.foreach { x =>
+      debug(x)
       yaml.contains(x) shouldBe true
     }
 

--- a/airframe-http/src/main/scala/wvlet/airframe/http/HttpContext.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/HttpContext.scala
@@ -19,9 +19,14 @@ import scala.concurrent.Future
 import scala.language.higherKinds
 
 /**
+  * A base type to use classOf[HttpContextBase]. classOf[HttpContext[_, _, _] is not supported for higherkinded types
+  */
+trait HttpContextBase
+
+/**
   * Used for passing the subsequent actions to HttpFilter and for defining the leaf action of request processing chain.
   */
-trait HttpContext[Req, Resp, F[_]] {
+trait HttpContext[Req, Resp, F[_]] extends HttpContextBase {
   protected def backend: HttpBackend[Req, Resp, F]
   private[http] def backendName: String = backend.name
 


### PR DESCRIPTION
- [x] Fix open api 

TODO: 
- Building router from classes is not working well in Scala 3