### PR TITLE
airframe-http: Use JSON encoding by default for HTTP clients

### DIFF
--- a/airframe-http/.js/src/test/scala/wvlet/airframe/http/client/JSRPCClientTest.scala
+++ b/airframe-http/.js/src/test/scala/wvlet/airframe/http/client/JSRPCClientTest.scala
@@ -13,6 +13,7 @@
  */
 package wvlet.airframe.http.client
 
+import wvlet.airframe.http.HttpHeader.MediaType
 import wvlet.airframe.http.{Http, HttpClientConfig, RPCMethod}
 import wvlet.airframe.surface.Surface
 import wvlet.airspec.AirSpec
@@ -36,7 +37,7 @@ class JSRPCClientTest extends AirSpec {
       .rpc[TestRequest, TestResponse](m, TestRequest(1, "test"))
       .map { response =>
         debug(response)
-        response.headers.get("Content-Type") shouldBe Some("application/msgpack")
+        response.headers.get("Content-Type") shouldBe Some(MediaType.ApplicationJson)
       }
   }
 

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/client/RPCHttpClientTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/client/RPCHttpClientTest.scala
@@ -16,6 +16,7 @@ package wvlet.airframe.http.client
 import wvlet.airframe.http.{Http, RPCMethod}
 import wvlet.airframe.surface.Surface
 import wvlet.airspec.AirSpec
+import wvlet.airframe.http.HttpHeader.MediaType
 
 object RPCHttpClientTest extends AirSpec {
 
@@ -32,7 +33,7 @@ object RPCHttpClientTest extends AirSpec {
 
     // Test message
     debug(response)
-    response.headers.get("Content-Type") shouldBe Some("application/msgpack")
+    response.headers.get("Content-Type") shouldBe Some(MediaType.ApplicationJson)
   }
 
 }

--- a/airframe-http/src/main/scala/wvlet/airframe/http/HttpClientConfig.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/HttpClientConfig.scala
@@ -44,7 +44,7 @@ trait ChannelConfig {
 case class HttpClientConfig(
     backend: HttpClientBackend = compat.defaultHttpClientBackend,
     requestFilter: Request => Request = identity,
-    rpcEncoding: RPCEncoding = RPCEncoding.MsgPack,
+    rpcEncoding: RPCEncoding = RPCEncoding.JSON,
     retryContext: RetryContext = compat.defaultHttpClientBackend.defaultRequestRetryer,
     codecFactory: MessageCodecFactory = MessageCodecFactory.defaultFactoryForJSON,
     // The default circuit breaker, which will be open after 5 consecutive failures

--- a/airframe-http/src/main/scala/wvlet/airframe/http/RPCEncoding.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/RPCEncoding.scala
@@ -15,6 +15,7 @@ package wvlet.airframe.http
 
 import wvlet.airframe.codec.MessageCodec
 import wvlet.airframe.codec.PrimitiveCodec.ValueCodec
+import wvlet.airframe.http.HttpHeader.MediaType
 import wvlet.airframe.msgpack.spi.Value
 
 import java.nio.charset.StandardCharsets
@@ -28,9 +29,9 @@ sealed trait RPCEncoding {
 }
 
 object RPCEncoding {
-  // Note on why we use appliaction/msgpack https://github.com/msgpack/msgpack/issues/194
-  val ApplicationMsgPack = "application/msgpack"
-  val ApplicationJson    = "application/json"
+  // Note on why we use application/msgpack https://github.com/msgpack/msgpack/issues/194
+  val ApplicationMsgPack = MediaType.ApplicationMsgPack
+  val ApplicationJson    = MediaType.ApplicationJson
 
   case object MsgPack extends RPCEncoding {
     override def applicationType: String = ApplicationMsgPack


### PR DESCRIPTION
Using JSON by default is good for compatibility. 