### PR TITLE
airframe-surface: Scala3 higher-kind type support

### DIFF
--- a/airframe-surface/src/test/scala/wvlet/airframe/surface/RecursiveHigherKindTypeTest.scala
+++ b/airframe-surface/src/test/scala/wvlet/airframe/surface/RecursiveHigherKindTypeTest.scala
@@ -37,8 +37,6 @@ class RecursiveHigherKindTypeTest extends SurfaceSpec {
   import Holder.BySkinny
 
   test("support recursive higher kind types") {
-    // ....
-
     val s = Surface.of[Holder[BySkinny]]
     assertEquals(s.name, "Holder[BySkinny]")
     assertEquals(s.isAlias, false)


### PR DESCRIPTION
- Remove `import dotty.tools.dotc.core.{Types as DottyTypes}`, which is available only in JVM, for supporting Scala.js
- Use pattern matching with ParamRef and TypeBounds instead of asInstanceOf class check