### PR TITLE
Scala3 crossbuild

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,7 @@ jobs:
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
         run: |
-          ./sbt "; + projectJVM/publishSigned;"
-          DOTTY=true ./sbt projectDotty/publishSigned
+          ./sbt "+ projectJVM/publishSigned"
       - name: Release to Sonatype
         env:
           SONATYPE_USERNAME: '${{ secrets.SONATYPE_USER }}'

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -31,7 +31,6 @@ jobs:
           SONATYPE_PASSWORD: '${{ secrets.SONATYPE_PASS }}'
         run: |
           ./sbt publishSnapshots
-          DOTTY=true ./sbt projectDotty/publish
       - name: Publish snapshots of AirSpec
         env:
           SONATYPE_USERNAME: '${{ secrets.SONATYPE_USER }}'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,6 +143,27 @@ jobs:
         with:
           report_paths: '**/target/test-reports/TEST-*.xml'
           check_name: Test Report Scala.js / Scala 2.13
+  test_js_3:
+    name: Scala.js / Scala 3
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: olafurpg/setup-scala@v11
+        with:
+          java-version: zulu@1.17
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+      - name: Node.js setup
+        run: ./scripts/setup-scalajs.sh
+      - name: Scala.js test
+        run: JVM_OPTS=-Xmx4g ./sbt ++3 projectJS/test
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v2
+        if: always() # always run even if the previous step fails
+        with:
+          report_paths: '**/target/test-reports/TEST-*.xml'
+          check_name: Test Report Scala.js / Scala 3
   test_airspec:
     name: AirSpec
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,7 +94,7 @@ jobs:
           java-version: zulu@1.17
       - name: Scala 3.x test
         # Test only Scala 3 supported projects
-        run: DOTTY=true ./sbt "projectDotty/test; dottyTest/run"
+        run: DOTTY=true ./sbt "projectJVM/test; dottyTest/run"
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v2
         if: always() # always run even if the previous step fails

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -157,7 +157,7 @@ jobs:
       - name: Node.js setup
         run: ./scripts/setup-scalajs.sh
       - name: Scala.js test
-        run: JVM_OPTS=-Xmx4g ./sbt "++3; projectJS/test"
+        run: JVM_OPTS=-Xmx4g ./sbt "++ 3; projectJS/test"
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v2
         if: always() # always run even if the previous step fails

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Node.js setup
         run: ./scripts/setup-scalajs.sh
       - name: Scala.js test
-        run: JVM_OPTS=-Xmx4g ./sbt ++2.12 projectJS/test
+        run: JVM_OPTS=-Xmx4g ./sbt "++ 2.12; projectJS/test"
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v2
         if: always() # always run even if the previous step fails
@@ -136,7 +136,7 @@ jobs:
       - name: Node.js setup
         run: ./scripts/setup-scalajs.sh
       - name: Scala.js test
-        run: JVM_OPTS=-Xmx4g ./sbt ++2.13 projectJS/test
+        run: JVM_OPTS=-Xmx4g ./sbt "++ 2.13; projectJS/test"
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v2
         if: always() # always run even if the previous step fails

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           java-version: zulu@1.17
       - name: Scala 2.13 test
-        run: ./sbt projectJVM/test
+        run: ./sbt ++2.13 projectJVM/test
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v2
         if: always() # always run even if the previous step fails
@@ -77,7 +77,7 @@ jobs:
         with:
           java-version: zulu@1.11
       - name: Scala 2.13 + JDK11 test
-        run: ./sbt projectJVM/test
+        run: ./sbt ++2.13 projectJVM/test
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v2
         if: always() # always run even if the previous step fails
@@ -93,7 +93,7 @@ jobs:
         with:
           java-version: zulu@1.17
       - name: Scala 3.x test
-        # Only use a limited number of tests until AirSpec and DI can support Scala 3
+        # Test only Scala 3 supported projects
         run: DOTTY=true ./sbt "projectDotty/test; dottyTest/run"
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v2
@@ -136,7 +136,7 @@ jobs:
       - name: Node.js setup
         run: ./scripts/setup-scalajs.sh
       - name: Scala.js test
-        run: JVM_OPTS=-Xmx4g ./sbt projectJS/test
+        run: JVM_OPTS=-Xmx4g ./sbt ++2.13 projectJS/test
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v2
         if: always() # always run even if the previous step fails

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           java-version: zulu@1.17
       - name: Scala 2.12 test
