### PR TITLE
Run Scala 3 unit tests on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,7 +89,7 @@ jobs:
           java-version: zulu@1.11
       - name: Scala 3.x test
         # Only use a limited number of tests until AirSpec and DI can support Scala 3
-        run: DOTTY=true ./sbt "projectDotty/compile; dottyTest/run"
+        run: DOTTY=true ./sbt "projectDotty/test; dottyTest/run"
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v2
         if: always() # always run even if the previous step fails

--- a/airframe-codec/src/main/scala/wvlet/airframe/codec/PrimitiveCodec.scala
+++ b/airframe-codec/src/main/scala/wvlet/airframe/codec/PrimitiveCodec.scala
@@ -921,7 +921,10 @@ object PrimitiveCodec {
     * Another option to implement AnyCodec is packing pairs of (type, value), but we will not take this approach as this
     * will require many bytes to fully encode type names.
     */
-  class AnyCodec(knownSurfaces: Seq[Surface] = Seq.empty) extends MessageCodec[Any] {
+  class AnyCodec(
+      codecFactory: MessageCodecFactory = MessageCodecFactory.defaultFactoryForJSON,
+      knownSurfaces: Seq[Surface] = Seq.empty
+  ) extends MessageCodec[Any] {
 
     private val knownSurfaceTable = knownSurfaces.map(s => s.rawType -> s).toMap[Class[_], Surface]
 
@@ -992,10 +995,10 @@ object PrimitiveCodec {
           val cl = v.getClass
           knownSurfaceTable.get(cl) match {
             case Some(surface) =>
-              val codec = MessageCodec.ofSurface(surface).asInstanceOf[MessageCodec[Any]]
+              val codec = codecFactory.ofSurface(surface).asInstanceOf[MessageCodec[Any]]
               codec.pack(p, v)
             case None =>
-              wvlet.airframe.codec.Compat.codecOfClass(cl) match {
+              wvlet.airframe.codec.Compat.codecOfClass(cl, codecFactory) match {
                 case Some(codec) =>
                   codec.asInstanceOf[MessageCodec[Any]].pack(p, v)
                 case None =>

--- a/airframe-codec/src/test/scala/wvlet/airframe/codec/PrimitiveCodecTest.scala
+++ b/airframe-codec/src/test/scala/wvlet/airframe/codec/PrimitiveCodecTest.scala
@@ -14,7 +14,7 @@
 package wvlet.airframe.codec
 
 import org.scalacheck.util.Pretty
-import wvlet.airframe.codec.PrimitiveCodec.LongCodec
+import wvlet.airframe.codec.PrimitiveCodec.{AnyCodec, LongCodec}
 import wvlet.airframe.json.JSON.JSONString
 import wvlet.airframe.msgpack.spi.MessagePack
 import wvlet.airframe.msgpack.spi.Value.StringValue
@@ -425,7 +425,7 @@ object PrimitiveCodecTest extends CodecSpec with PropertyCheck {
     if (isScalaJS) {
       pending("Scala.js doesn't support runtime reflection")
     }
-    val anyCodec = MessageCodec.of[Any]
+    val anyCodec = new AnyCodec(knownSurfaces = Seq(Surface.of[Person]))
     val json     = anyCodec.toJson(Person(1, "leo"))
     json shouldBe """{"id":1,"name":"leo"}"""
   }

--- a/airframe-parquet/src/main/scala/wvlet/airframe/parquet/ParquetRecordWriter.scala
+++ b/airframe-parquet/src/main/scala/wvlet/airframe/parquet/ParquetRecordWriter.scala
@@ -31,7 +31,7 @@ class ParquetRecordWriter(schema: MessageType, knownSurfaces: Seq[Surface] = Seq
     ParquetWriteCodec.parquetCodecOf(schema, surface, ValueCodec).asRoot
   }
 
-  private val codec = new AnyCodec(knownSurfaces)
+  private val codec = new AnyCodec(knownSurfaces = knownSurfaces)
 
   def pack(obj: Any, recordConsumer: RecordConsumer): Unit = {
     val msgpack =

--- a/build.sbt
+++ b/build.sbt
@@ -273,6 +273,7 @@ lazy val projectDotty =
       metricsJVM,
       msgpackJVM,
       jsonJVM,
+      parquet,
       rxJVM,
       // rx-html uses Scala Macros
       rxHtmlJVM,


### PR DESCRIPTION
Now that many unit tests runs smoothly for Scala 3, we can enable CI 