### PR TITLE
airframe-sql: Fix SQL generation for SetOperation in FROM clause

### DIFF
--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLGenerator.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLGenerator.scala
@@ -124,7 +124,9 @@ object SQLGenerator extends LogSupport {
       b += "FROM"
       f match {
         case _: Selection =>
-          b += "(" + printRelation(f) + ")"
+          b += s"(${printRelation(f)})"
+        case _: SetOperation =>
+          b += s"(${printRelation(f)})"
         case _ =>
           b += printRelation(f)
       }

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/parser/SQLGeneratorTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/parser/SQLGeneratorTest.scala
@@ -55,6 +55,13 @@ class SQLGeneratorTest extends AirSpec {
     sql shouldBe "SELECT id FROM (SELECT id FROM default.A)"
   }
 
+  test("print resolved UNION subquery plan") {
+    val resolvedPlan =
+      SQLAnalyzer.analyze("select id from (select id from A union all select id from A)", "default", demoCatalog)
+    val sql = SQLGenerator.print(resolvedPlan)
+    sql shouldBe "SELECT id FROM (SELECT id FROM default.A UNION ALL SELECT id FROM default.A)"
+  }
+
   test("print resolved CTE plan") {
     val resolvedPlan = SQLAnalyzer.analyze("with p as (select id from A) select * from p", "default", demoCatalog)
     val sql          = SQLGenerator.print(resolvedPlan)


### PR DESCRIPTION
https://github.com/wvlet/airframe/pull/2586 was not enough to cover subqueries in FROM clause. `SetOperation` also needs to be covered.