### PR TITLE
Upgrade to Node.js 18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,7 +133,7 @@ jobs:
           java-version: '17'
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
       - name: Node.js setup
         run: ./scripts/setup-scalajs.sh
       - name: Scala.js test
@@ -155,7 +155,7 @@ jobs:
           java-version: '17'
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
       - name: Node.js setup
         run: ./scripts/setup-scalajs.sh
       - name: Scala.js test
@@ -177,7 +177,7 @@ jobs:
           java-version: '17'
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
       - name: Node.js setup
         run: ./scripts/setup-scalajs.sh
       - name: Scala.js test

--- a/scripts/setup-scalajs.sh
+++ b/scripts/setup-scalajs.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-npm install jsdom@16.7.0
+npm install jsdom@20.0.0

--- a/scripts/setup-scalajs.sh
+++ b/scripts/setup-scalajs.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-npm install jsdom@20.0.0
+npm install jsdom@21.X


### PR DESCRIPTION
It seems using Node.js 18 breaks all Scala.js build that uses jsdom. 

An example error message:
```
$ node --version
v18.9.0
$ ./sbt
> httpJS/test

Node.js v18.9.0
/Users/leo/work/git/airframe/node_modules/jsdom/lib/jsdom/living/helpers/events.js:15
  const event = createAnEvent(e, target._globalObject, eventInterface, attributes);
                                        ^

TypeError: Cannot read properties of undefined (reading '_globalObject')
    at fireAnEvent (/Users/leo/work/git/airframe/node_modules/jsdom/lib/jsdom/living/helpers/events.js:15:41)
    at Timeout._onTimeout (/Users/leo/work/git/airframe/node_modules/jsdom/lib/jsdom/living/post-message.js:36:7)
    at listOnTimeout (node:internal/timers:564:17)
    at process.processTimers (node:internal/timers:507:7)
```