### PR TITLE
airframe-sql: Scala 3 support

### DIFF
--- a/airframe-parquet/src/main/scala-2/wvlet/airframe/parquet/ParquetCompat.scala
+++ b/airframe-parquet/src/main/scala-2/wvlet/airframe/parquet/ParquetCompat.scala
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.parquet
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.parquet.hadoop.{ParquetReader, ParquetWriter}
+import wvlet.airframe.surface.Surface
+
+import scala.reflect.runtime.{universe => ru}
+
+trait ParquetCompat {
+  def newWriter[A: ru.TypeTag](
+      path: String,
+      // Hadoop filesystem specific configuration, e.g., fs.s3a.access.key
+      hadoopConf: Configuration = new Configuration(),
+      config: ParquetWriterAdapter.Builder[A] => ParquetWriterAdapter.Builder[A] =
+        identity[ParquetWriterAdapter.Builder[A]](_)
+  ): ParquetWriter[A] = {
+    Parquet.newObjectWriter[A](Surface.of[A], path, hadoopConf, config)
+  }
+
+  def newReader[A: ru.TypeTag](
+      path: String,
+      // Hadoop filesystem specific configuration, e.g., fs.s3a.access.key
+      hadoopConf: Configuration = new Configuration(),
+      config: ParquetReader.Builder[A] => ParquetReader.Builder[A] = identity[ParquetReader.Builder[A]](_)
+  ): ParquetReader[A] = {
+    Parquet.newObjectReader[A](Surface.of[A], path, hadoopConf, config)
+  }
+
+  def query[A: ru.TypeTag](
+      path: String,
+      sql: String,
+      hadoopConf: Configuration = new Configuration(),
+      config: ParquetReader.Builder[A] => ParquetReader.Builder[A] = identity[ParquetReader.Builder[A]](_)
+  ): ParquetReader[A] = {
+    Parquet.queryObject[A](Surface.of[A], path, sql, hadoopConf, config)
+  }
+}

--- a/airframe-parquet/src/main/scala-3/wvlet/airframe/parquet/ParquetCompat.scala
+++ b/airframe-parquet/src/main/scala-3/wvlet/airframe/parquet/ParquetCompat.scala
@@ -1,0 +1,37 @@
+package wvlet.airframe.parquet
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.parquet.hadoop.{ParquetReader, ParquetWriter}
+import wvlet.airframe.surface.Surface
+
+trait ParquetCompat {
+
+  inline def newWriter[A](
+      path: String,
+      // Hadoop filesystem specific configuration, e.g., fs.s3a.access.key
+      hadoopConf: Configuration = new Configuration(),
+      config: ParquetWriterAdapter.Builder[A] => ParquetWriterAdapter.Builder[A] =
+        identity[ParquetWriterAdapter.Builder[A]](_)
+  ): ParquetWriter[A] = {
+    Parquet.newObjectWriter[A](Surface.of[A], path, hadoopConf, config)
+  }
+
+  inline def newReader[A](
+      path: String,
+      // Hadoop filesystem specific configuration, e.g., fs.s3a.access.key
+      hadoopConf: Configuration = new Configuration(),
+      config: ParquetReader.Builder[A] => ParquetReader.Builder[A] = identity[ParquetReader.Builder[A]](_)
+  ): ParquetReader[A] = {
+    Parquet.newObjectReader[A](Surface.of[A], path, hadoopConf, config)
+  }
+
+  inline def query[A](
+      path: String,
+      sql: String,
+      hadoopConf: Configuration = new Configuration(),
+      config: ParquetReader.Builder[A] => ParquetReader.Builder[A] = identity[ParquetReader.Builder[A]](_)
+  ): ParquetReader[A] = {
+    Parquet.queryObject[A](Surface.of[A], path, sql, hadoopConf, config)
+  }
+
+}

--- a/airframe-parquet/src/test/scala/wvlet/airframe/parquet/ParquetQueryTest.scala
+++ b/airframe-parquet/src/test/scala/wvlet/airframe/parquet/ParquetQueryTest.scala
@@ -52,7 +52,7 @@ object ParquetQueryTest extends AirSpec {
 
   case class RecordProjection(id: Int, b: Boolean)
 
-  test("SQL over Parquet") { file: Resource[File] =>
+  test("SQL over Parquet") { (file: Resource[File]) =>
     val path = file.get.getPath
     test("read all columns") {
       val reader = Parquet.query[Record](path, "select * from _")

--- a/airframe-parquet/src/test/scala/wvlet/airframe/parquet/ParquetTest.scala
+++ b/airframe-parquet/src/test/scala/wvlet/airframe/parquet/ParquetTest.scala
@@ -42,7 +42,7 @@ object ParquetTest extends AirSpec {
   test(
     "write Parquet",
     design = newDesign.bind[Resource[File]].toInstance(Resource.newTempFile("target/tmp", ".parquet"))
-  ) { parquetFile: Resource[File] =>
+  ) { (parquetFile: Resource[File]) =>
     val file = parquetFile.get
     debug(s"Writing to ${file}")
     withResource(

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
@@ -44,7 +44,7 @@ sealed trait Expression extends TreeNode[Expression] with Product {
 
     // Apply the rule to itself
     rule
-      .applyOrElse(newExpr, { x: Expression => x }).asInstanceOf[this.type]
+      .applyOrElse(newExpr, { (x: Expression) => x }).asInstanceOf[this.type]
   }
 
   def collectSubExpressions: List[Expression] = {

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLInterpreter.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLInterpreter.scala
@@ -668,10 +668,10 @@ class SQLInterpreter extends SqlBaseBaseVisitor[Any] with LogSupport {
 
   override def visitFunctionCall(ctx: FunctionCallContext): FunctionCall = {
     val name = ctx.qualifiedName().getText
-    val filter: Option[Expression] = Option(ctx.filter()).map { f: FilterContext =>
+    val filter: Option[Expression] = Option(ctx.filter()).map { (f: FilterContext) =>
       expression(f.booleanExpression())
     }
-    val over: Option[Window] = Option(ctx.over()).map { o: OverContext =>
+    val over: Option[Window] = Option(ctx.over()).map { (o: OverContext) =>
       visitOver(o)
     }
 

--- a/build.sbt
+++ b/build.sbt
@@ -276,7 +276,7 @@ lazy val projectDotty =
       rxJVM,
       // rx-html uses Scala Macros
       rxHtmlJVM,
-      // sql,
+      sql,
       ulidJVM
     )
 
@@ -630,9 +630,8 @@ lazy val codec =
       // TODO: #1698 Avoid "illegal multithreaded access to ContextBase error" on Scala 3
       // Tests in this project are sequentially executed
       Test / parallelExecution := false,
-
-      name        := "airframe-codec",
-      description := "Airframe MessagePack-based codec"
+      name                     := "airframe-codec",
+      description              := "Airframe MessagePack-based codec"
     )
     .jvmSettings(
       libraryDependencies ++= Seq(


### PR DESCRIPTION
- [x] airframe-sql 
- [x] airframe-parquet compat layer
- TODO: airframe-parquet needs to find Surface from a given runtime class to use AnyCodec for writing records containing objects. 