### PR TITLE
Include inputAttributes of all relations in UNION

### DIFF
--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
@@ -482,8 +482,9 @@ object LogicalPlan {
       val in = relations.map(_.sig(config)).mkString(",")
       s"U(${in})"
     }
-    override def inputAttributes: Seq[Attribute] =
-      relations.head.inputAttributes
+    override def inputAttributes: Seq[Attribute] = {
+      relations.flatMap(_.inputAttributes)
+    }
     override def outputAttributes: Seq[Attribute] =
       relations.head.outputAttributes
   }


### PR DESCRIPTION
Include inputAttributes of all relations in UNION's inputAttributes.