### PR TITLE
airframe-sql: Fix duplicated join keys handling

### DIFF
--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
@@ -265,11 +265,11 @@ object TypeResolver extends LogSupport {
       QName(name, None) match {
         case QName(Seq(db, t1, c1), _) if context.database == db =>
           inputAttributes.collect {
-            case a: ResolvedAttribute if a.matchesWith(t1, c1) => a
+            case a: ResolvedAttribute if a.matchesWith(t1, c1) => a.ofSourceColumn(t1, c1).getOrElse(a)
           }.toList
         case QName(Seq(t1, c1), _) =>
           inputAttributes.collect {
-            case a: ResolvedAttribute if a.matchesWith(t1, c1) => a
+            case a: ResolvedAttribute if a.matchesWith(t1, c1) => a.ofSourceColumn(t1, c1).getOrElse(a)
           }.toList
         case QName(Seq(c1), _) =>
           inputAttributes.collect {

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/ResolvedPlan.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/ResolvedPlan.scala
@@ -86,6 +86,12 @@ case class ResolvedAttribute(
     }
   }
 
+  def ofSourceColumn(table: String, column: String): Option[ResolvedAttribute] = {
+    sourceColumns.find(s => s.table.name == table && s.column.name == column).map { c =>
+      copy(sourceColumns = Seq(c))
+    }
+  }
+
   override def toString = {
     (qualifier, sourceColumns) match {
       case (Some(q), columns) if columns.nonEmpty =>


### PR DESCRIPTION
ouptputAttribute stays unresolved if the column is a duplicated key in equi join.

```scala
val p = analyze("select B.id from A inner join B on A.id = B.id")

println(p.outputAttributes) // => List(SingleColumn(UnresolvedAttribute(B.id)))
```

With this fix, outputAttributes will be `List(id:long <- B.id)`.