### PR TITLE
Use JDK17 for regular CI and JDK11 for releases

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: olafurpg/setup-scala@v11
         with:
-          java-version: zulu@1.11
+          java-version: zulu@1.17
       - name: Scala 2.13 test with coverage report
         run: ./sbt "; coverage; projectJVM/test; projectJVM/coverageReport; projectJVM/coverageAggregate"
       - uses: codecov/codecov-action@v1

--- a/.github/workflows/package-test.yml
+++ b/.github/workflows/package-test.yml
@@ -18,6 +18,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: olafurpg/setup-scala@v11
         with:
-          java-version: adopt@1.11
+          java-version: zulu@1.11
       - name: Packaging test
         run: ./sbt publishAllLocal

--- a/.github/workflows/sbt-integration.yml
+++ b/.github/workflows/sbt-integration.yml
@@ -27,7 +27,7 @@ jobs:
       - run: git fetch --tags -f
       - uses: olafurpg/setup-scala@v11
         with:
-          java-version: adopt@1.17
+          java-version: zulu@1.17
       - name: Get Airframe version
         run: echo "AIRFRAME_VERSION=$(./scripts/dynver.sh)" >> $GITHUB_ENV
       - name: Check Airframe version

--- a/.github/workflows/sbt-integration.yml
+++ b/.github/workflows/sbt-integration.yml
@@ -27,7 +27,7 @@ jobs:
       - run: git fetch --tags -f
       - uses: olafurpg/setup-scala@v11
         with:
-          java-version: adopt@1.11
+          java-version: adopt@1.17
       - name: Get Airframe version
         run: echo "AIRFRAME_VERSION=$(./scripts/dynver.sh)" >> $GITHUB_ENV
       - name: Check Airframe version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: olafurpg/setup-scala@v11
         with:
-          java-version: zulu@1.11
+          java-version: zulu@1.17
       - name: Scala 2.12 test
         run: ./sbt ++2.12.15 projectJVM/test
       - name: Publish Test Report
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: olafurpg/setup-scala@v11
         with:
-          java-version: zulu@1.11
+          java-version: zulu@1.17
       - name: Scala 2.13 test
         run: ./sbt projectJVM/test
       - name: Publish Test Report
@@ -63,22 +63,22 @@ jobs:
         with:
           report_paths: '**/target/test-reports/TEST-*.xml'
           check_name: Test Report Scala 2.13
-  test_2_13_lastet_jdk:
-    name: Scala 2.13 + JDK17
+  test_2_13_legacy_jdk:
+    name: Scala 2.13 + JDK11
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: olafurpg/setup-scala@v11
         with:
           java-version: zulu@1.17
-      - name: Scala 2.13 + JDK17 test
+      - name: Scala 2.13 + JDK11 test
         run: ./sbt projectJVM/test
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v2
         if: always() # always run even if the previous step fails
         with:
           report_paths: '**/target/test-reports/TEST-*.xml'
-          check_name: Test Report Scala 2.13 + JDK17
+          check_name: Test Report Scala 2.13 + JDK11
   test_3:
     name: Scala 3.x (Dotty)
     runs-on: ubuntu-latest
@@ -86,7 +86,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: olafurpg/setup-scala@v11
         with:
-          java-version: zulu@1.11
+          java-version: zulu@1.17
       - name: Scala 3.x test
         # Only use a limited number of tests until AirSpec and DI can support Scala 3
         run: DOTTY=true ./sbt "projectDotty/test; dottyTest/run"
@@ -103,14 +103,14 @@ jobs:
       - uses: actions/checkout@v2
       - uses: olafurpg/setup-scala@v11
         with:
-          java-version: zulu@1.11
+          java-version: zulu@1.17
       - uses: actions/setup-node@v2
         with:
           node-version: '16'
       - name: Node.js setup
         run: ./scripts/setup-scalajs.sh
       - name: Scala.js test
-        run: JVM_OPTS=-Xmx4g ./sbt "; projectJS/test"
+        run: JVM_OPTS=-Xmx4g ./sbt ++2.12.15 projectJS/test
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v2
         if: always() # always run even if the previous step fails
