### PR TITLE
airframe-sql: Prevent resolving Identifiers of column alias

### DIFF
--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/CTEResolver.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/CTEResolver.scala
@@ -46,7 +46,7 @@ object CTEResolver extends LogSupport {
             }
             // Add a projection for renaming columns
             val selectItems = resolvedQuery.outputAttributes.zip(aliases).map { case (col, alias) =>
-              TypeResolver.resolveAttribute(SingleColumn(col, Some(alias), None, col.nodeLocation))
+              TypeResolver.resolveAttribute(SingleColumn(col, Some(alias.sqlExpr), None, col.nodeLocation))
             }
             Project(resolvedQuery, selectItems, resolvedQuery.nodeLocation)
         }

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
@@ -236,7 +236,7 @@ object TypeResolver extends LogSupport {
             resolvedColumns += r
           case r: ResolvedAttribute if alias.nonEmpty =>
             resolvedColumns += ResolvedAttribute(
-              alias.get.sqlExpr,
+              alias.get,
               r.dataType,
               r.qualifier,
               r.sourceColumns,
@@ -256,8 +256,8 @@ object TypeResolver extends LogSupport {
     attribute match {
       case SingleColumn(r: ResolvedAttribute, None, _, _) =>
         r
-      case SingleColumn(r: ResolvedAttribute, Some(alias: Identifier), _, _) =>
-        r.withAlias(alias.value)
+      case SingleColumn(r: ResolvedAttribute, Some(alias), _, _) =>
+        r.withAlias(alias)
       case other => other
     }
   }
@@ -273,8 +273,8 @@ object TypeResolver extends LogSupport {
       expr: Expression,
       inputAttributes: Seq[Attribute]
   ): List[Expression] = {
-    trace(s"findMatchInInputAttributes: ${expr}, inputAttributes: ${inputAttributes}")
-    def lookup(name: String): List[Attribute] = {
+    info(s"findMatchInInputAttributes: ${expr}, inputAttributes: ${inputAttributes}")
+    def lookup(name: String): List[Expression] = {
       QName(name, None) match {
         case QName(Seq(db, t1, c1), _) if context.database == db =>
           inputAttributes.collect {

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
@@ -273,7 +273,7 @@ object TypeResolver extends LogSupport {
       expr: Expression,
       inputAttributes: Seq[Attribute]
   ): List[Expression] = {
-    info(s"findMatchInInputAttributes: ${expr}, inputAttributes: ${inputAttributes}")
+    debug(s"findMatchInInputAttributes: ${expr}, inputAttributes: ${inputAttributes}")
     def lookup(name: String): List[Expression] = {
       QName(name, None) match {
         case QName(Seq(db, t1, c1), _) if context.database == db =>

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
@@ -239,7 +239,7 @@ object Expression {
   }
   case class SingleColumn(
       expr: Expression,
-      // quoted or unquoted string 
+      // quoted or unquoted string
       alias: Option[String],
       qualifier: Option[String] = None,
       nodeLocation: Option[NodeLocation]

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
@@ -239,12 +239,12 @@ object Expression {
   }
   case class SingleColumn(
       expr: Expression,
-      alias: Option[Expression],
+      alias: Option[String],
       qualifier: Option[String] = None,
       nodeLocation: Option[NodeLocation]
   ) extends Attribute {
     override def name: String              = alias.getOrElse(expr).toString
-    override def children: Seq[Expression] = Seq(expr) ++ alias.toSeq
+    override def children: Seq[Expression] = Seq(expr)
     override def toString = s"SingleColumn(${alias.map(a => s"${expr} as ${a}").getOrElse(s"${expr}")})"
 
     override def withQualifier(newQualifier: String): Attribute = {

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
@@ -239,6 +239,7 @@ object Expression {
   }
   case class SingleColumn(
       expr: Expression,
+      // quoted or unquoted string 
       alias: Option[String],
       qualifier: Option[String] = None,
       nodeLocation: Option[NodeLocation]

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
@@ -539,7 +539,7 @@ object LogicalPlan {
           query.outputAttributes.zip(aliases).map { case (in, alias) =>
             SingleColumn(
               in,
-              Some(alias),
+              Some(alias.sqlExpr),
               None,
               alias.nodeLocation // TODO Is alias.nodeLocation suitable as NodeLocation for this?
             )

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLGenerator.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLGenerator.scala
@@ -364,7 +364,7 @@ object SQLGenerator extends LogSupport {
       case SingleColumn(ex, alias, _, _) =>
         val col = printExpression(ex)
         alias
-          .map(x => s"${col} AS ${printExpression(x)}")
+          .map(x => s"${col} AS ${x}")
           .getOrElse(col)
       case AllColumns(prefix, _) =>
         prefix.map(p => s"${p}.*").getOrElse("*")

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLInterpreter.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLInterpreter.scala
@@ -396,7 +396,7 @@ class SQLInterpreter(withNodeLocation: Boolean = true) extends SqlBaseBaseVisito
     val alias = Option(ctx.AS())
       .map(x => expression(ctx.identifier()))
       .orElse(Option(ctx.identifier()).map(expression(_)))
-    SingleColumn(expression(ctx.expression()), alias, None, getLocation(ctx))
+    SingleColumn(expression(ctx.expression()), alias.map(_.sqlExpr), None, getLocation(ctx))
   }
 
   override def visitExpression(ctx: ExpressionContext): Expression = {

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
@@ -263,6 +263,13 @@ class TypeResolverTest extends AirSpec {
       )
     }
 
+    test("resolve CTE redundant column alias") {
+      val p = analyze("with q1 as (select id as id from A) select id from q1")
+      p.outputAttributes.toList shouldBe List(
+        ResolvedAttribute("id", DataType.LongType, None, Seq(SourceColumn(tableA, a1)), None)
+      )
+    }
+
     test("parse multiple WITH sub queries") {
       val p = analyze("with q1 as (select id, name from A), q2 as (select name from q1) select * from q2")
       p.outputAttributes.toList shouldBe List(


### PR DESCRIPTION
Prevent resolving `Identifier`s of alias by making them `String`.