### PR TITLE
Retarget to JDK8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -93,7 +93,7 @@ val buildSettings = Seq[Setting[_]](
   crossScalaVersions := targetScalaVersions,
   crossPaths         := true,
   publishMavenStyle  := true,
-  javacOptions ++= Seq("-source", "11", "-target", "11"),
+  javacOptions ++= Seq("-source", "8", "-target", "8"),
   scalacOptions ++= Seq(
     "-feature",
     "-deprecation"


### PR DESCRIPTION
AWS EMR (e.g., serverless), Databricks, etc. still use Java8. To use these platform, we need to compile airframe against JDK8