@@ -124,14 +124,14 @@ jobs:
       - uses: actions/checkout@v2
       - uses: olafurpg/setup-scala@v11
         with:
-          java-version: zulu@1.11
+          java-version: zulu@1.17
       - uses: actions/setup-node@v2
         with:
           node-version: '16'
       - name: Node.js setup
         run: ./scripts/setup-scalajs.sh
-      - name: Scala.js test
-        run: JVM_OPTS=-Xmx4g ./sbt ++2.13.6 "; projectJS/test"
+      - name: Scala.js tesbt
+        run: JVM_OPTS=-Xmx4g ./sbt projectJS/test
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v2
         if: always() # always run even if the previous step fails
@@ -145,7 +145,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: olafurpg/setup-scala@v11
         with:
-          java-version: zulu@1.11
+          java-version: zulu@1.17
       - name: Scala JVM and Scala.js Test
         run: ../sbt "++airspecJVM/test; ++airspecJS/test"
         working-directory: ./airspec

--- a/sbt-airframe/build.sbt
+++ b/sbt-airframe/build.sbt
@@ -1,9 +1,9 @@
 // Reload build.sbt on changes
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
-val AIRFRAME_VERSION = sys.env.getOrElse("AIRFRAME_VERSION", "22.6.0")
-val AIRSPEC_VERSION  = "21.12.1"
-val SCALA_2_12       = "2.12.14"
+val AIRFRAME_VERSION = sys.env.getOrElse("AIRFRAME_VERSION", "22.6.1")
+val AIRSPEC_VERSION  = "22.6.1"
+val SCALA_2_12       = "2.12.15"
 
 ThisBuild / organization := "org.wvlet.airframe"
 

--- a/sbt-airframe/sbt
+++ b/sbt-airframe/sbt
@@ -34,11 +34,11 @@
 
 set -o pipefail
 
-declare -r sbt_release_version="1.5.1"
-declare -r sbt_unreleased_version="1.5.1"
+declare -r sbt_release_version="1.6.2"
+declare -r sbt_unreleased_version="1.7.0-M2"
 
-declare -r latest_213="2.13.5"
-declare -r latest_212="2.12.13"
+declare -r latest_213="2.13.8"
+declare -r latest_212="2.12.15"
 declare -r latest_211="2.11.12"
 declare -r latest_210="2.10.7"
 declare -r latest_29="2.9.3"
@@ -216,7 +216,8 @@ getJavaVersion() {
   # but on 9 and 10 it's 9.x.y and 10.x.y.
   if [[ "$str" =~ ^1\.([0-9]+)(\..*)?$ ]]; then
     echo "${BASH_REMATCH[1]}"
-  elif [[ "$str" =~ ^([0-9]+)(\..*)?$ ]]; then
+  # Fixes https://github.com/dwijnand/sbt-extras/issues/326
+  elif [[ "$str" =~ ^([0-9]+)(\..*)?(-ea)?$ ]]; then
     echo "${BASH_REMATCH[1]}"
   elif [[ -n "$str" ]]; then
     echoerr "Can't parse java version from: $str"
@@ -252,7 +253,9 @@ is_apple_silicon() { [[ "$(uname -s)" == "Darwin" && "$(uname -m)" == "arm64" ]]
 # MaxPermSize critical on pre-8 JVMs but incurs noisy warning on 8+
 default_jvm_opts() {
   local -r v="$(java_version)"
-  if [[ $v -ge 10 ]]; then
+  if [[ $v -ge 17 ]]; then
+    echo "$default_jvm_opts_common"
+  elif [[ $v -ge 10 ]]; then
     if is_apple_silicon; then
       # As of Dec 2020, JVM for Apple Silicon (M1) doesn't support JVMCI
       echo "$default_jvm_opts_common"


### PR DESCRIPTION
JDK17 (LTS version after JDK11) is already supported in Scala https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html

- Use JDK17 by default 
- Test JDK11 only for Scala 2.13 JVM 
- Use JDK11 for releasing to Maven. This is for ensuring binary compatibility with JDK11