-        run: ./sbt ++2.12 projectJVM/test
+        run: ./sbt "++2.12; projectJVM/test"
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v2
         if: always() # always run even if the previous step fails
@@ -61,7 +61,7 @@ jobs:
         with:
           java-version: zulu@1.17
       - name: Scala 2.13 test
-        run: ./sbt ++2.13 projectJVM/test
+        run: ./sbt "++2.13; projectJVM/test"
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v2
         if: always() # always run even if the previous step fails
@@ -94,7 +94,7 @@ jobs:
           java-version: zulu@1.17
       - name: Scala 3.x test
         # Test only Scala 3 supported projects
-        run: DOTTY=true ./sbt "projectJVM/test; dottyTest/run"
+        run: ./sbt "++ 3; projectDotty/test; dottyTest/run"
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v2
         if: always() # always run even if the previous step fails
@@ -157,7 +157,7 @@ jobs:
       - name: Node.js setup
         run: ./scripts/setup-scalajs.sh
       - name: Scala.js test
-        run: JVM_OPTS=-Xmx4g ./sbt ++3 projectJS/test
+        run: JVM_OPTS=-Xmx4g ./sbt "++3; projectJS/test"
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v2
         if: always() # always run even if the previous step fails

--- a/airframe-http/.js/src/main/scala/wvlet/airframe/http/js/JSHttpClient.scala
+++ b/airframe-http/.js/src/main/scala/wvlet/airframe/http/js/JSHttpClient.scala
@@ -69,7 +69,7 @@ object JSHttpClient {
     Retry
       .withBackOff(maxRetry = 3)
       .withResultClassifier(HttpClientException.classifyHttpResponse[Response])
-      .withErrorClassifier { e: Throwable => Retry.nonRetryableFailure(e) }
+      .withErrorClassifier { (e: Throwable) => Retry.nonRetryableFailure(e) }
       .beforeRetry(defaultBeforeRetryAction[Request])
   }
 }
