### PR TITLE
airframe-http: Add readAs[Resp], call[Req, Resp] to http clients

### DIFF
--- a/airframe-control/src/main/scala/wvlet/airframe/control/Retry.scala
+++ b/airframe-control/src/main/scala/wvlet/airframe/control/Retry.scala
@@ -295,7 +295,8 @@ object Retry extends LogSupport {
             // Wait until the next retry
             Compat.sleep(retryContext.nextWaitMillis)
           case ResultClass.Failed(_, cause, _) =>
-            circuitBreaker.recordFailure(cause)
+            // For regular non-retryable failures, we need to treat them as successful responses
+            circuitBreaker.recordSuccess
             // Non-retryable error. Exit the loop by throwing the exception
             throw cause
         }

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/client/JavaAsyncClientTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/client/JavaAsyncClientTest.scala
@@ -15,6 +15,7 @@ package wvlet.airframe.http.client
 
 import wvlet.airframe.Design
 import wvlet.airframe.codec.MessageCodec
+import wvlet.airframe.http.HttpMessage.Request
 import wvlet.airframe.http._
 import wvlet.airframe.json.JSON
 import wvlet.airspec.AirSpec
@@ -59,6 +60,15 @@ object JavaAsyncClientTest extends AirSpec {
       // .
       client
         .call[Person, Map[String, Any]](Http.GET("/get"), p)
+        .map { m =>
+          m("args") shouldBe Map("id" -> "1", "name" -> "leo")
+        }
+    }
+
+    test("call with GET") {
+      // .
+      client
+        .call[Person, Map[String, Any]](Http.GET("/get"), p, identity[Request](_))
         .map { m =>
           m("args") shouldBe Map("id" -> "1", "name" -> "leo")
         }

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/client/JavaSyncClientTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/client/JavaSyncClientTest.scala
@@ -17,14 +17,7 @@ import wvlet.airframe.Design
 import wvlet.airframe.codec.MessageCodec
 import wvlet.airframe.control.Control.withResource
 import wvlet.airframe.control.{CircuitBreaker, CircuitBreakerOpenException}
-import wvlet.airframe.http.{
-  Http,
-  HttpClientException,
-  HttpClientMaxRetryException,
-  HttpStatus,
-  RPCEncoding,
-  ServerAddress
-}
+import wvlet.airframe.http.{Http, HttpClientException, HttpClientMaxRetryException, HttpStatus, ServerAddress}
 import wvlet.airframe.json.{JSON, Json}
 import wvlet.airspec.AirSpec
 

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/client/JavaSyncClientTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/client/JavaSyncClientTest.scala
@@ -17,8 +17,15 @@ import wvlet.airframe.Design
 import wvlet.airframe.codec.MessageCodec
 import wvlet.airframe.control.Control.withResource
 import wvlet.airframe.control.{CircuitBreaker, CircuitBreakerOpenException}
-import wvlet.airframe.http.{Http, HttpClientException, HttpClientMaxRetryException, HttpStatus, ServerAddress}
-import wvlet.airframe.json.JSON
+import wvlet.airframe.http.{
+  Http,
+  HttpClientException,
+  HttpClientMaxRetryException,
+  HttpStatus,
+  RPCEncoding,
+  ServerAddress
+}
+import wvlet.airframe.json.{JSON, Json}
 import wvlet.airspec.AirSpec
 
 class JavaSyncClientTest extends AirSpec {
@@ -29,7 +36,11 @@ class JavaSyncClientTest extends AirSpec {
   override def design: Design =
     Design.newDesign
       .bind[SyncClient].toInstance {
-        new JavaSyncClient(ServerAddress(PUBLIC_REST_SERVICE), Http.client.withRetryContext(_.withMaxRetry(1)))
+        new JavaSyncClient(
+          ServerAddress(PUBLIC_REST_SERVICE),
+          Http.client.withJSONEncoding
+            .withRetryContext(_.withMaxRetry(1))
+        )
       }
 
   test("java http sync client") { (client: SyncClient) =>
@@ -42,6 +53,18 @@ class JavaSyncClientTest extends AirSpec {
       m("args") shouldBe Map("id" -> "1", "name" -> "leo")
     }
 
+    test("readAs") {
+      val m = client.readAs[Map[String, Any]](Http.GET("/get?id=1&name=leo"))
+      m("args") shouldBe Map("id" -> "1", "name" -> "leo")
+    }
+
+    test("readAs with HttpClientException") {
+      val e = intercept[HttpClientException] {
+        client.readAs[Map[String, Any]](Http.GET("/status/404"))
+      }
+      e.status shouldBe HttpStatus.NotFound_404
+    }
+
     test("POST") {
       val data = """{"id":1,"name":"leo"}"""
       val resp = client.send(Http.POST("/post").withContent(data))
@@ -51,6 +74,21 @@ class JavaSyncClientTest extends AirSpec {
       val m    = MessageCodec.of[Map[String, Any]].fromJson(json)
       m("data").toString shouldBe data
       m("json") shouldBe Map("id" -> 1, "name" -> "leo")
+    }
+
+    test("call") {
+      val data = """{"id":1,"name":"leo"}"""
+      val m    = client.call[Json, Map[String, Any]](Http.POST("/post"), data)
+      m("data") shouldBe data
+      m("json") shouldBe Map("id" -> 1, "name" -> "leo")
+    }
+
+    test("call with HttpClientException") {
+      val data = """{"id":1,"name":"leo"}"""
+      val e = intercept[HttpClientException] {
+        client.call[Json, Map[String, Any]](Http.POST("/status/404"), data)
+      }
+      e.status shouldBe HttpStatus.NotFound_404
     }
 
     test("404 with HttpClientException") {

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/client/URLConnectionClientTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/client/URLConnectionClientTest.scala
@@ -34,6 +34,7 @@ object URLConnectionClientTest extends AirSpec {
       .toInstance(
         Http.client
           .withBackend(URLConnectionClientBackend)
+          .withJSONEncoding
           .withRetryContext(_.withMaxRetry(1))
           .newSyncClient(PUBLIC_REST_SERVICE)
       )
@@ -84,20 +85,20 @@ object URLConnectionClientTest extends AirSpec {
 //      check(client.patchOps[Person, Map[String, Any]]("/post", p))
 //    }
 //
-//    test("xxxRaw") {
-//      check(client.postRaw[Person]("/post", p))
-//      check(client.putRaw[Person]("/put", p))
-//    }
-//
-//    test("getOps") {
-//      val m = client.getOps[Person, Map[String, Any]]("/get", p)
-//      m("args") shouldBe Map("id" -> "1", "name" -> "leo")
-//    }
-//
-//    test("xxxOps") {
-//      check(client.postOps[Person, Map[String, Any]]("/post", p))
-//      check(client.putOps[Person, Map[String, Any]]("/put", p))
-//    }
+    test("xxxRaw") {
+      check(client.call[Person, Response](Http.POST("/post"), p))
+      check(client.call[Person, Map[String, Any]](Http.PUT("/put"), p))
+    }
+
+    test("getOps") {
+      val m = client.readAs[Map[String, Any]](Http.GET(s"/get?id=${p.id}&name=${p.name}"))
+      m("args") shouldBe Map("id" -> "1", "name" -> "leo")
+    }
+
+    test("xxxOps") {
+      check(client.call[Person, Map[String, Any]](Http.POST("/post"), p))
+      check(client.call[Person, Map[String, Any]](Http.PUT("/put"), p))
+    }
 
     test("Handle 404 (Not Found)") {
       val errorResp = client.sendSafe(Http.GET("/status/404"))

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/client/URLConnectionClientTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/client/URLConnectionClientTest.scala
@@ -85,18 +85,21 @@ object URLConnectionClientTest extends AirSpec {
 //      check(client.patchOps[Person, Map[String, Any]]("/post", p))
 //    }
 //
-    test("xxxRaw") {
+    test("call with Response return value") {
       check(client.call[Person, Response](Http.POST("/post"), p))
-      check(client.call[Person, Map[String, Any]](Http.PUT("/put"), p))
+      check(client.call[Person, Response](Http.PUT("/put"), p))
     }
 
-    test("getOps") {
-      val m = client.readAs[Map[String, Any]](Http.GET(s"/get?id=${p.id}&name=${p.name}"))
+    test("call with GET") {
+      val m = client.call[Person, Map[String, Any]](Http.GET(s"/get"), p)
       m("args") shouldBe Map("id" -> "1", "name" -> "leo")
     }
 
-    test("xxxOps") {
+    test("call with POST") {
       check(client.call[Person, Map[String, Any]](Http.POST("/post"), p))
+    }
+
+    test("call with PUT") {
       check(client.call[Person, Map[String, Any]](Http.PUT("/put"), p))
     }
 

--- a/airframe-http/src/main/scala-2/wvlet/airframe/http/client/RPCClientBase.scala
+++ b/airframe-http/src/main/scala-2/wvlet/airframe/http/client/RPCClientBase.scala
@@ -77,4 +77,38 @@ trait RPCAsyncClientBase { self: AsyncClient =>
       request: RequestType,
       requestFilter: Request => Request
   ): Future[ResponseType] = macro HttpMacros.rpcSendAsync[RequestType, ResponseType]
+
+  /**
+    * Read the response as a specified type
+    * @param request
+    * @tparam Resp
+    * @return
+    *   a response translated to the specified type
+    */
+  def readAs[Resp](
+      request: Request
+  ): Future[Resp] = macro HttpMacros.read0Async[Resp]
+
+  /**
+    * Read the response as a specified type
+    * @param request
+    * @tparam Resp
+    * @return
+    *   response translated to the specified type
+    */
+  def readAs[Resp](
+      request: Request,
+      requestFilter: Request => Request
+  ): Future[Resp] = macro HttpMacros.read1Async[Resp]
+
+  def call[Req, Resp](
+      request: Request,
+      requestContent: Req
+  ): Future[Resp] = macro HttpMacros.call0Async[Req, Resp]
+
+  def call[Req, Resp](
+      request: Request,
+      requestContent: Req,
+      requestFilter: Request => Request
+  ): Future[Resp] = macro HttpMacros.call1Async[Req, Resp]
 }

--- a/airframe-http/src/main/scala-2/wvlet/airframe/http/client/RPCClientBase.scala
+++ b/airframe-http/src/main/scala-2/wvlet/airframe/http/client/RPCClientBase.scala
@@ -13,6 +13,7 @@
  */
 package wvlet.airframe.http.client
 
+import wvlet.airframe.http.HttpClientException
 import wvlet.airframe.http.HttpMessage.Request
 import wvlet.airframe.http.impl.HttpMacros
 
@@ -23,11 +24,51 @@ import scala.language.experimental.macros
   * Scala 2 specific helper method to make an RPC request
   */
 trait RPCSyncClientBase { self: SyncClient =>
-  def rpc[RequestType, ResponseType](
+  def rpc[Req, Resp](
       resourcePath: String,
-      request: RequestType,
+      request: Req,
       requestFilter: Request => Request
-  ): ResponseType = macro HttpMacros.rpcSend[RequestType, ResponseType]
+  ): Resp = macro HttpMacros.rpcSend[Req, Resp]
+
+  /**
+    * Read the response as a specified type
+    * @param request
+    * @tparam Resp
+    * @return
+    *   a response translated to the specified type
+    *
+    * @throws HttpClientException
+    *   if failed to read or process the response
+    */
+  def readAs[Resp](
+      request: Request
+  ): Resp = macro HttpMacros.read0[Resp]
+
+  /**
+    * Read the response as a specified type
+    * @param request
+    * @tparam Resp
+    * @return
+    *   response translated to the specified type
+    *
+    * @throws HttpClientException
+    *   if failed to read or process the response
+    */
+  def readAs[Resp](
+      request: Request,
+      requestFilter: Request => Request
+  ): Resp = macro HttpMacros.read1[Resp]
+
+  def call[Req, Resp](
+      request: Request,
+      requestContent: Req
+  ): Resp = macro HttpMacros.call0[Req, Resp]
+
+  def call[Req, Resp](
+      request: Request,
+      requestContent: Req,
+      requestFilter: Request => Request
+  ): Resp = macro HttpMacros.call1[Req, Resp]
 }
 
 trait RPCAsyncClientBase { self: AsyncClient =>

--- a/airframe-http/src/main/scala-2/wvlet/airframe/http/impl/HttpMacros.scala
+++ b/airframe-http/src/main/scala-2/wvlet/airframe/http/impl/HttpMacros.scala
@@ -20,12 +20,12 @@ import scala.reflect.macros.{blackbox => sm}
   */
 object HttpMacros {
 
-  def rpcSend[RequestType: c.WeakTypeTag, ResponseType: c.WeakTypeTag](
+  def rpcSend[Req: c.WeakTypeTag, Resp: c.WeakTypeTag](
       c: sm.Context
   )(resourcePath: c.Tree, request: c.Tree, requestFilter: c.Tree): c.Tree = {
     import c.universe._
-    val t1 = implicitly[c.WeakTypeTag[RequestType]]
-    val t2 = implicitly[c.WeakTypeTag[ResponseType]]
+    val t1 = implicitly[c.WeakTypeTag[Req]]
+    val t2 = implicitly[c.WeakTypeTag[Resp]]
     q"""{
           ${c.prefix}.sendRPC(
             ${resourcePath},
@@ -34,6 +34,79 @@ object HttpMacros {
             wvlet.airframe.surface.Surface.of[${t2}],
             ${requestFilter}
           ).asInstanceOf[${t2}]
+       }"""
+  }
+
+  def read0[Resp: c.WeakTypeTag](c: sm.Context)(
+      request: c.Tree
+  ): c.Tree = {
+    import c.universe._
+
+    val respType = implicitly[c.WeakTypeTag[Resp]]
+    q"""{
+         ${c.prefix}.sendRaw[${respType}](
+           ${request},
+           wvlet.airframe.surface.Surface.of[${respType}],
+           identity
+         )
+       }"""
+  }
+
+  def read1[Resp: c.WeakTypeTag](c: sm.Context)(
+      request: c.Tree,
+      requestFilter: c.Tree
+  ): c.Tree = {
+    import c.universe._
+
+    val respType = implicitly[c.WeakTypeTag[Resp]]
+
+    q"""{
+         ${c.prefix}.sendRaw[${respType}](
+           ${request},
+           wvlet.airframe.surface.Surface.of[${respType}],
+           ${requestFilter}
+         )
+       }"""
+  }
+
+  def call0[Req: c.WeakTypeTag, Resp: c.WeakTypeTag](c: sm.Context)(
+      request: c.Tree,
+      requestContent: c.Tree
+  ): c.Tree = {
+    import c.universe._
+
+    val reqType  = implicitly[c.WeakTypeTag[Req]]
+    val respType = implicitly[c.WeakTypeTag[Resp]]
+
+    q"""{
+         ${c.prefix}.sendRaw[${reqType}](
+           ${request},
+           wvlet.airframe.surface.Surface.of[${reqType}],
+           wvlet.airframe.surface.Surface.of[${respType}],
+           ${requestContent},
+           identity
+         )
+       }"""
+  }
+
+  def call1[Req: c.WeakTypeTag, Resp: c.WeakTypeTag](c: sm.Context)(
+      request: c.Tree,
+      requestContent: c.Tree,
+      requestFilter: c.Tree
+  ): c.Tree = {
+    import c.universe._
+
+    val reqType  = implicitly[c.WeakTypeTag[Req]]
+    val respType = implicitly[c.WeakTypeTag[Resp]]
+
+    q"""{
+         ${c.prefix}.sendRaw[${reqType}](
+           ${request},
+           wvlet.airframe.surface.Surface.of[${reqType}],
+           wvlet.airframe.surface.Surface.of[${respType}],
+           ${requestContent},
+           ${requestFilter}
+         )
        }"""
   }
 

--- a/airframe-http/src/main/scala-2/wvlet/airframe/http/impl/HttpMacros.scala
+++ b/airframe-http/src/main/scala-2/wvlet/airframe/http/impl/HttpMacros.scala
@@ -110,6 +110,79 @@ object HttpMacros {
        }"""
   }
 
+  def read0Async[Resp: c.WeakTypeTag](c: sm.Context)(
+      request: c.Tree
+  ): c.Tree = {
+    import c.universe._
+
+    val respType = implicitly[c.WeakTypeTag[Resp]]
+    q"""{
+         ${c.prefix}.readAsInternal[${respType}](
+           ${request},
+           wvlet.airframe.surface.Surface.of[${respType}],
+           identity
+         )
+       }"""
+  }
+
+  def read1Async[Resp: c.WeakTypeTag](c: sm.Context)(
+      request: c.Tree,
+      requestFilter: c.Tree
+  ): c.Tree = {
+    import c.universe._
+
+    val respType = implicitly[c.WeakTypeTag[Resp]]
+
+    q"""{
+         ${c.prefix}.readAsInternal[${respType}](
+           ${request},
+           wvlet.airframe.surface.Surface.of[${respType}],
+           ${requestFilter}
+         )
+       }"""
+  }
+
+  def call0Async[Req: c.WeakTypeTag, Resp: c.WeakTypeTag](c: sm.Context)(
+      request: c.Tree,
+      requestContent: c.Tree
+  ): c.Tree = {
+    import c.universe._
+
+    val reqType  = implicitly[c.WeakTypeTag[Req]]
+    val respType = implicitly[c.WeakTypeTag[Resp]]
+
+    q"""{
+         ${c.prefix}.callInternal[${reqType}, ${respType}](
+           ${request},
+           wvlet.airframe.surface.Surface.of[${reqType}],
+           wvlet.airframe.surface.Surface.of[${respType}],
+           ${requestContent},
+           identity
+         )
+       }"""
+  }
+
+  def call1Async[Req: c.WeakTypeTag, Resp: c.WeakTypeTag](c: sm.Context)(
+      request: c.Tree,
+      requestContent: c.Tree,
+      requestFilter: c.Tree
+  ): c.Tree = {
+    import c.universe._
+
+    val reqType  = implicitly[c.WeakTypeTag[Req]]
+    val respType = implicitly[c.WeakTypeTag[Resp]]
+
+    q"""{
+         ${c.prefix}.callInternal[${reqType}, ${respType}](
+           ${request},
+           wvlet.airframe.surface.Surface.of[${reqType}],
+           wvlet.airframe.surface.Surface.of[${respType}],
+           ${requestContent},
+           ${requestFilter}
+         )
+       }"""
+  }
+
   def rpcSendAsync[RequestType: c.WeakTypeTag, ResponseType: c.WeakTypeTag](
       c: sm.Context
   )(resourcePath: c.Tree, request: c.Tree, requestFilter: c.Tree): c.Tree = {

--- a/airframe-http/src/main/scala-2/wvlet/airframe/http/impl/HttpMacros.scala
+++ b/airframe-http/src/main/scala-2/wvlet/airframe/http/impl/HttpMacros.scala
@@ -44,7 +44,7 @@ object HttpMacros {
 
     val respType = implicitly[c.WeakTypeTag[Resp]]
     q"""{
-         ${c.prefix}.sendRaw[${respType}](
+         ${c.prefix}.readAsInternal[${respType}](
            ${request},
            wvlet.airframe.surface.Surface.of[${respType}],
            identity
@@ -61,7 +61,7 @@ object HttpMacros {
     val respType = implicitly[c.WeakTypeTag[Resp]]
 
     q"""{
-         ${c.prefix}.sendRaw[${respType}](
+         ${c.prefix}.readAsInternal[${respType}](
            ${request},
            wvlet.airframe.surface.Surface.of[${respType}],
            ${requestFilter}
@@ -79,7 +79,7 @@ object HttpMacros {
     val respType = implicitly[c.WeakTypeTag[Resp]]
 
     q"""{
-         ${c.prefix}.sendRaw[${reqType}](
+         ${c.prefix}.callInternal[${reqType}, ${respType}](
            ${request},
            wvlet.airframe.surface.Surface.of[${reqType}],
            wvlet.airframe.surface.Surface.of[${respType}],
@@ -100,7 +100,7 @@ object HttpMacros {
     val respType = implicitly[c.WeakTypeTag[Resp]]
 
     q"""{
-         ${c.prefix}.sendRaw[${reqType}](
+         ${c.prefix}.callInternal[${reqType}, ${respType}](
            ${request},
            wvlet.airframe.surface.Surface.of[${reqType}],
            wvlet.airframe.surface.Surface.of[${respType}],

--- a/airframe-http/src/main/scala-3/wvlet/airframe/http/client/RPCClientBase.scala
+++ b/airframe-http/src/main/scala-3/wvlet/airframe/http/client/RPCClientBase.scala
@@ -44,16 +44,16 @@ trait RPCSyncClientBase { self: SyncClient =>
     * @throws HttpClientException
     *   if failed to read or process the response
     */
-  inline def readAs[Resp](request: Request, requestFilter: Request => Request = identity): Resp = {
-    self.sendRaw[Resp](request, Surface.of[Resp], requestFilter)
+  inline def readAs[Resp](req: Request, requestFilter: Request => Request = identity): Resp = {
+    self.readAsInternal[Resp](req, Surface.of[Resp], requestFilter)
   }
 
   inline def call[Req, Resp](
-      request: Request,
+      req: Request,
       requestContent: Req,
       requestFilter: Request => Request = identity
   ): Resp = {
-    self.sendRaw[Req, Resp](request, Surface.of[Req], Surface.of[Resp], requestContent, requestFilter)
+    self.callInternal[Req, Resp](req, Surface.of[Req], Surface.of[Resp], requestContent, requestFilter)
   }
 }
 

--- a/airframe-http/src/main/scala-3/wvlet/airframe/http/client/RPCClientBase.scala
+++ b/airframe-http/src/main/scala-3/wvlet/airframe/http/client/RPCClientBase.scala
@@ -29,6 +29,14 @@ trait RPCSyncClientBase { self: SyncClient =>
   ): ResponseType = {
     self.sendRPC(resourcePath, Surface.of[RequestType], request, Surface.of[ResponseType], requestFilter).asInstanceOf[ResponseType]
   }
+
+  inline def readAs[Resp](request: Request, requestFilter: Request => Request = identity): Resp = {
+    self.sendRaw[Resp](request, Surface.of[Resp], requestFilter)
+  }
+
+  inline def call[Req, Resp](request: Request, requestContent: Req, requestFilter: Request => Request): Resp = {
+    self.sendRaw[Req, Resp](request, Surface.of[Req], Surface.of[Resp], requestContent, requestFilter)
+  }
 }
 
 

--- a/airframe-http/src/main/scala-3/wvlet/airframe/http/client/RPCClientBase.scala
+++ b/airframe-http/src/main/scala-3/wvlet/airframe/http/client/RPCClientBase.scala
@@ -13,6 +13,7 @@
  */
 package wvlet.airframe.http.client
 
+import wvlet.airframe.http.HttpClientException
 import wvlet.airframe.surface.Surface
 import wvlet.airframe.http.HttpMessage.{Request, Response}
 
@@ -30,11 +31,21 @@ trait RPCSyncClientBase { self: SyncClient =>
     self.sendRPC(resourcePath, Surface.of[RequestType], request, Surface.of[ResponseType], requestFilter).asInstanceOf[ResponseType]
   }
 
+  /**
+    * Read the response as a specified type
+    * @param request
+    * @tparam Resp
+    * @return
+    *   a response translated to the specified type
+    *
+    * @throws HttpClientException
+    *   if failed to read or process the response
+    */
   inline def readAs[Resp](request: Request, requestFilter: Request => Request = identity): Resp = {
     self.sendRaw[Resp](request, Surface.of[Resp], requestFilter)
   }
 
-  inline def call[Req, Resp](request: Request, requestContent: Req, requestFilter: Request => Request): Resp = {
+  inline def call[Req, Resp](request: Request, requestContent: Req, requestFilter: Request => Request = identity): Resp = {
     self.sendRaw[Req, Resp](request, Surface.of[Req], Surface.of[Resp], requestContent, requestFilter)
   }
 }

--- a/airframe-http/src/main/scala-3/wvlet/airframe/http/client/RPCClientBase.scala
+++ b/airframe-http/src/main/scala-3/wvlet/airframe/http/client/RPCClientBase.scala
@@ -68,4 +68,16 @@ trait RPCAsyncClientBase { self: AsyncClient =>
         Future[ResponseType]
       ]
   }
+
+  inline def readAs[Resp](req: Request, requestFilter: Request => Request = identity): Future[Resp] = {
+    self.readAsInternal[Resp](req, Surface.of[Resp], requestFilter)
+  }
+
+  inline def call[Req, Resp](
+    req: Request,
+    requestContent: Req,
+    requestFilter: Request => Request = identity
+  ): Future[Resp] = {
+    self.callInternal[Req, Resp](req, Surface.of[Req], Surface.of[Resp], requestContent, requestFilter)
+  }
 }

--- a/airframe-http/src/main/scala-3/wvlet/airframe/http/client/RPCClientBase.scala
+++ b/airframe-http/src/main/scala-3/wvlet/airframe/http/client/RPCClientBase.scala
@@ -28,7 +28,10 @@ trait RPCSyncClientBase { self: SyncClient =>
       request: RequestType,
       requestFilter: Request => Request
   ): ResponseType = {
-    self.sendRPC(resourcePath, Surface.of[RequestType], request, Surface.of[ResponseType], requestFilter).asInstanceOf[ResponseType]
+    self
+      .sendRPC(resourcePath, Surface.of[RequestType], request, Surface.of[ResponseType], requestFilter).asInstanceOf[
+        ResponseType
+      ]
   }
 
   /**
@@ -45,18 +48,24 @@ trait RPCSyncClientBase { self: SyncClient =>
     self.sendRaw[Resp](request, Surface.of[Resp], requestFilter)
   }
 
-  inline def call[Req, Resp](request: Request, requestContent: Req, requestFilter: Request => Request = identity): Resp = {
+  inline def call[Req, Resp](
+      request: Request,
+      requestContent: Req,
+      requestFilter: Request => Request = identity
+  ): Resp = {
     self.sendRaw[Req, Resp](request, Surface.of[Req], Surface.of[Resp], requestContent, requestFilter)
   }
 }
 
-
 trait RPCAsyncClientBase { self: AsyncClient =>
   inline def rpc[RequestType, ResponseType](
-    resourcePath: String,
-    request: RequestType,
-    requestFilter: Request => Request
+      resourcePath: String,
+      request: RequestType,
+      requestFilter: Request => Request
   ): Future[ResponseType] = {
-    self.sendRPC(resourcePath, Surface.of[RequestType], request, Surface.of[ResponseType], requestFilter).asInstanceOf[Future[ResponseType]]
+    self
+      .sendRPC(resourcePath, Surface.of[RequestType], request, Surface.of[ResponseType], requestFilter).asInstanceOf[
+        Future[ResponseType]
+      ]
   }
 }

--- a/airframe-http/src/main/scala-3/wvlet/airframe/http/client/RPCClientBase.scala
+++ b/airframe-http/src/main/scala-3/wvlet/airframe/http/client/RPCClientBase.scala
@@ -74,9 +74,9 @@ trait RPCAsyncClientBase { self: AsyncClient =>
   }
 
   inline def call[Req, Resp](
-    req: Request,
-    requestContent: Req,
-    requestFilter: Request => Request = identity
+      req: Request,
+      requestContent: Req,
+      requestFilter: Request => Request = identity
   ): Future[Resp] = {
     self.callInternal[Req, Resp](req, Surface.of[Req], Surface.of[Resp], requestContent, requestFilter)
   }

--- a/airframe-http/src/main/scala/wvlet/airframe/http/Http.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/Http.scala
@@ -20,7 +20,7 @@ import wvlet.airframe.http.client.SyncClient
 import java.time.{Instant, ZoneId, ZoneOffset}
 import java.time.format.DateTimeFormatter
 import java.util.Locale
-import scala.concurrent.{ExecutionContextExecutor, Future}
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
 import scala.language.higherKinds
 
 /**
@@ -30,7 +30,7 @@ object Http {
 
   // Standard HttpFilter
   abstract class Filter extends HttpFilter[Request, Response, Future] {
-    protected implicit val executorContext: ExecutionContextExecutor = DefaultBackend.executionContext
+    protected implicit lazy val executorContext: ExecutionContext = compat.defaultExecutionContext
     override protected def backend: HttpBackend[Request, Response, Future] =
       HttpBackend.DefaultBackend
   }

--- a/airframe-http/src/main/scala/wvlet/airframe/http/HttpBackend.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/HttpBackend.scala
@@ -93,7 +93,7 @@ object HttpBackend {
 
   object DefaultBackend extends HttpBackend[HttpMessage.Request, HttpMessage.Response, scala.concurrent.Future] {
     // TODO: Should we customize execution Context?
-    private[http] implicit lazy val executionContext: ExecutionContextExecutor = ExecutionContext.global
+    private[http] implicit lazy val executionContext: ExecutionContext = compat.defaultExecutionContext
 
     override protected implicit val httpRequestAdapter: HttpRequestAdapter[HttpMessage.Request] =
       HttpMessage.HttpMessageRequestAdapter

--- a/airframe-http/src/main/scala/wvlet/airframe/http/HttpClientConfig.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/HttpClientConfig.scala
@@ -77,6 +77,9 @@ case class HttpClientConfig(
   def withRPCEncoding(newEncoding: RPCEncoding): HttpClientConfig = {
     this.copy(rpcEncoding = newEncoding)
   }
+  def withJSONEncoding: HttpClientConfig    = withRPCEncoding(RPCEncoding.JSON)
+  def withMsgPackEncoding: HttpClientConfig = withRPCEncoding(RPCEncoding.MsgPack)
+
   def withCodecFactory(newCodecFactory: MessageCodecFactory): HttpClientConfig =
     this.copy(codecFactory = newCodecFactory)
   def withRetryContext(filter: RetryContext => RetryContext): HttpClientConfig =

--- a/airframe-http/src/main/scala/wvlet/airframe/http/HttpMessage.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/HttpMessage.scala
@@ -76,6 +76,10 @@ trait HttpMessage[Raw] extends HttpMessageBase[Raw] {
   def withJson(json: String): Raw = {
     copyWith(HttpMessage.stringMessage(json)).asInstanceOf[HttpMessage[Raw]].withContentTypeJson
   }
+  def withJson(json: Array[Byte]): Raw = {
+    copyWith(HttpMessage.byteArrayMessage(json)).asInstanceOf[HttpMessage[Raw]].withContentTypeJson
+  }
+
   def withMsgPack(msgPack: MsgPack): Raw = {
     copyWith(HttpMessage.byteArrayMessage(msgPack)).asInstanceOf[HttpMessage[Raw]].withContentTypeMsgPack
   }

--- a/airframe-http/src/main/scala/wvlet/airframe/http/client/HttpClients.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/client/HttpClients.scala
@@ -16,7 +16,6 @@ package wvlet.airframe.http.client
 import wvlet.airframe.codec.MessageCodec
 import wvlet.airframe.http.HttpMessage.{Request, Response}
 import wvlet.airframe.http._
-import wvlet.airframe.json.JSON.{JSONArray, JSONObject}
 import wvlet.airframe.surface.Surface
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -59,7 +58,7 @@ trait SyncClient extends RPCSyncClientBase with AutoCloseable {
     }
   }
 
-  private[client] def readAsInternal[Resp](
+  def readAsInternal[Resp](
       req: Request,
       responseSurface: Surface,
       requestFilter: Request => Request
@@ -68,7 +67,7 @@ trait SyncClient extends RPCSyncClientBase with AutoCloseable {
     HttpClients.parseResponse[Resp](config, responseSurface, resp)
   }
 
-  private[client] def callInternal[Req, Resp](
+  def callInternal[Req, Resp](
       req: Request,
       requestSurface: Surface,
       responseSurface: Surface,
@@ -95,7 +94,7 @@ trait SyncClient extends RPCSyncClientBase with AutoCloseable {
     *
     * @throws RPCException
     */
-  private[client] def sendRPC[Req](
+  def sendRPC[Req](
       resourcePath: String,
       requestSurface: Surface,
       requestContent: Req,
@@ -145,7 +144,7 @@ trait AsyncClient extends RPCAsyncClientBase with AutoCloseable {
     */
   def sendSafe(req: Request, requestFilter: Request => Request = identity): Future[Response]
 
-  private[client] def readAsInternal[Resp](
+  def readAsInternal[Resp](
       req: Request,
       responseSurface: Surface,
       requestFilter: Request => Request
@@ -155,7 +154,7 @@ trait AsyncClient extends RPCAsyncClientBase with AutoCloseable {
     }
   }
 
-  private[client] def callInternal[Req, Resp](
+  def callInternal[Req, Resp](
       req: Request,
       requestSurface: Surface,
       responseSurface: Surface,
@@ -173,7 +172,7 @@ trait AsyncClient extends RPCAsyncClientBase with AutoCloseable {
       }
   }
 
-  private[client] def sendRPC[Req](
+  def sendRPC[Req](
       resourcePath: String,
       requestSurface: Surface,
       requestContent: Req,

--- a/airframe-http/src/main/scala/wvlet/airframe/http/client/HttpClients.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/client/HttpClients.scala
@@ -13,15 +13,13 @@
  */
 package wvlet.airframe.http.client
 
-import wvlet.airframe.codec
 import wvlet.airframe.codec.MessageCodec
 import wvlet.airframe.http.HttpMessage.{Request, Response}
 import wvlet.airframe.http._
-import wvlet.airframe.surface.{RecordSurface, Surface}
+import wvlet.airframe.surface.Surface
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
-import scala.util.control.NonFatal
 
 /**
   * A standard blocking http client interface

--- a/airframe-http/src/main/scala/wvlet/airframe/http/client/HttpClients.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/client/HttpClients.scala
@@ -58,7 +58,7 @@ trait SyncClient extends RPCSyncClientBase with AutoCloseable {
     }
   }
 
-  protected def sendRaw[Resp](
+  private[client] def readAsInternal[Resp](
       req: Request,
       responseSurface: Surface,
       requestFilter: Request => Request
@@ -67,7 +67,7 @@ trait SyncClient extends RPCSyncClientBase with AutoCloseable {
     HttpClients.parseResponse(config, responseSurface, resp)
   }
 
-  protected def sendRaw[Req, Resp](
+  private[client] def callInternal[Req, Resp](
       req: Request,
       requestSurface: Surface,
       responseSurface: Surface,
@@ -94,7 +94,7 @@ trait SyncClient extends RPCSyncClientBase with AutoCloseable {
     *
     * @throws RPCException
     */
-  protected def sendRPC[Req](
+  private[client] def sendRPC[Req](
       resourcePath: String,
       requestSurface: Surface,
       requestContent: Req,


### PR DESCRIPTION
This is for complementing functionalities in the old HttpClient interface