### PR TITLE
openapi: Fixes #2562. Find method default arguments only when RPC interface is a class

### DIFF
--- a/airframe-http-codegen/src/test/scala/wvlet/airframe/http/openapi/OpenAPITest.scala
+++ b/airframe-http-codegen/src/test/scala/wvlet/airframe/http/openapi/OpenAPITest.scala
@@ -533,8 +533,12 @@ class OpenAPITest extends AirSpec {
     //      .setContents(new java.awt.datatransfer.StringSelection(yaml), null)
 
     fragments.foreach { x =>
-      debug(x)
-      yaml.contains(x) shouldBe true
+      try {
+        yaml.contains(x) shouldBe true
+      } catch {
+        case e: Throwable =>
+          fail(s"Match failure for:\n${x}")
+      }
     }
 
     // Parsing test


### PR DESCRIPTION
- openapi: Fixes #2562. Find method default arguments only when RPC interface is a class
- wip
