### PR TITLE
Classify PRs with test-libray-update label as Dependency Updates

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -14,6 +14,7 @@ categories:
   - title: '⛓  Dependency Updates'
     label:
       - 'library-update'
+      - 'test-library-upadte'
       - 'sbt-plugin-update'
       - 'dependencies'
   - title: '🛠  Internal Updates'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -14,7 +14,7 @@ categories:
   - title: '⛓  Dependency Updates'
     label:
       - 'library-update'
-      - 'test-library-upadte'
+      - 'test-library-update'
       - 'sbt-plugin-update'
       - 'dependencies'
   - title: '🛠  Internal Updates'


### PR DESCRIPTION
For properly categorizing test library updates like https://github.com/wvlet/airframe/pull/2508 in the release note draft