### PR TITLE
airframe-sql: Fix collectExpression() to cover nested plans

### DIFF
--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
@@ -40,6 +40,7 @@ trait LogicalPlan extends TreeNode[LogicalPlan] with Product with SQLSig {
     def collectExpression(x: Any): Seq[Expression] = {
       x match {
         case e: Expression  => e :: Nil
+        case p: LogicalPlan => p.expressions
         case Some(x)        => collectExpression(x)
         case s: Iterable[_] => s.flatMap(collectExpression _).toSeq
         case other          => Nil


### PR DESCRIPTION
`LogicalPlan.resolved` returns `true` even if there are unresolved attributes inside sub queries without this, but this change may have unexpected side-effect?

By the way, `LogicalPlan.resolved` also returns `true` when `Id(col)` remains in the plan. But it looks like impossible to determine which identifiers should be resolved or not systematically on the current mechanism. For example, it should be resolved if it's a column reference, but shouldn't if it's a column or table alias.

Any ideas to correctly detect identifiers that should be resolved?