### PR TITLE
airframe-grpc: Fix thread local storage

### DIFF
--- a/airframe-http-grpc/src/main/scala/wvlet/airframe/http/grpc/GrpcContext.scala
+++ b/airframe-http-grpc/src/main/scala/wvlet/airframe/http/grpc/GrpcContext.scala
@@ -28,7 +28,13 @@ object GrpcContext {
     *
     * @return
     */
-  def current: Option[GrpcContext]  = Option(contextKey.get())
+  def current: Option[GrpcContext] = Option(contextKey.get())
+  private[grpc] def init: Unit = {
+    current.foreach {
+      wvlet.airframe.http.Compat.attachRPCContext(_)
+    }
+  }
+
   private[grpc] def currentEncoding = current.map(_.encoding).getOrElse(RPCEncoding.MsgPack)
 
   private[grpc] val KEY_ACCEPT       = Metadata.Key.of("accept", Metadata.ASCII_STRING_MARSHALLER)

--- a/airframe-http-grpc/src/main/scala/wvlet/airframe/http/grpc/GrpcContext.scala
+++ b/airframe-http-grpc/src/main/scala/wvlet/airframe/http/grpc/GrpcContext.scala
@@ -29,11 +29,6 @@ object GrpcContext {
     * @return
     */
   def current: Option[GrpcContext] = Option(contextKey.get())
-  private[grpc] def init: Unit = {
-    current.foreach {
-      wvlet.airframe.http.Compat.attachRPCContext(_)
-    }
-  }
 
   private[grpc] def currentEncoding = current.map(_.encoding).getOrElse(RPCEncoding.MsgPack)
 

--- a/airframe-http-grpc/src/main/scala/wvlet/airframe/http/grpc/GrpcService.scala
+++ b/airframe-http-grpc/src/main/scala/wvlet/airframe/http/grpc/GrpcService.scala
@@ -15,7 +15,7 @@ package wvlet.airframe.http.grpc
 
 import io.grpc.ServerServiceDefinition
 import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder
-import wvlet.airframe.http.grpc.internal.{GrpcResponseHeaderInterceptor, ContextTrackInterceptor, GrpcRequestLogger}
+import wvlet.airframe.http.grpc.internal.{GrpcContextTrackInterceptor, GrpcRequestLogger, GrpcResponseHeaderInterceptor}
 import wvlet.log.LogSupport
 
 import java.util.concurrent.ExecutorService
@@ -46,7 +46,7 @@ case class GrpcService(
     // Add an interceptor for setting content-type response header
     serverBuilder.intercept(GrpcResponseHeaderInterceptor)
     // Add an interceptor for remembering GrpcContext. This must happen at the root level
-    serverBuilder.intercept(ContextTrackInterceptor)
+    serverBuilder.intercept(GrpcContextTrackInterceptor)
 
     val customServerBuilder = config.serverInitializer(serverBuilder)
     val server              = new GrpcServer(this, customServerBuilder.build())

--- a/airframe-http-grpc/src/test/scala/wvlet/airframe/http/grpc/GrpcContextTest.scala
+++ b/airframe-http-grpc/src/test/scala/wvlet/airframe/http/grpc/GrpcContextTest.scala
@@ -20,6 +20,7 @@ import wvlet.airframe.http.grpc.example.DemoApi.DemoApiClient
 import wvlet.airspec.AirSpec
 
 import java.util.concurrent.Executor
+import scala.collection.parallel.CollectionConverters._
 
 object GrpcContextTest extends AirSpec {
 
@@ -28,12 +29,14 @@ object GrpcContextTest extends AirSpec {
   test("thread local context") { (client: DemoApiClient) =>
     test("get context") {
       val ret = client.getContext
-      info(ret)
+      debug(ret)
     }
 
     test("get context from RPCContext") {
-      val ret = client.getRPCContext
-      ret shouldBe Some(DemoApi.demoClientId)
+      for (i <- (1 to 100).par) {
+        val ret = client.getRPCContext
+        ret shouldBe Some(DemoApi.demoClientId)
+      }
     }
 
     test("get http request from RPCContext") {

--- a/airframe-http-grpc/src/test/scala/wvlet/airframe/http/grpc/GrpcContextTest.scala
+++ b/airframe-http-grpc/src/test/scala/wvlet/airframe/http/grpc/GrpcContextTest.scala
@@ -20,7 +20,7 @@ import wvlet.airframe.http.grpc.example.DemoApi.DemoApiClient
 import wvlet.airspec.AirSpec
 
 import java.util.concurrent.Executor
-import scala.collection.parallel.CollectionConverters._
+import scala.collection.parallel.ParSeq
 
 object GrpcContextTest extends AirSpec {
 
@@ -33,7 +33,7 @@ object GrpcContextTest extends AirSpec {
     }
 
     test("get context from RPCContext") {
-      for (i <- (1 to 10).par) {
+      for (i <- ParSeq(1 to 10)) {
         val ret = client.getRPCContext
         ret shouldBe Some(DemoApi.demoClientId)
       }

--- a/airframe-http-grpc/src/test/scala/wvlet/airframe/http/grpc/GrpcContextTest.scala
+++ b/airframe-http-grpc/src/test/scala/wvlet/airframe/http/grpc/GrpcContextTest.scala
@@ -33,7 +33,7 @@ object GrpcContextTest extends AirSpec {
     }
 
     test("get context from RPCContext") {
-      for (i <- (1 to 100).par) {
+      for (i <- (1 to 10).par) {
         val ret = client.getRPCContext
         ret shouldBe Some(DemoApi.demoClientId)
       }

--- a/airframe-http/.js/src/main/scala/wvlet/airframe/http/Compat.scala
+++ b/airframe-http/.js/src/main/scala/wvlet/airframe/http/Compat.scala
@@ -58,4 +58,5 @@ private object Compat extends CompatApi {
 
   override def currentRPCContext: RPCContext                     = ???
   override def attachRPCContext(context: RPCContext): RPCContext = ???
+  override def detachRPCContext(previous: RPCContext): Unit = ???
 }

--- a/airframe-http/.js/src/main/scala/wvlet/airframe/http/Compat.scala
+++ b/airframe-http/.js/src/main/scala/wvlet/airframe/http/Compat.scala
@@ -58,5 +58,5 @@ private object Compat extends CompatApi {
 
   override def currentRPCContext: RPCContext                     = ???
   override def attachRPCContext(context: RPCContext): RPCContext = ???
-  override def detachRPCContext(previous: RPCContext): Unit = ???
+  override def detachRPCContext(previous: RPCContext): Unit      = ???
 }

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/Compat.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/Compat.scala
@@ -59,5 +59,5 @@ object Compat extends CompatApi {
 
   override def currentRPCContext: RPCContext                     = LocalRPCContext.current
   override def attachRPCContext(context: RPCContext): RPCContext = LocalRPCContext.attach(context)
-  override def detachRPCContext(previous: RPCContext): Unit = LocalRPCContext.detach(previous)
+  override def detachRPCContext(previous: RPCContext): Unit      = LocalRPCContext.detach(previous)
 }

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/Compat.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/Compat.scala
@@ -59,4 +59,5 @@ object Compat extends CompatApi {
 
   override def currentRPCContext: RPCContext                     = LocalRPCContext.current
   override def attachRPCContext(context: RPCContext): RPCContext = LocalRPCContext.attach(context)
+  override def detachRPCContext(previous: RPCContext): Unit = LocalRPCContext.detach(previous)
 }

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/internal/LocalRPCContext.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/internal/LocalRPCContext.scala
@@ -32,10 +32,9 @@ object LocalRPCContext {
     prev
   }
   def detach(previousContext: RPCContext): Unit = {
-    if(previousContext != rootContext) {
+    if (previousContext != rootContext) {
       localContext.set(previousContext)
-    }
-    else {
+    } else {
       // Avoid preserving the root thread information TLS
       localContext.set(null)
     }

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/internal/LocalRPCContext.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/internal/LocalRPCContext.scala
@@ -35,7 +35,7 @@ object LocalRPCContext {
     if (previousContext != rootContext) {
       localContext.set(previousContext)
     } else {
-      // Avoid preserving the root thread information TLS
+      // Avoid preserving the root thread information in the TLS
       localContext.set(null)
     }
   }

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/internal/LocalRPCContext.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/internal/LocalRPCContext.scala
@@ -17,7 +17,7 @@ import wvlet.airframe.http.{RPCContext, EmptyRPCContext}
 
 object LocalRPCContext {
   private val localContext = new ThreadLocal[RPCContext]()
-  private val rootContext  = new EmptyRPCContext()
+  private val rootContext  = EmptyRPCContext
 
   def current: RPCContext = {
     Option(localContext.get()).getOrElse(rootContext)
@@ -30,5 +30,14 @@ object LocalRPCContext {
     val prev = current
     localContext.set(newContext)
     prev
+  }
+  def detach(previousContext: RPCContext): Unit = {
+    if(previousContext != rootContext) {
+      localContext.set(previousContext)
+    }
+    else {
+      // Avoid preserving the root thread information TLS
+      localContext.set(null)
+    }
   }
 }

--- a/airframe-http/src/main/scala/wvlet/airframe/http/CompatApi.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/CompatApi.scala
@@ -29,4 +29,5 @@ trait CompatApi {
 
   def currentRPCContext: RPCContext
   def attachRPCContext(context: RPCContext): RPCContext
+  def detachRPCContext(previous: RPCContext): Unit
 }

--- a/airframe-http/src/main/scala/wvlet/airframe/http/RPCContext.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/RPCContext.scala
@@ -53,7 +53,7 @@ trait RPCContext {
 /**
   * An empty RPCContext
   */
-class EmptyRPCContext extends RPCContext {
+object EmptyRPCContext extends RPCContext {
   override def setThreadLocal[A](key: String, value: A): Unit = {
     // no-op
   }


### PR DESCRIPTION
To properly access thread-local storage in gRPC, the code needs to be wrapped inside the Listener body. 