### PR TITLE
airframe-sql: Add SQL type name parser

### DIFF
--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLTypeParser.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLTypeParser.scala
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.sql.parser
+
+import wvlet.log.LogSupport
+
+import scala.util.parsing.combinator.RegexParsers
+
+trait SQLType
+
+object SQLType {
+  case class GenericType(name: String, typeArgs: Seq[SQLTypeParam]) extends SQLType {
+    override def toString: String = {
+      if (typeArgs.isEmpty) name
+      else
+        s"${name}(${typeArgs.mkString(",")})"
+    }
+  }
+
+  private def toTypeName(name: String, typeArgs: Seq[SQLTypeParam]): String = {
+    if (typeArgs.isEmpty)
+      name
+    else {
+      s"${name}(${typeArgs.mkString(",")})"
+    }
+  }
+
+  sealed abstract trait SQLTypeParam {
+    def typeName: String
+  }
+
+  case class NumericTypeParam(value: Int) extends SQLTypeParam {
+    override def toString: String = typeName
+    def typeName: String          = s"${value}"
+  }
+  case class TypeVariable(name: String) extends SQLTypeParam {
+    override def toString: String = typeName
+    override def typeName: String = s"${name}"
+  }
+}
+
+import SQLType._
+
+object SQLTypeParser extends RegexParsers with LogSupport {
+
+  private def typeName: Parser[String] = "[a-zA-Z_]([a-zA-Z0-9_]+)?".r
+  private def number: Parser[Int]      = "[0-9]+".r ^^ { _.toInt }
+
+  def typeParams: Parser[List[SQLTypeParam]] = repsep(typeParam, ",")
+
+  def typeParam: Parser[SQLTypeParam] = typeName ^^ { case name => TypeVariable(name) } |
+    number ^^ { case num => NumericTypeParam(num) }
+
+  def genericType: Parser[SQLType] = typeName ~ opt("(" ~ typeParams ~ ")") ^^ {
+    case name ~ None                        => GenericType(name, Seq.empty)
+    case name ~ Some(_ ~ optTypeParams ~ _) => GenericType(name, optTypeParams)
+  }
+
+  def sqlType: Parser[SQLType] = genericType
+
+  def parseSQLType(s: String): Option[SQLType] = {
+    parseAll(sqlType, s) match {
+      case Success(result, next) => Some(result)
+      case Error(msg, next) =>
+        warn(msg)
+        None
+      case Failure(msg, next) =>
+        warn(msg)
+        None
+    }
+  }
+
+}

