### PR TITLE
airframe-jdbc: Scala 3 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -267,7 +267,7 @@ lazy val projectDotty =
       // // Finagle isn't supporting Scala 3
       // httpFinagle,
       // grpc,
-      // jdbc,
+      jdbc,
       jmx,
       launcher,
       metricsJVM,
@@ -630,9 +630,8 @@ lazy val codec =
       // TODO: #1698 Avoid "illegal multithreaded access to ContextBase error" on Scala 3
       // Tests in this project are sequentially executed
       Test / parallelExecution := false,
-
-      name        := "airframe-codec",
-      description := "Airframe MessagePack-based codec"
+      name                     := "airframe-codec",
+      description              := "Airframe MessagePack-based codec"
     )
     .jvmSettings(
       libraryDependencies ++= Seq(

--- a/docs/airframe-jdbc.md
+++ b/docs/airframe-jdbc.md
@@ -88,7 +88,7 @@ DbConfig.ofPostgreSQL(
 To add more configurations to the connection pool, use `withHikariConfig(...): 
 
 ```scala
-DbConfig().withHikariConfig { c: HikariConfig =>
+DbConfig().withHikariConfig { (c: HikariConfig) =>
   // Add your configurations for HikariConfig 
   c.setIdleTimeout(...)
   c
@@ -129,12 +129,15 @@ object MultipleConnection {
 
 import MultipleConnection._
 
-trait MultipleConnection {
-  val pool1 = bind{ (p: ConnectionPoolFactory, c:MyDB1Config) => p.newConnectionPool(c) }
-  val pool2 = bind{ (p: ConnectionPoolFactory, c:MyDB2Config) => p.newConnectionPool(c) }
+class MultipleConnection(f:ConnectionPoolFactory, c1:MyDB1Config, c2: MyDB2Config) {
+  val pool1 = f.newConnectionPool(c1)
+  val pool2 = f.newConnectionPool(c2) 
 }
 
 val d = newDesign
   .bind[MyDb1Config].toInstance(DbConfig.ofSQLite(path="mydb.sqlite"))
   .bind[MyDb2Config].toInstance(DbConfig.ofPostgreSQL(database="mydatabase"))
+  
+d.build[MultipleConnection] { c => ... }
+// connections will be closed after the DI session closes   
 ``` 


### PR DESCRIPTION
Now that airframe-config supports Scala 3 #2205, airframe-jdbc can support Scala 3 as well.