### PR TITLE
OpenAPI: Generate parameters with default value

### DIFF
--- a/airframe-http-codegen/src/main/scala/wvlet/airframe/http/openapi/OpenAPI.scala
+++ b/airframe-http-codegen/src/main/scala/wvlet/airframe/http/openapi/OpenAPI.scala
@@ -16,7 +16,7 @@ package wvlet.airframe.http.openapi
 import wvlet.airframe.codec.MessageCodecFactory
 import wvlet.airframe.http.Router
 import wvlet.airframe.http.openapi.OpenAPI._
-import wvlet.airframe.json.YAMLFormatter
+import wvlet.airframe.json.{JSON, YAMLFormatter}
 import wvlet.airframe.surface.{Union2, Union3}
 
 case class OpenAPI(
@@ -98,6 +98,12 @@ object OpenAPI {
       allowEmptyValue: Option[Boolean] = None
   ) extends Union2[Parameter, ParameterRef] {
     override def getElementClass = classOf[Parameter]
+
+    def toJSON: String = Parameter.codec.toJson(this)
+    def toYAML: String = YAMLFormatter.toYaml(toJSON)
+  }
+  object Parameter {
+    private val codec = MessageCodecFactory.defaultFactoryForJSON.of[Parameter]
   }
 
   case class ParameterRef(
@@ -150,6 +156,7 @@ object OpenAPI {
 
   case class Schema(
       `type`: String,
+      default: Option[String] = None,
       format: Option[String] = None,
       description: Option[String] = None,
       required: Option[Seq[String]] = None,

--- a/airframe-http-codegen/src/main/scala/wvlet/airframe/http/openapi/OpenAPI.scala
+++ b/airframe-http-codegen/src/main/scala/wvlet/airframe/http/openapi/OpenAPI.scala
@@ -16,7 +16,7 @@ package wvlet.airframe.http.openapi
 import wvlet.airframe.codec.MessageCodecFactory
 import wvlet.airframe.http.Router
 import wvlet.airframe.http.openapi.OpenAPI._
-import wvlet.airframe.json.{JSON, YAMLFormatter}
+import wvlet.airframe.json.YAMLFormatter
 import wvlet.airframe.surface.{Union2, Union3}
 
 case class OpenAPI(
@@ -98,12 +98,6 @@ object OpenAPI {
       allowEmptyValue: Option[Boolean] = None
   ) extends Union2[Parameter, ParameterRef] {
     override def getElementClass = classOf[Parameter]
-
-    def toJSON: String = Parameter.codec.toJson(this)
-    def toYAML: String = YAMLFormatter.toYaml(toJSON)
-  }
-  object Parameter {
-    private val codec = MessageCodecFactory.defaultFactoryForJSON.of[Parameter]
   }
 
   case class ParameterRef(

--- a/airframe-http-codegen/src/main/scala/wvlet/airframe/http/openapi/OpenAPIGenerator.scala
+++ b/airframe-http-codegen/src/main/scala/wvlet/airframe/http/openapi/OpenAPIGenerator.scala
@@ -301,7 +301,7 @@ class OpenAPIGenerator(config: OpenAPIGeneratorConfig) extends LogSupport {
               registerComponent(p.surface)
               Some(SchemaRef(s"#/components/schemas/${schemaName(p.surface)}"))
             },
-            allowEmptyValue = if (p.getDefaultValue.nonEmpty) Some(true) else None
+            allowEmptyValue = optDefaultValue.map(_ => true)
           )
         } else {
           ParameterRef(s"#/components/parameters/${schemaName(p.surface)}")

--- a/airframe-http-codegen/src/test/scala/example/openapi/OpenAPIExample.scala
+++ b/airframe-http-codegen/src/test/scala/example/openapi/OpenAPIExample.scala
@@ -63,7 +63,7 @@ trait OpenAPIEndpointExample {
   def get2(id: Int, name: String): Unit
 
   @Endpoint(method = HttpMethod.GET, path = "/v1/get3/:id")
-  def get3(id: Int, p1: String): Unit
+  def get3(id: Int, p1: String, p2: String = "foo"): Unit
 
   @Endpoint(method = HttpMethod.POST, path = "/v1/post1")
   def post1(): Unit

--- a/airframe-http-codegen/src/test/scala/wvlet/airframe/http/openapi/OpenAPITest.scala
+++ b/airframe-http-codegen/src/test/scala/wvlet/airframe/http/openapi/OpenAPITest.scala
@@ -302,7 +302,14 @@ class OpenAPITest extends AirSpec {
         |          in: query
         |          required: true
         |          schema:
-        |            type: string""".stripMargin,
+        |            type: string
+        |            - name: opt1
+        |        - name: p2
+        |          in: query
+        |          required: false
+        |          schema:
+        |            type: string
+        |            default: foo""".stripMargin,
       """  /v1/post1:
         |    post:
         |      summary: post1

--- a/airframe-http-codegen/src/test/scala/wvlet/airframe/http/openapi/OpenAPITest.scala
+++ b/airframe-http-codegen/src/test/scala/wvlet/airframe/http/openapi/OpenAPITest.scala
@@ -543,25 +543,6 @@ class OpenAPITest extends AirSpec {
     // java.awt.Toolkit.getDefaultToolkit.getSystemClipboard
     //      .setContents(new java.awt.datatransfer.StringSelection(yaml), null)
 
-    openapi.paths.get("/v1/get3/{id}").flatMap(_.get("get")).flatMap(_.parameters).flatMap(_.lastOption).map { s =>
-      s match {
-        case s: Parameter              => s.toYAML
-        case OpenAPI.ParameterRef(ref) => s"OpenAPI.ParameterRef($ref)"
-        case _                         => "otherwise"
-      }
-    } shouldBe Some("""name: p2
-        |in: query
-        |required: false
-        |schema:
-        |  type: string
-        |  default: foo
-        |allowEmptyValue: true""".stripMargin)
-
-    ((openapi.components.flatMap(_.schemas).get("OpenAPIEndpointExample.EndpointRequest")) match {
-      case s: OpenAPI.Schema => s.properties.flatMap(_.get("x9"))
-      case _                 => None
-    }) shouldBe Some(Schema("integer", default = None, format = Some("int32")))
-
     fragments.foreach { x =>
       try {
         yaml.contains(x) shouldBe true

--- a/airframe-surface/.jvm/src/main/scala/wvlet/airframe/surface/reflect/RuntimeMethodParameter.scala
+++ b/airframe-surface/.jvm/src/main/scala/wvlet/airframe/surface/reflect/RuntimeMethodParameter.scala
@@ -66,16 +66,25 @@ case class RuntimeMethodParameter(
     val maybeTraitMethod =
       findInstanceMethod("%s$default$%d".format(this.method.name, index + 1)).filter(_.getDeclaringClass.isInterface)
     val maybeValueFromInstanceMethod = maybeTraitMethod.map { m =>
-      val classConstructor = classOf[MethodHandles.Lookup].getDeclaredConstructor(classOf[Class[_]], classOf[Int])
-      classConstructor.setAccessible(true)
       val proxyInstance = java.lang.reflect.Proxy.newProxyInstance(
         m.getDeclaringClass.getClassLoader,
         Array(m.getDeclaringClass),
         (proxy: Any, method: Method, args: Array[AnyRef]) => {
-          // Explicit type cast can be dropped if we drop Scala 2.12
-          val accessModifiers =
-            (MethodHandles.Lookup.PUBLIC | MethodHandles.Lookup.PRIVATE).asInstanceOf[java.lang.Integer]
-          val lookup       = classConstructor.newInstance(method.getDeclaringClass, accessModifiers)
+          val lookup =
+            try {
+              val classConstructor =
+                classOf[MethodHandles.Lookup].getDeclaredConstructor(classOf[Class[_]], classOf[Int])
+              classConstructor.setAccessible(true)
+              // Explicit type cast can be dropped if we drop Scala 2.12
+              val accessModifiers =
+                (MethodHandles.Lookup.PUBLIC | MethodHandles.Lookup.PRIVATE).asInstanceOf[java.lang.Integer]
+              classConstructor.newInstance(method.getDeclaringClass, accessModifiers)
+            } catch {
+              case _: NoSuchMethodException =>
+                // In JDK 17+, Lookup's private constructor is gone.
+                // An instance returned by lookup() factory works.
+                MethodHandles.lookup()
+            }
           val methodHandle = lookup.unreflectSpecial(method, method.getDeclaringClass).bindTo(proxy)
           methodHandle.invokeWithArguments(args: _*)
         }

--- a/airframe-surface/.jvm/src/main/scala/wvlet/airframe/surface/reflect/RuntimeMethodParameter.scala
+++ b/airframe-surface/.jvm/src/main/scala/wvlet/airframe/surface/reflect/RuntimeMethodParameter.scala
@@ -14,7 +14,8 @@
 package wvlet.airframe.surface.reflect
 
 import java.{lang => jl}
-
+import java.lang.invoke.MethodHandles
+import java.lang.reflect.Method
 import wvlet.airframe.surface._
 import wvlet.log.LogSupport
 
@@ -58,7 +59,29 @@ case class RuntimeMethodParameter(
   }
 
   def getDefaultValue: Option[Any] = {
-    ReflectTypeUtil.companionObject(method.owner).flatMap { companion =>
+    // This supports a case that method owner is a Trait. In that case, Scala compiler encodes method default parameter
+    // into a default method in an Interface, instead of companion object.
+    // To fetch the default value, it is required to invoke the special method on an instance of the Trait.
+    // So we need to instantiate the Trait, by building a Proxy object that implements the Trait.
+    val maybeTraitMethod =
+      findInstanceMethod("%s$default$%d".format(this.method.name, index + 1)).filter(_.getDeclaringClass.isInterface)
+    val maybeValueFromInstanceMethod = maybeTraitMethod.map { m =>
+      val classConstructor = classOf[MethodHandles.Lookup].getDeclaredConstructor(classOf[Class[_]], classOf[Int])
+      classConstructor.setAccessible(true)
+      val proxyInstance = java.lang.reflect.Proxy.newProxyInstance(
+        m.getDeclaringClass.getClassLoader,
+        Array(m.getDeclaringClass),
+        (proxy: Any, method: Method, args: Array[AnyRef]) => {
+          val accessModifiers = MethodHandles.Lookup.PUBLIC | MethodHandles.Lookup.PRIVATE
+          val lookup          = classConstructor.newInstance(method.getDeclaringClass, accessModifiers)
+          val methodHandle    = lookup.unreflectSpecial(method, method.getDeclaringClass).bindTo(proxy)
+          methodHandle.invokeWithArguments(args: _*)
+        }
+      )
+      m.invoke(proxyInstance)
+    }
+
+    maybeValueFromInstanceMethod.orElse(ReflectTypeUtil.companionObject(method.owner).flatMap { companion =>
       def findMethod(name: String) = {
         try {
           Some(ReflectTypeUtil.cls(companion).getDeclaredMethod(name))
@@ -76,7 +99,7 @@ case class RuntimeMethodParameter(
         case e: Throwable =>
           None
       }
-    }
+    })
   }
 
   override def getMethodArgDefaultValue(methodOwner: Any): Option[Any] = {
@@ -99,4 +122,6 @@ case class RuntimeMethodParameter(
     val annots = this.findAnnotationOf[secret]
     annots.isDefined
   }
+
+  private def findInstanceMethod(name: String) = Try(method.owner.getMethod(name)).toOption
 }

--- a/airframe-surface/.jvm/src/main/scala/wvlet/airframe/surface/reflect/RuntimeMethodParameter.scala
+++ b/airframe-surface/.jvm/src/main/scala/wvlet/airframe/surface/reflect/RuntimeMethodParameter.scala
@@ -72,9 +72,11 @@ case class RuntimeMethodParameter(
         m.getDeclaringClass.getClassLoader,
         Array(m.getDeclaringClass),
         (proxy: Any, method: Method, args: Array[AnyRef]) => {
-          val accessModifiers = MethodHandles.Lookup.PUBLIC | MethodHandles.Lookup.PRIVATE
-          val lookup          = classConstructor.newInstance(method.getDeclaringClass, accessModifiers)
-          val methodHandle    = lookup.unreflectSpecial(method, method.getDeclaringClass).bindTo(proxy)
+          // Explicit type cast can be dropped if we drop Scala 2.12
+          val accessModifiers =
+            (MethodHandles.Lookup.PUBLIC | MethodHandles.Lookup.PRIVATE).asInstanceOf[java.lang.Integer]
+          val lookup       = classConstructor.newInstance(method.getDeclaringClass, accessModifiers)
+          val methodHandle = lookup.unreflectSpecial(method, method.getDeclaringClass).bindTo(proxy)
           methodHandle.invokeWithArguments(args: _*)
         }
       )

--- a/airframe-surface/.jvm/src/test/scala-2/wvlet/airframe/surface/AirSpecBridgeCompat.scala
+++ b/airframe-surface/.jvm/src/test/scala-2/wvlet/airframe/surface/AirSpecBridgeCompat.scala
@@ -14,6 +14,6 @@
 package wvlet.airframe.surface
 
 object AirSpecBridgeCompat {
-  val isScalaJS: Boolean   = true
+  val isScalaJS: Boolean   = false
   val isScala3JVM: Boolean = false
 }

--- a/airframe-surface/.jvm/src/test/scala-3/wvlet/airframe/surface/AirSpecBridgeCompat.scala
+++ b/airframe-surface/.jvm/src/test/scala-3/wvlet/airframe/surface/AirSpecBridgeCompat.scala
@@ -14,5 +14,6 @@
 package wvlet.airframe.surface
 
 object AirSpecBridgeCompat {
-  val isScalaJS: Boolean = false
+  val isScalaJS: Boolean   = false
+  val isScala3JVM: Boolean = true
 }

--- a/airframe-surface/src/test/scala/wvlet/airframe/surface/AirSpecBridge.scala
+++ b/airframe-surface/src/test/scala/wvlet/airframe/surface/AirSpecBridge.scala
@@ -17,7 +17,8 @@ package wvlet.airframe.surface
   * Provide AirSpec-like helper
   */
 trait AirSpecBridge extends munit.Assertions {
-  def isScalaJS: Boolean = AirSpecBridgeCompat.isScalaJS
+  def isScalaJS: Boolean   = AirSpecBridgeCompat.isScalaJS
+  def isScala3JVM: Boolean = AirSpecBridgeCompat.isScala3JVM
   def pendingUntil(msg: String): Unit = {
     assume(false, msg)
   }

--- a/airframe-surface/src/test/scala/wvlet/airframe/surface/MethodSurfaceTest.scala
+++ b/airframe-surface/src/test/scala/wvlet/airframe/surface/MethodSurfaceTest.scala
@@ -123,7 +123,7 @@ class MethodSurfaceTest extends SurfaceSpec {
     assert(m.args.headOption.isDefined)
     val h = m.args.head
     // FIXME: Fix StaticMethodParameter in CompileTimeSurfaceFactory for Scala 3
-    if (!isScalaJS && !isScala3) {
+    if (!isScalaJS && !isScala3JVM) {
       assertEquals(h.getDefaultValue, Some("default"))
 
       val d = new E {

--- a/airframe-surface/src/test/scala/wvlet/airframe/surface/MethodSurfaceTest.scala
+++ b/airframe-surface/src/test/scala/wvlet/airframe/surface/MethodSurfaceTest.scala
@@ -42,6 +42,10 @@ object MethodExamples {
   class D {
     def hello(v: String = "hello"): String = v
   }
+
+  trait E {
+    def hello(v: String = "default"): String
+  }
 }
 
 import wvlet.airframe.surface.MethodExamples._
@@ -111,5 +115,22 @@ class MethodSurfaceTest extends SurfaceSpec {
 
     val msg = m.call(d, "world")
     assertEquals(msg, "world")
+  }
+
+  test("find method default parameter in trait") {
+    val ms = Surface.methodsOf[E]
+    val m  = ms.find(_.name == "hello").get
+    assert(m.args.headOption.isDefined)
+    val h = m.args.head
+    if (!isScalaJS) {
+      assertEquals(h.getDefaultValue, Some("default"))
+
+      val d = new E {
+        override def hello(v: String = "yay"): String = v
+      }
+      val v = h.getMethodArgDefaultValue(d)
+      // Scala.js doesn't support reading default method arguments
+      assertEquals(v, Some("yay"))
+    }
   }
 }

--- a/airframe-surface/src/test/scala/wvlet/airframe/surface/MethodSurfaceTest.scala
+++ b/airframe-surface/src/test/scala/wvlet/airframe/surface/MethodSurfaceTest.scala
@@ -122,7 +122,8 @@ class MethodSurfaceTest extends SurfaceSpec {
     val m  = ms.find(_.name == "hello").get
     assert(m.args.headOption.isDefined)
     val h = m.args.head
-    if (!isScalaJS) {
+    // FIXME: Fix StaticMethodParameter in CompileTimeSurfaceFactory for Scala 3
+    if (!isScalaJS && !isScala3) {
       assertEquals(h.getDefaultValue, Some("default"))
 
       val d = new E {


### PR DESCRIPTION
Closes #2596 

This PR improved `RuntimeMethodParameter` so it can extract default method parameters defined in trait such as `trait OpenAPIEndpointExample`.
OpenAPIGenerator leverages `RuntimeMethodParameter` and now generates the `default` field in schema.

Note that Scala 3's `StaticMethodParameter` in `CompileTimeSurfaceFactory` is not touched in this PR.
Because this new feature is useful and `httpCodeGen` project is Scala 2 only at this moment, and I am still new to Scala 3's macro 😓 