--- a/airframe-sql/src/test/resources/wvlet/airframe/sql/catalog/argtypes.txt
+++ b/airframe-sql/src/test/resources/wvlet/airframe/sql/catalog/argtypes.txt
@@ -1,0 +1,171 @@
+E
+E, array(E)
+E, bigint
+K
+K, V
+T
+T, S, function(S,T,S), function(S,S,S)
+V
+V, K
+V, K, bigint
+V, bigint
+V, bigint, double
+array(E)
+array(E), E
+array(K), array(V)
+array(T), S, function(S,T,S), function(S,R)
+array(T), varchar
+array(T), varchar, varchar
+array(array(E))
+array(e)
+array(e), array(e)
+array(e), bigint
+array(e), bigint, bigint
+array(e), e
+array(geometry)
+array(row(k,v))
+array(t)
+array(t), array(t)
+array(t), function(t,boolean)
+array(t), function(t,t,integer)
+array(t), integer
+array(t), t
+bigint
+bigint, array(double)
+bigint, bigint
+bigint, bigint, bigint
+bigint, color
+bigint, double
+bigint, double, array(double)
+bigint, double, double
+bigint, double, double, double
+bigint, integer
+bigint, real
+bigint, real, double
+bigint, varchar, bigint
+bingtile
+boolean
+char(x)
+char(x), char(y)
+char(x), codepoints
+date
+date, date
+date, date, interval day to second
+date, date, interval year to month
+decimal(a_precision,a_scale), decimal(b_precision,b_scale)
+decimal(p,s)
+decimal(p,s), integer
+double
+double, array(double)
+double, bigint
+double, bigint, bigint
+double, bigint, color, color
+double, color
+double, color, color
+double, double
+double, double, array(double)
+double, double, double
+double, double, double, color, color
+double, double, double, double
+double, double, integer
+double, double, integer, double
+double, integer
+double, varchar(x)
+geometry
+geometry, double
+geometry, geometry
+geometry, integer
+hyperloglog
+integer
+integer, integer
+integer, integer, integer
+interval day to second
+interval year to month
+json
+json, bigint
+json, boolean
+json, double
+json, jsonpath
+json, varchar(x)
+kdbtree, geometry
+kdbtree, geometry, double
+map(K,V)
+map(K,V), K
+map(K,V), function(K,V,boolean)
+map(K,V1), map(K,V2), function(K,V1,V2,V3)
+map(k,v)
+map(varchar,double), map(varchar,double)
+qdigest(T)
+real
+real, array(double)
+real, double
+real, double, array(double)
+real, double, double
+real, double, double, double
+real, integer
+real, real
+setdigest
+setdigest, setdigest
+smallint
+smallint, integer
+smallint, smallint
+t
+t, bigint
+t, bigint, t
+t, double
+t, integer
+tdigest
+time(p)
+time(p) with time zone
+timestamp(p)
+timestamp(p) with time zone
+timestamp(p) with time zone, varchar(x)
+timestamp(p), timestamp(p), interval day to second
+timestamp(p), timestamp(p), interval year to month
+timestamp(p), varchar(x)
+tinyint
+tinyint, integer
+tinyint, tinyint
+varbinary
+varbinary, bigint
+varbinary, bigint, varbinary
+varbinary, varbinary
+varbinary, varchar(x)
+varchar
+varchar(1)
+varchar(x)
+varchar(x), bigint
+varchar(x), bigint, date
+varchar(x), bigint, time(p)
+varchar(x), bigint, time(p) with time zone
+varchar(x), bigint, timestamp(p)
+varchar(x), bigint, timestamp(p) with time zone
+varchar(x), bigint, varchar(y)
+varchar(x), boolean
+varchar(x), codepoints
+varchar(x), color
+varchar(x), date
+varchar(x), date, date
+varchar(x), double
+varchar(x), joniregexp
+varchar(x), joniregexp, bigint
+varchar(x), joniregexp, integer
+varchar(x), joniregexp, integer, integer
+varchar(x), joniregexp, varchar(y)
+varchar(x), jsonpath
+varchar(x), time(p)
+varchar(x), time(p) with time zone
+varchar(x), time(p) with time zone, time(p) with time zone
+varchar(x), time(p), time(p)
+varchar(x), timestamp(p)
+varchar(x), timestamp(p) with time zone
+varchar(x), timestamp(p) with time zone, timestamp(p) with time zone
+varchar(x), timestamp(p), timestamp(p)
+varchar(x), varchar(y)
+varchar(x), varchar(y), bigint
+varchar(x), varchar(y), varchar(z)
+varchar, array(varchar)
+varchar, double
+varchar, joniregexp, function(array(varchar),varchar(x))
+varchar, varchar
+varchar, varchar, bigint

