### PR TITLE
airframe-surface: Do not traverse non-public constructor

### DIFF
--- a/airframe-http-grpc/src/test/scala/wvlet/airframe/http/grpc/GrpcSurfaceTest.scala
+++ b/airframe-http-grpc/src/test/scala/wvlet/airframe/http/grpc/GrpcSurfaceTest.scala
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.http.grpc
+
+import io.grpc.{Channel, ServerServiceDefinition}
+import wvlet.airframe.surface.Surface
+import wvlet.airspec.AirSpec
+
+object GrpcSurfaceTest extends AirSpec {
+
+  test("build Surface related to gRPC") {
+    // ....
+    Surface.of[ServerServiceDefinition]
+    Surface.of[GrpcService]
+    Surface.of[Channel]
+    Surface.of[GrpcServerConfig]
+    Surface.of[GrpcServer]
+  }
+}

--- a/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
+++ b/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
@@ -260,7 +260,7 @@ private[surface] class CompileTimeSurfaceFactory[Q <: Quotes](using quotes: Q) {
   private def genericTypeWithConstructorFactory: Factory = {
     case t
         if !t.typeSymbol.flags.is(Flags.Abstract) && !t.typeSymbol.flags.is(Flags.Trait)
-          && Option(t.typeSymbol.primaryConstructor).exists(p => p.exists && p.paramSymss.nonEmpty) =>
+          && Option(t.typeSymbol.primaryConstructor).exists(p => p.exists && !p.flags.is(Flags.Private) && p.paramSymss.nonEmpty) =>
       val typeArgs     = typeArgsOf(t.simplified).map(surfaceOf(_))
       val methodParams = constructorParametersOf(t)
       val isStatic     = !t.typeSymbol.flags.is(Flags.Local)


### PR DESCRIPTION
Surface for Scala 3 tried to traverse ServerServiceDefinition in grpc-java too deep and caused `java.util.NoSuchElementException: key not found: <special-ops>.<FromJavaObject>` error. 

This PR provides a workaround so as not to traverse private constructors, which might have tricky java classes.
After a new version of AirSpec with this fix is released, DI with gRPC will work.

We still need a fix for [#2194](https://github.com/wvlet/airframe/issues/2194)