### PR TITLE
airframe-metrics: Use ZoneId for TimeWindow.withTimeZone() instead of ZoneOffset

### DIFF
--- a/airframe-metrics/.jvm/src/main/scala/wvlet/airframe/metrics/TimeWindow.scala
+++ b/airframe-metrics/.jvm/src/main/scala/wvlet/airframe/metrics/TimeWindow.scala
@@ -146,13 +146,15 @@ object TimeWindow extends LogSupport {
       .map(ZoneId.of(_))
       .getOrElse { ZoneId.of(zoneName) }
 
-    val offset = ZonedDateTime.now(zoneId).getOffset
-    withTimeZone(offset)
+    withTimeZone(zoneId)
   }
 
-  def withTimeZone(zoneId: ZoneOffset): TimeWindowBuilder = new TimeWindowBuilder(zoneId)
-  def withUTC: TimeWindowBuilder                          = withTimeZone(UTC)
-  def withSystemTimeZone: TimeWindowBuilder               = withTimeZone(systemTimeZone)
+  def withTimeZone(zoneId: ZoneId): TimeWindowBuilder = {
+    val offset = ZonedDateTime.now(zoneId).getOffset
+    new TimeWindowBuilder(offset)
+  }
+  def withUTC: TimeWindowBuilder            = withTimeZone(UTC)
+  def withSystemTimeZone: TimeWindowBuilder = withTimeZone(systemTimeZone)
 }
 
 class TimeWindowBuilder(val zone: ZoneOffset, currentTime: Option[ZonedDateTime] = None) extends LogSupport {


### PR DESCRIPTION
Building ZoneOffset is not straightforward compared to using ZoneId.of(name). 