### PR TITLE
airframe-surface: Avoid recursive update of surface cache

### DIFF
--- a/airframe-surface/.jvm/src/main/scala-2/wvlet/airframe/surface/reflect/ReflectSurfaceFactory.scala
+++ b/airframe-surface/.jvm/src/main/scala-2/wvlet/airframe/surface/reflect/ReflectSurfaceFactory.scala
@@ -133,7 +133,12 @@ object ReflectSurfaceFactory extends LogSupport {
   }
 
   def apply(tpe: ru.Type): Surface = {
-    surfaceCache.getOrElseUpdate(fullTypeNameOf(tpe), new SurfaceFinder().surfaceOf(tpe))
+    val tpeName = fullTypeNameOf(tpe)
+    if (!surfaceCache.contains(tpeName)) {
+      val surface = new SurfaceFinder().surfaceOf(tpe)
+      surfaceCache += tpeName -> surface
+    }
+    surfaceCache(fullTypeNameOf(tpe))
   }
 
   def methodsOf(s: Surface): Seq[MethodSurface] = {
@@ -149,11 +154,11 @@ object ReflectSurfaceFactory extends LogSupport {
 
   def methodsOfType(tpe: ru.Type, cls: Option[Class[_]] = None): Seq[MethodSurface] = {
     val name = fullTypeNameOf(tpe)
-    methodSurfaceCache.getOrElseUpdate(
-      name, {
-        new SurfaceFinder().createMethodSurfaceOf(tpe, cls)
-      }
-    )
+    if (!methodSurfaceCache.contains(name)) {
+      val methodSurface = new SurfaceFinder().createMethodSurfaceOf(tpe, cls)
+      methodSurfaceCache += name -> methodSurface
+    }
+    methodSurfaceCache(name)
   }
 
   def methodsOfClass(cls: Class[_]): Seq[MethodSurface] = {

--- a/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
+++ b/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
@@ -103,7 +103,13 @@ private[surface] class CompileTimeSurfaceFactory[Q <: Quotes](using quotes: Q) {
           } else {
             fullTypeNameOf(t)
           }
-        '{ wvlet.airframe.surface.surfaceCache.getOrElseUpdate(${ Expr(cacheKey) }, ${ expr }) }
+        '{
+            val key = ${Expr(cacheKey)}
+            if(!wvlet.airframe.surface.surfaceCache.contains(key)) {
+              wvlet.airframe.surface.surfaceCache += key -> ${expr}
+            }
+            wvlet.airframe.surface.surfaceCache(key)
+         }
       }
       val surface = generator(t)
       memo += (t -> surface)

--- a/build.sbt
+++ b/build.sbt
@@ -630,9 +630,9 @@ lazy val codec =
     .settings(
       // TODO: #1698 Avoid "illegal multithreaded access to ContextBase error" on Scala 3
       // Tests in this project are sequentially executed
-      Test / parallelExecution := false,
-      name                     := "airframe-codec",
-      description              := "Airframe MessagePack-based codec"
+      // Test / parallelExecution := false,
+      name        := "airframe-codec",
+      description := "Airframe MessagePack-based codec"
     )
     .jvmSettings(
       libraryDependencies ++= Seq(


### PR DESCRIPTION
An alternative approach for #2260 as concurrent creation of the same Surface type should not be a big issue. 