--- a/airframe-sql/src/test/resources/wvlet/airframe/sql/catalog/types.txt
+++ b/airframe-sql/src/test/resources/wvlet/airframe/sql/catalog/types.txt
@@ -1,0 +1,84 @@
+E
+R
+S
+T
+V
+array(E)
+array(T)
+array(V)
+array(array(t))
+array(bigint)
+array(bingtile)
+array(date)
+array(double)
+array(e)
+array(geometry)
+array(integer)
+array(k)
+array(real)
+array(row(k,v))
+array(t)
+array(timestamp(p))
+array(v)
+array(varchar(x))
+bigint
+bingtile
+boolean
+char(u)
+char(x)
+color
+date
+decimal(1,0)
+decimal(38,0)
+decimal(p,s)
+decimal(r_precision,r_scale)
+decimal(rp,0)
+decimal(rp,rs)
+decimal(rp,s)
+double
+e
+geometry
+hyperloglog
+integer
+interval day to second
+interval year to month
+json
+map(K,V)
+map(K,V3)
+map(K,array(V))
+map(K,bigint)
+map(bigint,bigint)
+map(bigint,smallint)
+map(double,double)
+map(k,array(v))
+map(k,v)
+map(real,real)
+map(unknown,unknown)
+map(varchar,bigint)
+qdigest(T)
+qdigest(V)
+real
+row("x" integer,"y" integer)
+setdigest
+smallint
+t
+tdigest
+time(p)
+time(p) with time zone
+timestamp(3)
+timestamp(3) with time zone
+timestamp(9)
+timestamp(9) with time zone
+timestamp(p)
+timestamp(p) with time zone
+tinyint
+varbinary
+varchar
+varchar(1)
+varchar(16)
+varchar(35)
+varchar(41)
+varchar(u)
+varchar(x)
+varchar(y)
+varchar(z)

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/catalog/DataTypeTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/catalog/DataTypeTest.scala
@@ -33,6 +33,7 @@ class DataTypeTest extends AirSpec {
     parse("int", LongType)
     parse("long", LongType)
     parse("float", DoubleType)
+    parse("real", DoubleType)
     parse("double", DoubleType)
     parse("boolean", BooleanType)
     parse("any", AnyType)
@@ -43,16 +44,16 @@ class DataTypeTest extends AirSpec {
     parse("json", JsonType)
     parse("binary", BinaryType)
     parse("timestamp", TimestampType)
-    parse("array[int]", ArrayType(LongType))
-    parse("array[array[string]]", ArrayType(ArrayType(StringType)))
-    parse("map[string,long]", MapType(StringType, LongType))
-    parse("map[string,array[string]]", MapType(StringType, ArrayType(StringType)))
+    parse("array(int)", ArrayType(LongType))
+    parse("array(array(string))", ArrayType(ArrayType(StringType)))
+    parse("map(string,long)", MapType(StringType, LongType))
+    parse("map(string,array(string))", MapType(StringType, ArrayType(StringType)))
     parse(
       """{id:long,name:string}""",
       DataType.RecordType(Seq(NamedType("id", LongType), NamedType("name", StringType)))
     )
     parse(
-      """{id:long,name:string,address:array[string]}""",
+      """{id:long,name:string,address:array(string)}""",
       DataType.RecordType(
         Seq(NamedType("id", LongType), NamedType("name", StringType), NamedType("address", ArrayType(StringType)))
       )
@@ -67,22 +68,7 @@ class DataTypeTest extends AirSpec {
 
   test("return any type for unknwon types") {
     parse("unknown", AnyType)
-    parse("map[bit,long]", MapType(AnyType, LongType))
+    parse("map(bit,long)", MapType(AnyType, LongType))
   }
 
-  test("parse various types") {
-    val types = IOUtil.readAsString(Resource.find("wvlet.airframe.sql.catalog", "types.txt").get).split("\n")
-    for (t <- types) {
-      debug(s"parse ${t}")
-      DataType.parse(t)
-    }
-  }
-
-  test("parse type args") {
-    val args = IOUtil.readAsString(Resource.find("wvlet.airframe.sql.catalog", "argtypes.txt").get).split("\n")
-    for (a <- args) {
-      debug(s"parse type args: ${a}")
-      DataType.parseArgs(a)
-    }
-  }
 }

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/catalog/DataTypeTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/catalog/DataTypeTest.scala
@@ -15,6 +15,7 @@
 package wvlet.airframe.sql.catalog
 import wvlet.airframe.sql.catalog.DataType._
 import wvlet.airspec.AirSpec
+import wvlet.log.io.{IOUtil, Resource}
 
 /**
   */
@@ -58,8 +59,30 @@ class DataTypeTest extends AirSpec {
     )
   }
 
+  test("parse varchar(x)") {
+    parse("varchar", StringType)
+    parse("varchar(x)", StringType)
+    parse("varchar(10)", StringType)
+  }
+
   test("return any type for unknwon types") {
     parse("unknown", AnyType)
     parse("map[bit,long]", MapType(AnyType, LongType))
+  }
+
+  test("parse various types") {
+    val types = IOUtil.readAsString(Resource.find("wvlet.airframe.sql.catalog", "types.txt").get).split("\n")
+    for (t <- types) {
+      debug(s"parse ${t}")
+      DataType.parse(t)
+    }
+  }
+
+  test("parse type args") {
+    val args = IOUtil.readAsString(Resource.find("wvlet.airframe.sql.catalog", "argtypes.txt").get).split("\n")
+    for (a <- args) {
+      debug(s"parse type args: ${a}")
+      DataType.parseArgs(a)
+    }
   }
 }

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/parser/SQLTypeParserTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/parser/SQLTypeParserTest.scala
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.sql.parser
+
+import wvlet.airspec.AirSpec
+import wvlet.log.io.{IOUtil, Resource}
+
+class SQLTypeParserTest extends AirSpec {
+
+  test("parse various types") {
+    val types = IOUtil.readAsString(Resource.find("wvlet.airframe.sql.catalog", "types.txt").get).split("\n")
+    for (t <- types) {
+      val dt = SQLTypeParser.parseSQLType(t)
+      debug(s"parse: ${t} -> ${dt}")
+    }
+  }
+
+//  test("parse type args") {
+//    val args = IOUtil.readAsString(Resource.find("wvlet.airframe.sql.catalog", "argtypes.txt").get).split("\n")
+//    for (a <- args) {
+//      debug(s"parse type args: ${a}")
+//      DataType.parseArgs(a)
+//    }
+//  }//
+}

--- a/build.sbt
+++ b/build.sbt
@@ -907,7 +907,7 @@ lazy val fluentd =
     .dependsOn(codecJVM, diJVM)
 
 def sqlRefLib = { scalaVersion: String =>
-  if (scalaVersion.startsWith("2.12")) {
+  if (scalaVersion.startsWith("2.13")) {
     Seq(
       // Include Spark just as a reference implementation
       "org.apache.spark" %% "spark-sql" % "3.3.0" % Test,


### PR DESCRIPTION
For parsing column type information returned from information_schema, show functions, etc.