### PR TITLE
airframe-di: registerTraitFactory for Scala 3

### DIFF
--- a/airframe-di/src/main/scala-3/wvlet/airframe/package.scala
+++ b/airframe-di/src/main/scala-3/wvlet/airframe/package.scala
@@ -58,9 +58,30 @@ package object airframe {
     val parents = List(TypeTree.of[Object], TypeTree.of[A], TypeTree.of[DISupport])
     val cls = Symbol.newClass(Symbol.spliceOwner, name, parents = parents.map(_.tpe), _ => List.empty[Symbol], selfType = None)
     println(s"${cls.tree.show}")
+    val clasDef = ClassDef(cls, parents, body = Nil)
+    val newCls = Typed(Apply(Select(New(TypeIdent(cls)), cls.primaryConstructor), Nil), TypeTree.of[A with DISupport])
+
+    //val exampleExpr = '{ (s: Session) => new Object with DISupport { def session: Session = s } }
+    //println("===========")
+    //println(exampleExpr.asTerm)
+
+    val body = Lambda(
+      owner = Symbol.spliceOwner,
+      tpe = MethodType(List("s"))(_ => List(TypeRepr.of[Session]), _ => TypeRepr.of[A]),
+      rhsFn = (sym: Symbol, paramRefs: List[Tree]) => {
+        val s = paramRefs.head.asExprOf[Session].asTerm
+        val fn = newCls
+        fn.changeOwner(sym)
+      }
+    )
+    println("=------------")
+    println(body.show)
+
+    //val fn = '{ (s: Session) => ${ newCls('s) } }
+
 
     // { (s: Session) => new A with DISupport { def session = s } }
-    val t = TypeRepr.of[A]
+
       '{
         val s = Surface.of[A]
         ()

--- a/airframe-di/src/main/scala-3/wvlet/airframe/package.scala
+++ b/airframe-di/src/main/scala-3/wvlet/airframe/package.scala
@@ -54,40 +54,46 @@ package object airframe {
     import quotes._
     import quotes.reflect._
 
-    val name = "$anon"
+    val name    = "$anon"
     val parents = List(TypeTree.of[Object], TypeTree.of[A], TypeTree.of[DISupport])
-    val cls = Symbol.newClass(Symbol.spliceOwner, name, parents = parents.map(_.tpe), _ => List.empty[Symbol], selfType = None)
-    println(s"${cls.tree.show}")
-    val clasDef = ClassDef(cls, parents, body = Nil)
-    val newCls = Typed(Apply(Select(New(TypeIdent(cls)), cls.primaryConstructor), Nil), TypeTree.of[A with DISupport])
 
-    //val exampleExpr = '{ (s: Session) => new Object with DISupport { def session: Session = s } }
-    //println("===========")
-    //println(exampleExpr.asTerm)
+    //  val sessionMethod = TypeRepr.of[DISupport].typeSymbol.declaredMethod("session").head.info
 
+    def decls(cls: Symbol): List[Symbol] =
+      List(Symbol.newMethod(cls, "session", MethodType(Nil)(_ => Nil, _ => TypeRepr.of[Session])))
+
+    val cls = Symbol.newClass(Symbol.spliceOwner, name, parents = parents.map(_.tpe), decls, selfType = None)
+    // println(s"${cls.tree.show}")
+
+    val sessionMethodSym          = cls.declaredMethod("session").head
+    def sessionMethodDef(s: Term) = DefDef(sessionMethodSym, argss => Some(s))
+
+    def newCls(s: Term) = {
+      val clsDef = ClassDef(cls, parents, body = List(sessionMethodDef(s)))
+      val newCls = Typed(Apply(Select(New(TypeIdent(cls)), cls.primaryConstructor), Nil), TypeTree.of[A])
+
+      Block(List(clsDef), newCls)
+    }
+
+    // Generate code { (s: Session) => new A with DISupport { def sesion: Session = s } }
     val body = Lambda(
       owner = Symbol.spliceOwner,
       tpe = MethodType(List("s"))(_ => List(TypeRepr.of[Session]), _ => TypeRepr.of[A]),
       rhsFn = (sym: Symbol, paramRefs: List[Tree]) => {
-        val s = paramRefs.head.asExprOf[Session].asTerm
-        val fn = newCls
+        val s  = paramRefs.head.asExprOf[Session].asTerm
+        val fn = newCls(s)
         fn.changeOwner(sym)
       }
     )
-    println("=------------")
-    println(body.show)
+    // println(body.show)
 
-    //val fn = '{ (s: Session) => ${ newCls('s) } }
+    // val exampleExpr = '{ (s: Session) => new Object with DISupport { def session: Session = s } }
+    // println(exampleExpr.show)
 
-
+    // Register trait factory
     // { (s: Session) => new A with DISupport { def session = s } }
-
-      '{
-        val s = Surface.of[A]
-        ()
-        //{ (ss: Session) => new A with DISupport {
-        //        override def session: Session = ss
-        //      }}
-      }
+    '{
+      wvlet.airframe.getOrElseUpdateTraitFactoryCache(Surface.of[A], ${ body.asExprOf[Session => Any] })
+    }
   }
 }

