### PR TITLE
  airframe-di: Deprecate toInstanceOf, toSingletonOf, toInstanceProvider, toSingletonProvider

### DIFF
--- a/airframe-di/src/main/scala-2/wvlet/airframe/BinderImpl.scala
+++ b/airframe-di/src/main/scala-2/wvlet/airframe/BinderImpl.scala
@@ -22,18 +22,24 @@ private[airframe] trait BinderImpl[A] extends LogSupport { self: Binder[A] =>
     * @tparam B
     * @return
     */
+  @deprecated("Use toSingletonOf[X] instead. This method will not be available in Scala 3", "21.5.1")
   def toInstanceOf[B <: A]: DesignWithContext[B] = macro binderToImpl[B]
 
   def toSingletonOf[B <: A]: DesignWithContext[B] = macro binderToSingletonOfImpl[B]
 
   def toEagerSingletonOf[B <: A]: DesignWithContext[B] = macro binderToEagerSingletonOfImpl[B]
 
+  @deprecated("Use toProvider[X] instead. This method will not be available in Scala 3", "21.5.1")
   def toInstanceProvider[D1](factory: D1 => A): DesignWithContext[A] = macro bindToProvider1[A, D1]
+  @deprecated("Use toProvider[X] instead. This method will not be available in Scala 3", "21.5.1")
   def toInstanceProvider[D1, D2](factory: (D1, D2) => A): DesignWithContext[A] = macro bindToProvider2[A, D1, D2]
+  @deprecated("Use toProvider[X] instead. This method will not be available in Scala 3", "21.5.1")
   def toInstanceProvider[D1, D2, D3](factory: (D1, D2, D3) => A): DesignWithContext[A] =
     macro bindToProvider3[A, D1, D2, D3]
+  @deprecated("Use toProvider[X] instead. This method will not be available in Scala 3", "21.5.1")
   def toInstanceProvider[D1, D2, D3, D4](factory: (D1, D2, D3, D4) => A): DesignWithContext[A] =
     macro bindToProvider4[A, D1, D2, D3, D4]
+  @deprecated("Use toProvider[X] instead. This method will not be available in Scala 3", "21.5.1")
   def toInstanceProvider[D1, D2, D3, D4, D5](factory: (D1, D2, D3, D4, D5) => A): DesignWithContext[A] =
     macro bindToProvider5[A, D1, D2, D3, D4, D5]
 
@@ -46,13 +52,18 @@ private[airframe] trait BinderImpl[A] extends LogSupport { self: Binder[A] =>
   def toProvider[D1, D2, D3, D4, D5](factory: (D1, D2, D3, D4, D5) => A): DesignWithContext[A] =
     macro bindToSingletonProvider5[A, D1, D2, D3, D4, D5]
 
+  @deprecated("Use toProvider[X] instead. This method will not be available in Scala 3", "21.5.1")
   def toSingletonProvider[D1](factory: D1 => A): DesignWithContext[A] = macro bindToSingletonProvider1[A, D1]
+  @deprecated("Use toProvider[X] instead. This method will not be available in Scala 3", "21.5.1")
   def toSingletonProvider[D1, D2](factory: (D1, D2) => A): DesignWithContext[A] =
     macro bindToSingletonProvider2[A, D1, D2]
+  @deprecated("Use toProvider[X] instead. This method will not be available in Scala 3", "21.5.1")
   def toSingletonProvider[D1, D2, D3](factory: (D1, D2, D3) => A): DesignWithContext[A] =
     macro bindToSingletonProvider3[A, D1, D2, D3]
+  @deprecated("Use toProvider[X] instead. This method will not be available in Scala 3", "21.5.1")
   def toSingletonProvider[D1, D2, D3, D4](factory: (D1, D2, D3, D4) => A): DesignWithContext[A] =
     macro bindToSingletonProvider4[A, D1, D2, D3, D4]
+  @deprecated("Use toProvider[X] instead. This method will not be available in Scala 3", "21.5.1")
   def toSingletonProvider[D1, D2, D3, D4, D5](factory: (D1, D2, D3, D4, D5) => A): DesignWithContext[A] =
     macro bindToSingletonProvider5[A, D1, D2, D3, D4, D5]
 

--- a/airframe-di/src/main/scala-2/wvlet/airframe/BinderImpl.scala
+++ b/airframe-di/src/main/scala-2/wvlet/airframe/BinderImpl.scala
@@ -22,9 +22,10 @@ private[airframe] trait BinderImpl[A] extends LogSupport { self: Binder[A] =>
     * @tparam B
     * @return
     */
-  @deprecated("Use toSingletonOf[X] instead. This method will not be available in Scala 3", "21.5.1")
+  @deprecated("Use to[X] instead. This method will not be available in Scala 3", "21.5.1")
   def toInstanceOf[B <: A]: DesignWithContext[B] = macro binderToImpl[B]
 
+  @deprecated("Use to[X] instead. This method will not be available in Scala 3", "21.5.1")
   def toSingletonOf[B <: A]: DesignWithContext[B] = macro binderToSingletonOfImpl[B]
 
   def toEagerSingletonOf[B <: A]: DesignWithContext[B] = macro binderToEagerSingletonOfImpl[B]


### PR DESCRIPTION
Aiframe DI will manage only singleton instances within a session for simplicity. This PR mark toInstance[X]... methods as deprecated. 