### PR TITLE
Exclude pseudo headers from response of JDK's http client

### DIFF
--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/client/JavaClientChannel.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/client/JavaClientChannel.scala
@@ -128,10 +128,11 @@ class JavaClientChannel(serverAddress: ServerAddress, private[http] val config: 
     // Read HTTP response headers
     val header: HttpMultiMap = {
       val h = HttpMultiMap.newBuilder
-      httpResponse.headers().map().asScala.map { case (key, values) =>
-        values.asScala.foreach { v =>
-          h.add(key, v)
-        }
+      httpResponse.headers().map().asScala.map {
+        case (key, values) if !key.startsWith(":") =>
+          values.asScala.foreach { v =>
+            h.add(key, v)
+          }
       }
       h.result()
     }


### PR DESCRIPTION
Response of JDK's http client contains some pseudo headers that start with `:`.

Finagle's validation error occurs if we try to return a response that include these headers in airframe-http/rpc based server application.

```
2022-10-18 14:19:25.142+0900  warn [FinagleServer] Request("GET /v1/status", from /127.0.0.1:60175) failed: com.twitter.finagle.http.headers.Rfc7230HeaderValidation$NameValidationException: Header ':status': name cannot contain the prohibited character '0x3a': :  - (FinagleServer.scala:272)
com.twitter.finagle.http.headers.Rfc7230HeaderValidation$NameValidationException: Header ':status': name cannot contain the prohibited character '0x3a': :
        at com.twitter.finagle.http.headers.Rfc7230HeaderValidation$.validateName(Rfc7230HeaderValidation.scala:106)
        at com.twitter.finagle.http.HeaderMap$.validateName(HeaderMap.scala:129)
        at com.twitter.finagle.http.headers.JTreeMapBackedHeaderMap.add(JTreeMapBackedHeaderMap.scala:37)
        at com.twitter.finagle.http.headers.JTreeMapBackedHeaderMap.add(JTreeMapBackedHeaderMap.scala:11)
        at wvlet.airframe.http.finagle.package$.$anonfun$convertToFinagleResponse$1(package.scala:195)
        at scala.collection.immutable.List.foreach(List.scala:333)
        at wvlet.airframe.http.finagle.package$.convertToFinagleResponse(package.scala:194)
        at wvlet.airframe.http.finagle.FinagleResponseHandler.toHttpResponse(FinagleResponseHandler.scala:118)
        at wvlet.airframe.http.finagle.FinagleResponseHandler.toHttpResponse(FinagleResponseHandler.scala:32)
        ...
```

It would be better to exclude these JDK's http client specific pseudo headers inside airframe-http-client's abstraction layer.