@@ -85,7 +85,7 @@ case class JSHttpClientConfig(
     codecFactory: MessageCodecFactory = MessageCodecFactory.defaultFactoryForJSON,
     // The default circuit breaker, which will be open after 5 consecutive failures
     circuitBreaker: CircuitBreaker = CircuitBreaker.withConsecutiveFailures(5),
-    rxConverter: Future[_] => RxStream[_] = { f: Future[_] =>
+    rxConverter: Future[_] => RxStream[_] = { (f: Future[_]) =>
       Rx.future(f)(scala.scalajs.concurrent.JSExecutionContext.queue)
     }
 ) {

--- a/airframe-rx-html/.js/src/test/scala/wvlet/airframe/http/rx/html/HtmlRenderingTest.scala
+++ b/airframe-rx-html/.js/src/test/scala/wvlet/airframe/http/rx/html/HtmlRenderingTest.scala
@@ -15,6 +15,7 @@ package wvlet.airframe.rx.html
 
 import org.scalajs.dom
 import wvlet.airframe.rx.Rx
+import wvlet.airframe.rx.html._
 import wvlet.airframe.rx.html.all._
 import wvlet.airspec._
 
@@ -86,7 +87,7 @@ class HtmlRenderingTest extends AirSpec {
   }
 
   test("add onclick") {
-    val d = button("hello", onclick { e: dom.MouseEvent => println("clicked") })
+    val d = button("hello", onclick { (e: dom.MouseEvent) => println("clicked") })
     render(d)
   }
 

--- a/airframe-rx-html/.js/src/test/scala/wvlet/airframe/http/rx/html/RxRenderingTest.scala
+++ b/airframe-rx-html/.js/src/test/scala/wvlet/airframe/http/rx/html/RxRenderingTest.scala
@@ -17,6 +17,7 @@ import org.scalajs.dom.HTMLElement
 import wvlet.airframe.rx.{Cancelable, Rx, RxStream}
 import wvlet.airframe.rx.html.{DOMRenderer, Embedded, RxElement}
 import wvlet.airspec.AirSpec
+import wvlet.airframe.rx.html._
 import wvlet.airframe.rx.html.all._
 
 /**

--- a/airframe-rx-widget/src/main/scala/wvlet/airframe/rx/html/widget/ui/bootstrap/Button.scala
+++ b/airframe-rx-widget/src/main/scala/wvlet/airframe/rx/html/widget/ui/bootstrap/Button.scala
@@ -14,6 +14,7 @@
 package wvlet.airframe.rx.html.widget.ui.bootstrap
 
 import wvlet.airframe.rx.html.RxElement
+import wvlet.airframe.rx.html._
 import wvlet.airframe.rx.html.all.{button, cls, disabled, tpe}
 import wvlet.log.LogSupport
 

--- a/airframe-rx-widget/src/test/scala/wvlet/airframe/http/rx/widget/RxWidgetTest.scala
+++ b/airframe-rx-widget/src/test/scala/wvlet/airframe/http/rx/widget/RxWidgetTest.scala
@@ -15,6 +15,7 @@ package wvlet.airframe.rx.html.widget
 
 import org.scalajs.dom
 import wvlet.airframe.rx.Rx
+import wvlet.airframe.rx.html._
 import wvlet.airframe.rx.html.all._
 import wvlet.airframe.rx.html.{DOMRenderer, Embedded, RxComponent, RxElement}
 import wvlet.airframe.rx.html.widget.ui.bootstrap._

--- a/build.sbt
+++ b/build.sbt
@@ -821,8 +821,8 @@ lazy val benchmark =
     // Necessary for generating /META-INF/BenchmarkList
     .enablePlugins(JmhPlugin, PackPlugin)
     .settings(buildSettings)
-    .settings(scala2Only)
     .settings(noPublish)
+    .settings(scala2Only)
     .settings(
       name     := "airframe-benchmark",
       packMain := Map("airframe-benchmark" -> "wvlet.airframe.benchmark.BenchmarkMain"),
@@ -982,6 +982,7 @@ lazy val examples =
     .settings(
       name        := "airframe-examples",
       description := "Airframe examples",
+      crossScalaVersions ++= targetScalaVersions,
       libraryDependencies ++= Seq(
       )
     )

--- a/build.sbt
+++ b/build.sbt
@@ -62,7 +62,12 @@ ThisBuild / usePipelining := false
 val DOTTY = sys.env.isDefinedAt("DOTTY")
 
 // If DOTTY is set, use Scala 3 by default. This is for the convenience of working on Scala 3 projects
-ThisBuild / scalaVersion := { if (DOTTY) SCALA_3_0 else SCALA_2_13 }
+ThisBuild / scalaVersion := {
+  if (DOTTY)
+    SCALA_3_0
+  else
+    SCALA_2_13
+}
 
 ThisBuild / organization := "org.wvlet.airframe"
 
@@ -199,7 +204,7 @@ lazy val jvmProjects: Seq[ProjectReference] = communityBuildProjects ++ Seq[Proj
   examples
 )
 
-// Scala.js build (only for Scala 2.12 + 2.13)
+// Scala.js build (Scala 2.12, 2.13, and 3.x)
 lazy val jsProjects: Seq[ProjectReference] = Seq(
   logJS,
   surfaceJS,
@@ -211,8 +216,8 @@ lazy val jsProjects: Seq[ProjectReference] = Seq(
   jsonJS,
   msgpackJS,
   codecJS,
-  rxJS,
   httpJS,
+  rxJS,
   rxHtmlJS,
   widgetJS
 )
@@ -220,18 +225,27 @@ lazy val jsProjects: Seq[ProjectReference] = Seq(
 // For community-build
 lazy val communityBuild =
   project
-    .settings(noPublish)
+    .settings(
+      noPublish,
+      crossScalaVersions := targetScalaVersions
+    )
     .aggregate(communityBuildProjects: _*)
 
 // For Scala 2.12
 lazy val projectJVM =
   project
-    .settings(noPublish)
+    .settings(
+      noPublish,
+      crossScalaVersions := targetScalaVersions
+    )
     .aggregate(jvmProjects: _*)
 
 lazy val projectJS =
   project
-    .settings(noPublish)
+    .settings(
+      noPublish,
+      crossScalaVersions := targetScalaVersions
+    )
     .aggregate(jsProjects: _*)
 
 // A scoped project only for Dotty (Scala 3).

--- a/build.sbt
+++ b/build.sbt
@@ -61,7 +61,7 @@ ThisBuild / usePipelining := false
 // A build configuration switch for working on Dotty migration. This needs to be removed eventually
 val DOTTY = sys.env.isDefinedAt("DOTTY")
 
-// If DOTTY is set, use Scala 3 by default
+// If DOTTY is set, use Scala 3 by default. This is for the convenience of working on Scala 3 projects
 ThisBuild / scalaVersion := { if (DOTTY) SCALA_3_0 else SCALA_2_13 }
 
 ThisBuild / organization := "org.wvlet.airframe"
@@ -234,7 +234,8 @@ lazy val projectJS =
     .settings(noPublish)
     .aggregate(jsProjects: _*)
 
-// For Dotty (Scala 3)
+// A scoped project only for Dotty (Scala 3).
+// This is a workaround as projectJVM/test shows compile errors for non Scala 3 ready projects
 lazy val projectDotty =
   project
     .settings(
@@ -812,6 +813,7 @@ lazy val benchmark =
     // Necessary for generating /META-INF/BenchmarkList
     .enablePlugins(JmhPlugin, PackPlugin)
     .settings(buildSettings)
+    .settings(scala2Only)
     .settings(noPublish)
     .settings(
       name     := "airframe-benchmark",

--- a/build.sbt
+++ b/build.sbt
@@ -141,6 +141,9 @@ val noPublish = Seq(
   publishArtifact := false,
   publish         := {},
   publishLocal    := {},
+  publish / skip  := true,
+  // This must be Nil to use crossScalaVersions of individual modules in `+ projectJVM/xxxx` tasks
+  crossScalaVersions := Nil,
   // Explicitly skip the doc task because protobuf related Java files causes no type found error
   Compile / doc / sources                := Seq.empty,
   Compile / packageDoc / publishArtifact := false
@@ -225,37 +228,25 @@ lazy val jsProjects: Seq[ProjectReference] = Seq(
 // For community-build
 lazy val communityBuild =
   project
-    .settings(
-      noPublish,
-      crossScalaVersions := targetScalaVersions
-    )
+    .settings(noPublish)
     .aggregate(communityBuildProjects: _*)
 
 // For Scala 2.12
 lazy val projectJVM =
   project
-    .settings(
-      noPublish,
-      crossScalaVersions := targetScalaVersions
-    )
+    .settings(noPublish)
     .aggregate(jvmProjects: _*)
 
 lazy val projectJS =
   project
-    .settings(
-      noPublish,
-      crossScalaVersions := targetScalaVersions
-    )
+    .settings(noPublish)
     .aggregate(jsProjects: _*)
 
 // A scoped project only for Dotty (Scala 3).
 // This is a workaround as projectJVM/test shows compile errors for non Scala 3 ready projects
 lazy val projectDotty =
   project
-    .settings(
-      noPublish,
-      crossScalaVersions := Seq(SCALA_3_0)
-    )
+    .settings(noPublish)
     .aggregate(
       diMacrosJVM,
       diJVM,
@@ -270,6 +261,8 @@ lazy val projectDotty =
       httpRouter,
       // Surface.of(Class[_]) needs to be supported
       // httpCodeGen
+      // Finagle is used in the http recorder
+      // httpRecorder
       // // Finagle isn't supporting Scala 3
       // httpFinagle,
       // grpc,
@@ -792,6 +785,7 @@ lazy val httpRecorder =
   project
     .in(file("airframe-http-recorder"))
     .settings(buildSettings)
+    .settings(scala2Only)
     .settings(
       name        := "airframe-http-recorder",
       description := "Http Response Recorder",


### PR DESCRIPTION
Now that AirSpec supports Scala 3 + Scala.js, there is no need to use DOTTY flag to switch build.sbt configurations.

- Use Scala3, Scala2 cross build by default. For projects not supporting Scala 3, `scala2Only` setting will be added. 
  - Now + projectJVM/publish, + projectJS/publish work for publishing Scala 2/3 modules at once
- All of the Scala.js modules support Scala 3 (rxHtml, widget, etc.)
- Hopefully, IntelliJ understands Scala 3 source code folder for syntax highlighting. 
- DOTTY=true ./sbt is still useful if you want to work on Scala 3 by default.

cc: @exoego 
