### PR TITLE
openapi: Fixes #2491: Use YAML literal for multi-line strings and strings with single quote

### DIFF
--- a/airframe-http-codegen/src/test/scala/wvlet/airframe/http/openapi/SimpleOpenAPITest.scala
+++ b/airframe-http-codegen/src/test/scala/wvlet/airframe/http/openapi/SimpleOpenAPITest.scala
@@ -104,6 +104,12 @@ object SimpleOpenAPITest extends AirSpec {
         @description("custom parameter 1")
         p1: String
     ): Method1Response
+
+    @description("multi-line\ndescription")
+    def method2(): Unit
+
+    @description("'single-quoted' description")
+    def method3(): Unit
   }
 
   @description("method1 response")
@@ -118,6 +124,18 @@ object SimpleOpenAPITest extends AirSpec {
     yaml.contains("description: 'custom parameter 1'") shouldBe true
     yaml.contains("description: 'method1 response'") shouldBe true
     yaml.contains("description: 'response code'") shouldBe true
-  }
 
+    test("Use literal format multiline descriptions") {
+      yaml.contains("""description: |
+          |  multi-line
+          |  description""".stripMargin)
+    }
+
+    test("Use literal format for strings with single quote") {
+      yaml.contains(
+        """description: |
+          |  'single-quoted' description""".stripMargin
+      )
+    }
+  }
 }

--- a/airframe-json/src/test/scala/wvlet/airframe/json/YAMLFormatterTest.scala
+++ b/airframe-json/src/test/scala/wvlet/airframe/json/YAMLFormatterTest.scala
@@ -87,6 +87,17 @@ class YAMLFormatterTest extends AirSpec {
                |    c: 2
                |  - b: 3
                |    c: 4""".stripMargin
+    ),
+    Test(
+      json = """{"description":"multi-line\nstrings"}""",
+      yaml = """description: |
+          |  multi-line
+          |  strings""".stripMargin
+    ),
+    Test(
+      json = """{"description":"with quote(')"}""",
+      yaml = """description: |
+          |  with quote(')""".stripMargin
     )
   )
 


### PR DESCRIPTION
- Fixes #2491: Use literal format when necessry
- Add openapi test for multi-line literal
