### PR TITLE
openapi: Avoid recursive cache update to support future Scala 2.13.x

### DIFF
--- a/airframe-http-codegen/src/main/scala/wvlet/airframe/http/openapi/OpenAPIGenerator.scala
+++ b/airframe-http-codegen/src/main/scala/wvlet/airframe/http/openapi/OpenAPIGenerator.scala
@@ -363,11 +363,21 @@ class OpenAPIGenerator(config: OpenAPIGeneratorConfig) extends LogSupport {
     }
   }
 
+  private def getOrUpdateSchema(surface: Surface, factory: => SchemaOrRef): SchemaOrRef = {
+    schemaCache.get(surface) match {
+      case Some(x) => x
+      case None =>
+        val v = factory
+        schemaCache += surface -> v
+        v
+    }
+  }
+
   def getOpenAPISchemaOfSurface(s: Surface, seen: Set[Surface]): SchemaOrRef = {
     if (seen.contains(s)) {
       SchemaRef(`$ref` = s"#/components/schemas/${schemaName(s)}")
     } else {
-      schemaCache.getOrElseUpdate(
+      getOrUpdateSchema(
         s, {
           debug(s"Find Open API Schema of ${s}")
           s match {


### PR DESCRIPTION
A fix for https://github.com/scala/community-build/pull/1568