--- a/airframe-di/src/main/scala/wvlet/airframe/DISupport.scala
+++ b/airframe-di/src/main/scala/wvlet/airframe/DISupport.scala
@@ -17,5 +17,5 @@ package wvlet.airframe
   * A trait for embedding Session to user traits or classes
   */
 trait DISupport {
-  def session: Session
+  def session(): Session
 }

--- a/airframe-di/src/main/scala/wvlet/airframe/Session.scala
+++ b/airframe-di/src/main/scala/wvlet/airframe/Session.scala
@@ -170,7 +170,7 @@ object Session extends LogSupport {
 
     def findEmbeddedSession: Option[AnyRef => Session] = {
       if (classOf[DISupport] isAssignableFrom (cl)) {
-        Some({ (obj: AnyRef) => obj.asInstanceOf[DISupport].session })
+        Some({ (obj: AnyRef) => obj.asInstanceOf[DISupport].session() })
       } else {
         None
       }

--- a/airframe-di/src/test/scala-2/wvlet/airframe/legacy/AssistedInjectionTest.scala
+++ b/airframe-di/src/test/scala-2/wvlet/airframe/legacy/AssistedInjectionTest.scala
@@ -55,14 +55,14 @@ object AssistedInjectionTest extends LogSupport {
   trait NamedServiceProvider {
     val provider = (givenName: String, ss: Session) =>
       new NamedService with DISupport {
-        override def session: Session = ss
-        val name: String              = givenName
+        override def session(): Session = ss
+        val name: String                = givenName
       }
   }
 
   def assistedInjector(serviceName: String, ss: Session): NamedService =
     new NamedService with DISupport {
-      override def session: Session = ss
-      val name: String              = serviceName
+      override def session(): Session = ss
+      val name: String                = serviceName
     }
 }

--- a/airframe-di/src/test/scala-3/wvlet/airframe/di/TraitFactoryTest.scala
+++ b/airframe-di/src/test/scala-3/wvlet/airframe/di/TraitFactoryTest.scala
@@ -21,7 +21,6 @@ object TraitFactoryTest extends AirSpec {
   trait A
 
   test("register trait factory") {
-    // --
     wvlet.airframe.registerTraitFactory[A]
   }
 }

--- a/airframe-di/src/test/scala-3/wvlet/airframe/di/TraitFactoryTest.scala
+++ b/airframe-di/src/test/scala-3/wvlet/airframe/di/TraitFactoryTest.scala
@@ -21,6 +21,7 @@ object TraitFactoryTest extends AirSpec {
   trait A
 
   test("register trait factory") {
+    // --
     wvlet.airframe.registerTraitFactory[A]
   }
 }

--- a/airframe-di/src/test/scala-3/wvlet/airframe/di/TraitFactoryTest.scala
+++ b/airframe-di/src/test/scala-3/wvlet/airframe/di/TraitFactoryTest.scala
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.di
+
+import wvlet.airspec.AirSpec
+import scala.language.experimental
+
+object TraitFactoryTest extends AirSpec {
+
+  trait A
+
+  test("register trait factory") {
+    wvlet.airframe.registerTraitFactory[A]
+  }
+}

--- a/airframe-http-router/src/main/scala/wvlet/airframe/http/Router.scala
+++ b/airframe-http-router/src/main/scala/wvlet/airframe/http/Router.scala
@@ -34,7 +34,7 @@ import scala.language.higherKinds
   * e1 -> Filter1 andThen process(e1) e2 -> Filter1 andThen process(e2) e3 -> Filter1 andThen Filter2 andThen
   * process(e3) e4 -> process(e4)
   */
-case class Rofuter(
+case class Router(
     surface: Option[Surface] = None,
     children: Seq[Router] = Seq.empty,
     localRoutes: Seq[Route] = Seq.empty,

--- a/airframe-http-router/src/main/scala/wvlet/airframe/http/Router.scala
+++ b/airframe-http-router/src/main/scala/wvlet/airframe/http/Router.scala
@@ -34,7 +34,7 @@ import scala.language.higherKinds
   * e1 -> Filter1 andThen process(e1) e2 -> Filter1 andThen process(e2) e3 -> Filter1 andThen Filter2 andThen
   * process(e3) e4 -> process(e4)
   */
-case class Router(
+case class Rofuter(
     surface: Option[Surface] = None,
     children: Seq[Router] = Seq.empty,
     localRoutes: Seq[Route] = Seq.empty,


### PR DESCRIPTION
This is a blocker for supporting airframe-http and grpc in Scala 3 https://github.com/wvlet/airframe/issues/2194

- example https://github.com/lampepfl/dotty/blob/main/tests/run-macros/newClassExtendsClassParams/Macro_1.scala