### PR TITLE
airframe-sql: Refine Union handling

### DIFF
--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLGenerator.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLGenerator.scala
@@ -76,11 +76,11 @@ object SQLGenerator extends LogSupport {
   private def printSetOperation(s: SetOperation, context: List[Relation]): String = {
     val isDistinct = containsDistinctPlan(context)
     val op = s match {
-      case Union(relations, _, _) =>
+      case Union(relations, _) =>
         if (isDistinct) "UNION" else "UNION ALL"
       case Except(left, right, _) =>
         if (isDistinct) "EXCEPT" else "EXCEPT ALL"
-      case Intersect(relations, _, _) =>
+      case Intersect(relations, _) =>
         if (isDistinct) "INTERSECT" else "INTERSECT ALL"
     }
     s.children.map(printRelation).mkString(s" ${op} ")
@@ -366,6 +366,8 @@ object SQLGenerator extends LogSupport {
         alias
           .map(x => s"${col} AS ${x}")
           .getOrElse(col)
+      case MultiColumn(inputs, _) =>
+        inputs.collectFirst { case a: Attribute => a }.map(printExpression).getOrElse(unknown(e))
       case AllColumns(prefix, _, _) =>
         prefix.map(p => s"${p}.*").getOrElse("*")
       case a: Attribute =>

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLInterpreter.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLInterpreter.scala
@@ -122,9 +122,9 @@ class SQLInterpreter(withNodeLocation: Boolean = true) extends SqlBaseBaseVisito
       .map(visitSetQuantifier(_).isDistinct)
       .getOrElse(true)
     val base = if (ctx.INTERSECT() != null) {
-      Intersect(children, None, getLocation(ctx.INTERSECT()))
+      Intersect(children, getLocation(ctx.INTERSECT()))
     } else if (ctx.UNION() != null) {
-      Union(children, None, getLocation(ctx.UNION()))
+      Union(children, getLocation(ctx.UNION()))
     } else if (ctx.EXCEPT() != null) {
       Except(children(0), children(1), getLocation(ctx.EXCEPT()))
     } else {


### PR DESCRIPTION
I thought we can handle Union by letting `ResolvedAttribute` has multiple `SourceColumn`s, however it wasn't enough.

This pull request will revert it to represent union columns as a special expression type `MultiSourceColumn` which is similar to `UnionColumn` in the previous PR.