### PR TITLE
airframe-sql: Fixes table/relation alias handling in TypeResolver 

### DIFF
--- a/airframe-parquet/src/main/scala/wvlet/airframe/parquet/ParquetQueryPlanner.scala
+++ b/airframe-parquet/src/main/scala/wvlet/airframe/parquet/ParquetQueryPlanner.scala
@@ -53,7 +53,7 @@ object ParquetQueryPlanner extends LogSupport {
           parseRelation(input, queryPlan).selectAllColumns
         case Project(input, selectItems) =>
           val columns = selectItems.map {
-            case SingleColumn(id: Identifier, _) =>
+            case SingleColumn(id: Identifier, _, _) =>
               id.value
             case other =>
               throw new IllegalArgumentException(s"Invalid select item: ${other}")

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
@@ -28,7 +28,6 @@ object TypeResolver extends LogSupport {
     // First resolve all input table types
     // CTE Table Refs must be resolved before resolving aggregation indexes
     TypeResolver.resolveCTETableRef _ ::
-      TypeResolver.resolveAliases _ ::
       TypeResolver.resolveAggregationIndexes _ ::
       TypeResolver.resolveAggregationKeys _ ::
       TypeResolver.resolveTableRef _ ::
@@ -102,10 +101,6 @@ object TypeResolver extends LogSupport {
       val resolvedGroupingKeys =
         groupingKeys.map(x => GroupingKey(resolveExpression(context, x.child, inputAttributes)))
       Aggregate(resolvedChild, selectItems, resolvedGroupingKeys, having)
-  }
-
-  def resolveAliases(context: AnalyzerContext): PlanRewriter = { case plan =>
-    plan
   }
 
   /**

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
@@ -107,9 +107,10 @@ object TypeResolver extends LogSupport {
     */
   def resolveAggregationKeys(context: AnalyzerContext): PlanRewriter = {
     case a @ Aggregate(child, selectItems, groupingKeys, having) =>
-      val resolvedChild        = resolveRelation(context, child)
-      val inputAttributes      = resolvedChild.outputAttributes
-      val resolvedGroupingKeys = groupingKeys.map(x => GroupingKey(resolveExpression(x.child, inputAttributes)))
+      val resolvedChild   = resolveRelation(context, child)
+      val inputAttributes = resolvedChild.outputAttributes
+      val resolvedGroupingKeys =
+        groupingKeys.map(x => GroupingKey(resolveExpression(context, x.child, inputAttributes)))
       Aggregate(resolvedChild, selectItems, resolvedGroupingKeys, having)
   }
 
@@ -151,7 +152,7 @@ object TypeResolver extends LogSupport {
       // from A join B using(c1, c2, ...)
       val resolvedJoin = Join(joinType, resolveRelation(context, left), resolveRelation(context, right), u)
       val resolvedJoinKeys: Seq[Expression] = joinKeys.flatMap { k =>
-        findMatchInInputAttributes(k, resolvedJoin.inputAttributes) match {
+        findMatchInInputAttributes(context, k, resolvedJoin.inputAttributes) match {
           case Nil =>
             throw SQLErrorCode.ColumnNotFound.newException(s"join key column: ${k.sqlExpr} is not found")
           case other =>
@@ -163,7 +164,7 @@ object TypeResolver extends LogSupport {
     case j @ Join(joinType, left, right, u @ JoinOn(Eq(leftKey, rightKey))) =>
       val resolvedJoin = Join(joinType, resolveRelation(context, left), resolveRelation(context, right), u)
       val resolvedJoinKeys: Seq[Expression] = Seq(leftKey, rightKey).flatMap { k =>
-        findMatchInInputAttributes(k, resolvedJoin.inputAttributes) match {
+        findMatchInInputAttributes(context, k, resolvedJoin.inputAttributes) match {
           case Nil =>
             throw SQLErrorCode.ColumnNotFound.newException(s"join key column: ${k.sqlExpr} is not found")
           case other =>
@@ -176,9 +177,9 @@ object TypeResolver extends LogSupport {
 
   def resolveRegularRelation(context: AnalyzerContext): PlanRewriter = {
     case filter @ Filter(child, filterExpr) =>
-      filter.transformExpressions { case x: Expression => resolveExpression(x, filter.inputAttributes) }
+      filter.transformExpressions { case x: Expression => resolveExpression(context, x, filter.inputAttributes) }
     case r: Relation =>
-      r.transformExpressions { case x: Expression => resolveExpression(x, r.inputAttributes) }
+      r.transformExpressions { case x: Expression => resolveExpression(context, x, r.inputAttributes) }
   }
 
   def resolveUnion(context: AnalyzerContext): PlanRewriter = {
@@ -188,7 +189,7 @@ object TypeResolver extends LogSupport {
   }
 
   def resolveColumns(context: AnalyzerContext): PlanRewriter = { case p @ Project(child, columns) =>
-    val resolvedColumns = resolveOutputColumns(child.outputAttributes, columns)
+    val resolvedColumns = resolveOutputColumns(context, child.outputAttributes, columns)
     val resolved        = Project(child, resolvedColumns)
     resolved
   }
@@ -199,7 +200,11 @@ object TypeResolver extends LogSupport {
     * @param outputColumns
     * @return
     */
-  private def resolveOutputColumns(inputAttributes: Seq[Attribute], outputColumns: Seq[Attribute]): Seq[Attribute] = {
+  private def resolveOutputColumns(
+      context: AnalyzerContext,
+      inputAttributes: Seq[Attribute],
+      outputColumns: Seq[Attribute]
+  ): Seq[Attribute] = {
 
     val resolvedColumns = Seq.newBuilder[Attribute]
     outputColumns.map {
@@ -207,7 +212,7 @@ object TypeResolver extends LogSupport {
         // TODO check (prefix).* to resolve attributes
         resolvedColumns ++= inputAttributes
       case SingleColumn(expr, alias, _) =>
-        resolveExpression(expr, inputAttributes) match {
+        resolveExpression(context, expr, inputAttributes) match {
           case r: ResolvedAttribute if alias.isEmpty =>
             resolvedColumns += r
           case r: ResolvedAttribute if alias.nonEmpty =>
@@ -244,23 +249,26 @@ object TypeResolver extends LogSupport {
     * @param inputAttributes
     * @return
     */
-  private def findMatchInInputAttributes(expr: Expression, inputAttributes: Seq[Attribute]): List[Expression] = {
+  private def findMatchInInputAttributes(
+      context: AnalyzerContext,
+      expr: Expression,
+      inputAttributes: Seq[Attribute]
+  ): List[Expression] = {
     trace(s"findMatchInInputAttributes: ${expr}, inputAttributes: ${inputAttributes}")
     def lookup(name: String): List[Attribute] = {
       QName(name) match {
+        case QName(Seq(db, t1, c1)) if context.database == db =>
+          inputAttributes.collect {
+            case a: ResolvedAttribute if a.hasMatch(t1, c1) => a
+          }.toList
         case QName(Seq(t1, c1)) =>
-          val attrs = inputAttributes.collect {
-            case a @ ResolvedAttribute(c, _, None, Some(t), _) if t.name == t1 && c == c1 => a
-            // table name alias
-            case a @ ResolvedAttribute(c, _, Some(ref), _, _) if ref == t1 && c == c1 => a
-            case a @ ResolvedAttribute(c, _, _, None, _) if c == c1                   => a
-          }
-          attrs.toList
+          inputAttributes.collect {
+            case a: ResolvedAttribute if a.hasMatch(t1, c1) => a
+          }.toList
         case QName(Seq(c1)) =>
-          val attrs = inputAttributes.collect {
-            case a @ ResolvedAttribute(c, _, _, _, _) if c == c1 => a
-          }
-          attrs.toList
+          inputAttributes.collect {
+            case a: ResolvedAttribute if a.name == c1 => a
+          }.toList
         case _ =>
           List.empty
       }
@@ -279,8 +287,8 @@ object TypeResolver extends LogSupport {
   /**
     * Resolve untyped expressions
     */
-  def resolveExpression(expr: Expression, inputAttributes: Seq[Attribute]): Expression = {
-    findMatchInInputAttributes(expr, inputAttributes) match {
+  def resolveExpression(context: AnalyzerContext, expr: Expression, inputAttributes: Seq[Attribute]): Expression = {
+    findMatchInInputAttributes(context, expr, inputAttributes) match {
       case lst if lst.length > 1 =>
         throw SQLErrorCode.SyntaxError.newException(s"${expr.sqlExpr} is ambiguous")
       case lst =>

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
@@ -15,17 +15,7 @@ package wvlet.airframe.sql.analyzer
 import wvlet.airframe.sql.SQLErrorCode
 import wvlet.airframe.sql.analyzer.SQLAnalyzer.{PlanRewriter, Rule}
 import wvlet.airframe.sql.model.Expression._
-import wvlet.airframe.sql.model.LogicalPlan.{
-  Aggregate,
-  AliasedRelation,
-  Filter,
-  Join,
-  Project,
-  Query,
-  Relation,
-  TableRef,
-  Union
-}
+import wvlet.airframe.sql.model.LogicalPlan._
 import wvlet.airframe.sql.model._
 import wvlet.log.LogSupport
 

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
@@ -244,8 +244,8 @@ object TypeResolver extends LogSupport {
     * @param inputAttributes
     * @return
     */
-  def findMatchInInputAttributes(expr: Expression, inputAttributes: Seq[Attribute]): List[Expression] = {
-    debug(s"findMatchInInputAttributes: ${expr}, inputAttributes: ${inputAttributes}")
+  private def findMatchInInputAttributes(expr: Expression, inputAttributes: Seq[Attribute]): List[Expression] = {
+    trace(s"findMatchInInputAttributes: ${expr}, inputAttributes: ${inputAttributes}")
     def lookup(name: String): List[Attribute] = {
       QName(name) match {
         case QName(Seq(t1, c1)) =>

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
@@ -249,11 +249,11 @@ object TypeResolver extends LogSupport {
       QName(name) match {
         case QName(Seq(db, t1, c1)) if context.database == db =>
           inputAttributes.collect {
-            case a: ResolvedAttribute if a.hasMatch(t1, c1) => a
+            case a: ResolvedAttribute if a.matchesWith(t1, c1) => a
           }.toList
         case QName(Seq(t1, c1)) =>
           inputAttributes.collect {
-            case a: ResolvedAttribute if a.hasMatch(t1, c1) => a
+            case a: ResolvedAttribute if a.matchesWith(t1, c1) => a
           }.toList
         case QName(Seq(c1)) =>
           inputAttributes.collect {

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
@@ -226,18 +226,14 @@ object Expression {
     override def children: Seq[Expression] = keys
   }
 
-  case class AllColumns(prefix: Option[QName]) extends Attribute {
-    override def name: String              = prefix.map(x => s"${x}.*").getOrElse("*")
-    override def children: Seq[Expression] = prefix.toSeq
+  case class AllColumns(qualifier: Option[QName]) extends Attribute {
+    override def name: String              = qualifier.map(x => s"${x}.*").getOrElse("*")
+    override def children: Seq[Expression] = qualifier.toSeq
     override def toString                  = s"AllColumns(${name})"
     override lazy val resolved             = false
 
     override def withQualifier(newQualifier: String): Attribute = {
-      prefix match {
-        case Some(p) if p.fullName.startsWith(newQualifier) => this
-        case Some(p)                                        => AllColumns(Some(QName(s"${newQualifier}.${p.fullName}")))
-        case _                                              => AllColumns(Some(QName(newQualifier)))
-      }
+      this.copy(qualifier = Some(QName(newQualifier)))
     }
   }
   case class SingleColumn(expr: Expression, alias: Option[Expression], qualifier: Option[String] = None)

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
@@ -232,7 +232,13 @@ object Expression {
     override def toString                  = s"AllColumns(${name})"
     override lazy val resolved             = false
 
-    override def withQualifier(newQualifier: String): Attribute = ???
+    override def withQualifier(newQualifier: String): Attribute = {
+      prefix match {
+        case Some(p) if p.fullName.startsWith(newQualifier) => this
+        case Some(p)                                        => AllColumns(Some(QName(s"${newQualifier}.${p.fullName}")))
+        case _                                              => AllColumns(Some(QName(newQualifier)))
+      }
+    }
   }
   case class SingleColumn(expr: Expression, alias: Option[Expression], qualifier: Option[String] = None)
       extends Attribute {

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
@@ -249,7 +249,11 @@ object LogicalPlan {
     override def sig(config: QuerySignatureConfig): String = child.sig(config)
 
     override def inputAttributes: Seq[Attribute]  = child.inputAttributes
-    override def outputAttributes: Seq[Attribute] = child.outputAttributes
+    override def outputAttributes: Seq[Attribute] = {
+
+
+      child.outputAttributes
+    }
   }
 
   case class Values(rows: Seq[Expression]) extends Relation with LeafPlan {

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
@@ -250,8 +250,9 @@ object LogicalPlan {
 
     override def inputAttributes: Seq[Attribute] = child.inputAttributes
     override def outputAttributes: Seq[Attribute] = {
-
-      child.outputAttributes
+      child.outputAttributes.map { a =>
+        a.withQualifier(alias.value)
+      }
     }
   }
 

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
@@ -248,9 +248,8 @@ object LogicalPlan {
       extends UnaryRelation {
     override def sig(config: QuerySignatureConfig): String = child.sig(config)
 
-    override def inputAttributes: Seq[Attribute]  = child.inputAttributes
+    override def inputAttributes: Seq[Attribute] = child.inputAttributes
     override def outputAttributes: Seq[Attribute] = {
-
 
       child.outputAttributes
     }

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/ResolvedPlan.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/ResolvedPlan.scala
@@ -29,7 +29,7 @@ case class TableScan(table: Catalog.Table, columns: Seq[Catalog.TableColumn]) ex
   override def inputAttributes: Seq[Attribute] = Seq.empty
   override def outputAttributes: Seq[Attribute] = {
     columns.map { col =>
-      ResolvedAttribute(col.name, col.dataType, Some(table), Some(col))
+      ResolvedAttribute(col.name, col.dataType, None, Some(table), Some(col))
     }
   }
   override def sig(config: QuerySignatureConfig): String = {
@@ -43,9 +43,12 @@ case class TableScan(table: Catalog.Table, columns: Seq[Catalog.TableColumn]) ex
   override lazy val resolved = true
 }
 
+case class Alias(name: String, resolvedAttribute: ResolvedAttribute)
+
 case class ResolvedAttribute(
     name: String,
     dataType: DataType,
+    qualifier: Option[String],
     sourceTable: Option[Catalog.Table],
     sourceColumn: Option[Catalog.TableColumn]
 ) extends Attribute {
@@ -67,6 +70,10 @@ case class ResolvedAttribute(
     // s"${sourceTable.map(t => s"${t.name}.${name}").getOrElse(name)}:${dataType}"
   }
   override lazy val resolved = true
+
+  override def withQualifier(newQualifier: String): Attribute = {
+    this.copy(qualifier = Some(newQualifier))
+  }
 }
 
 /**

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/ResolvedPlan.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/ResolvedPlan.scala
@@ -59,10 +59,12 @@ case class ResolvedAttribute(
   }
 
   override def toString = {
-    (sourceTable, sourceColumn) match {
-      case (Some(t), Some(c)) if c.name == name =>
+    (qualifier, sourceTable, sourceColumn) match {
+      case (Some(q), Some(t), Some(c)) =>
+        s"${q}.${name}:${dataType} <- ${t.name}.${c.name}"
+      case (None, Some(t), Some(c)) if c.name == name =>
         s"${t.name}.${name}:${dataType}"
-      case (Some(t), Some(c)) =>
+      case (None, Some(t), Some(c)) =>
         s"${name}:${dataType} <- ${t.name}.${c.name}"
       case _ =>
         s"${name}:${dataType}"

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/ResolvedPlan.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/ResolvedPlan.scala
@@ -59,7 +59,10 @@ case class ResolvedAttribute(
 
   def relationName: Option[String] = qualifier.orElse(sourceTable.map(_.name))
 
-  def hasMatch(tableName: String, columnName: String): Boolean = {
+  /**
+    * Returns true if this resolved attribute matches with a given table name and colum name
+    */
+  def matchesWith(tableName: String, columnName: String): Boolean = {
     relationName match {
       case Some(tbl) =>
         tbl == tableName && columnName == name

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/ResolvedPlan.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/ResolvedPlan.scala
@@ -14,8 +14,7 @@
 package wvlet.airframe.sql.model
 
 import wvlet.airframe.sql.analyzer.QuerySignatureConfig
-import wvlet.airframe.sql.catalog.Catalog
-import wvlet.airframe.sql.catalog.DataType
+import wvlet.airframe.sql.catalog.{Catalog, DataType}
 import wvlet.airframe.sql.model.LogicalPlan.Relation
 
 /**

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/ResolvedPlan.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/ResolvedPlan.scala
@@ -58,6 +58,17 @@ case class ResolvedAttribute(
     this.copy(name = newName)
   }
 
+  def relationName: Option[String] = qualifier.orElse(sourceTable.map(_.name))
+
+  def hasMatch(tableName: String, columnName: String): Boolean = {
+    relationName match {
+      case Some(tbl) =>
+        tbl == tableName && columnName == name
+      case None =>
+        columnName == name
+    }
+  }
+
   override def toString = {
     (qualifier, sourceTable, sourceColumn) match {
       case (Some(q), Some(t), Some(c)) =>

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLGenerator.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLGenerator.scala
@@ -348,7 +348,7 @@ object SQLGenerator extends LogSupport {
         printExpression(k)
       case ParenthesizedExpression(expr) =>
         s"(${printExpression(expr)})"
-      case SingleColumn(ex, alias) =>
+      case SingleColumn(ex, alias, _) =>
         val col = printExpression(ex)
         alias
           .map(x => s"${col} AS ${printExpression(x)}")

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/SQLAnalyzerTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/SQLAnalyzerTest.scala
@@ -51,8 +51,8 @@ class SQLAnalyzerTest extends AirSpec {
     val plan = SQLAnalyzer.analyze("select id, name from a", "public", catalog)
     plan.resolved shouldBe true
     plan.outputAttributes.toList shouldBe List(
-      ResolvedAttribute("id", DataType.LongType, Some(tbl1), Some(tbl1.column("id"))),
-      ResolvedAttribute("name", DataType.StringType, Some(tbl1), Some(tbl1.column("name")))
+      ResolvedAttribute("id", DataType.LongType, None, Some(tbl1), Some(tbl1.column("id"))),
+      ResolvedAttribute("name", DataType.StringType, None, Some(tbl1), Some(tbl1.column("name")))
     )
   }
 
@@ -60,9 +60,9 @@ class SQLAnalyzerTest extends AirSpec {
     val plan = SQLAnalyzer.analyze("select * from a", "public", catalog)
     plan.resolved shouldBe true
     plan.outputAttributes.toList shouldBe List(
-      ResolvedAttribute("id", DataType.LongType, Some(tbl1), Some(tbl1.column("id"))),
-      ResolvedAttribute("name", DataType.StringType, Some(tbl1), Some(tbl1.column("name"))),
-      ResolvedAttribute("address", DataType.StringType, Some(tbl1), Some(tbl1.column("address")))
+      ResolvedAttribute("id", DataType.LongType, None, Some(tbl1), Some(tbl1.column("id"))),
+      ResolvedAttribute("name", DataType.StringType, None, Some(tbl1), Some(tbl1.column("name"))),
+      ResolvedAttribute("address", DataType.StringType, None, Some(tbl1), Some(tbl1.column("address")))
     )
   }
 
@@ -70,7 +70,7 @@ class SQLAnalyzerTest extends AirSpec {
     val plan = SQLAnalyzer.analyze("select id as person_id from a", "public", catalog)
     plan.resolved shouldBe true
     plan.outputAttributes.toList shouldBe List(
-      ResolvedAttribute("person_id", DataType.LongType, Some(tbl1), Some(tbl1.column("id")))
+      ResolvedAttribute("person_id", DataType.LongType, None, Some(tbl1), Some(tbl1.column("id")))
     )
   }
 
@@ -82,10 +82,10 @@ class SQLAnalyzerTest extends AirSpec {
     )
     plan.resolved shouldBe true
     plan.outputAttributes.toList shouldBe List(
-      ResolvedAttribute("id", DataType.LongType, Some(tbl1), Some(tbl1.column("id"))),
-      ResolvedAttribute("name", DataType.StringType, Some(tbl1), Some(tbl1.column("name"))),
-      ResolvedAttribute("address", DataType.StringType, Some(tbl1), Some(tbl1.column("address"))),
-      ResolvedAttribute("person_id", DataType.StringType, Some(tbl2), Some(tbl2.column("phone")))
+      ResolvedAttribute("id", DataType.LongType, None, Some(tbl1), Some(tbl1.column("id"))),
+      ResolvedAttribute("name", DataType.StringType, None, Some(tbl1), Some(tbl1.column("name"))),
+      ResolvedAttribute("address", DataType.StringType, None, Some(tbl1), Some(tbl1.column("address"))),
+      ResolvedAttribute("person_id", DataType.StringType, None, Some(tbl2), Some(tbl2.column("phone")))
     )
   }
 

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
@@ -13,14 +13,14 @@
  */
 package wvlet.airframe.sql.analyzer
 
-import wvlet.airframe.sql.{SQLError, SQLErrorCode}
 import wvlet.airframe.sql.analyzer.SQLAnalyzer.PlanRewriter
 import wvlet.airframe.sql.catalog.Catalog._
 import wvlet.airframe.sql.catalog.{Catalog, DataType, InMemoryCatalog}
-import wvlet.airframe.sql.model.Expression.{And, Cast, Eq, FunctionCall, GroupingKey, LongLiteral, SingleColumn}
+import wvlet.airframe.sql.model.Expression._
 import wvlet.airframe.sql.model.LogicalPlan.{Aggregate, Filter, Project}
-import wvlet.airframe.sql.model.{Expression, LogicalPlan, LogicalPlanPrinter, ResolvedAttribute}
+import wvlet.airframe.sql.model.{Expression, LogicalPlan, ResolvedAttribute}
 import wvlet.airframe.sql.parser.SQLParser
+import wvlet.airframe.sql.{SQLError, SQLErrorCode}
 import wvlet.airspec.AirSpec
 
 class TypeResolverTest extends AirSpec {

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
@@ -90,18 +90,25 @@ class TypeResolverTest extends AirSpec {
   test("resolveTableRef") {
     test("resolve all columns") {
       val p = analyzeSingle("select * from A", TypeResolver.resolveTableRef)
-      p.inputAttributes shouldBe Seq(ra1, ra2)
+      p.inputAttributes shouldBe List(ra1, ra2)
     }
 
     test("resolve the right table") {
       val p = analyzeSingle("select * from B", TypeResolver.resolveTableRef)
-      p.inputAttributes shouldBe Seq(rb1, rb2)
+      p.inputAttributes shouldBe List(rb1, rb2)
     }
 
     test("resolve database.table name format") {
       val p = analyzeSingle("select * from default.A", TypeResolver.resolveTableRef)
-      p.inputAttributes shouldBe Seq(ra1, ra2)
+      p.inputAttributes shouldBe List(ra1, ra2)
     }
+  }
+
+  test("resolve full table name") {
+    val p = analyze("select default.A.id from A")
+    p.outputAttributes shouldBe List(
+      ra1
+    )
   }
 
   test("resolveRelation") {
@@ -239,7 +246,7 @@ class TypeResolverTest extends AirSpec {
     }
   }
 
-  test("resolve alias") {
+  test("resolve aliases") {
     test("rename table") {
       val p = analyze("select a.id from A a")
       p.outputAttributes shouldBe List(

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
@@ -239,6 +239,23 @@ class TypeResolverTest extends AirSpec {
     }
   }
 
+  test("resolve alias") {
+    test("rename table") {
+      val p = analyze("select a.id from A a")
+      p.outputAttributes shouldBe List(
+        ra1.withQualifier("a")
+      )
+    }
+
+    test("rename table and select *") {
+      val p = analyze("select * from A a")
+      p.outputAttributes shouldBe List(
+        ra1.withQualifier("a"),
+        ra2.withQualifier("a")
+      )
+    }
+  }
+
   test("resolve join attributes") {
     test("join with USING") {
       val p = analyze("select id, A.name from A join B using(id)")
@@ -257,11 +274,10 @@ class TypeResolverTest extends AirSpec {
     }
 
     test("join with on condition for aliased columns") {
-      warn(s"----------")
       val p = analyze("select id, a.name from A a join B b on a.id = b.id")
       p.outputAttributes shouldBe List(
-        ra1,
-        ra2
+        ra1.withQualifier("a"),
+        ra2.withQualifier("a")
       )
     }
 

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
@@ -261,6 +261,22 @@ class TypeResolverTest extends AirSpec {
       )
     }
 
+    test("join with on condition for aliased columns") {
+      val p = analyze("select id, a.name from A a join B b on a.id = b.id")
+      p.outputAttributes shouldBe List(
+        ResolvedAttribute("id", DataType.LongType, Some(tableA), Some(a1)),
+        ResolvedAttribute("name", DataType.StringType, Some(tableA), Some(a2))
+      )
+    }
+
+    test("join with on condition for qualified columns") {
+      val p = analyze("select id, default.A.name from default.A join default.B on default.A.id = default.B.id")
+      p.outputAttributes shouldBe List(
+        ResolvedAttribute("id", DataType.LongType, Some(tableA), Some(a1)),
+        ResolvedAttribute("name", DataType.StringType, Some(tableA), Some(a2))
+      )
+    }
+
     test("join with different column names") {
       val p = analyze("select pid, name from A join (select id pid from B) on A.id = B.pid")
       p.outputAttributes shouldBe List(


### PR DESCRIPTION
- Added `qualifier` parameter to ResolvedAttribute for tracking aliases
- AliasedRelation.output attributes returns a list of ResolvedAttributes with a qualifier (i.e. aliases)
- Fixed column name match when the context database is in the qualified name (QName)