### PR TITLE
airframe-sql: Add DataType to Expression nodes

### DIFF
--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/catalog/DataType.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/catalog/DataType.scala
@@ -16,14 +16,13 @@ package wvlet.airframe.sql.catalog
 import wvlet.airframe.sql.SQLErrorCode
 import wvlet.log.LogSupport
 
-import javax.lang.model.`type`.PrimitiveType
-
 abstract class DataType(val typeName: String, val typeParams: Seq[DataType]) {
-  override def toString: String = {
+  override def toString: String = typeDescription
+  def typeDescription: String = {
     if (typeParams.isEmpty)
       typeName
     else {
-      s"${typeName}(${typeParams.mkString(",")})"
+      s"${typeName}(${typeParams.mkString(", ")})"
     }
   }
   def baseTypeName: String = typeName
@@ -186,6 +185,15 @@ object DataType extends LogSupport {
   case class ArrayType(elemType: DataType)                   extends DataType(s"array", Seq(elemType))
   case class MapType(keyType: DataType, valueType: DataType) extends DataType(s"map", Seq(keyType, valueType))
   case class RecordType(elems: Seq[DataType])                extends DataType("record", elems)
+
+  /**
+    * For describing the type of 'select *'
+    */
+  case class EmbeddedRecordType(elems: Seq[DataType]) extends DataType("*", elems) {
+    override def typeDescription: String = {
+      elems.map(_.typeDescription).mkString(", ")
+    }
+  }
 
   def parse(typeName: String): DataType = {
     DataTypeParser.parse(typeName)

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/catalog/DataTypeParser.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/catalog/DataTypeParser.scala
@@ -72,7 +72,7 @@ object DataTypeParser extends RegexParsers with LogSupport {
 
   private def decimalType: Parser[DataType.DecimalType] =
     "decimal" ~ "(" ~ typeParam ~ "," ~ typeParam ~ ")" ^^ { case _ ~ _ ~ p ~ _ ~ s ~ _ =>
-      DecimalType(p, s)
+      DecimalType.of(p, s)
     }
 
   private def varcharType: Parser[DataType] =
@@ -94,7 +94,8 @@ object DataTypeParser extends RegexParsers with LogSupport {
   }
 
   private def primitiveType: Parser[DataType] = {
-    typeName ^? { case str if DataType.isPrimitiveTypeName(str) => DataType.getPrimitiveType(str) }
+    typeName ^? { case str if DataType.isPrimitiveTypeName(str) => DataType.getPrimitiveType(str) } |
+      "?" ^? { case _ => UnknownType }
     // nullType | booleanType | numericType | stringType | anyType | jsonType | binaryType | dateType | ipAddressType
   }
 

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
@@ -29,9 +29,14 @@ sealed trait Expression extends TreeNode[Expression] with Product {
     * * Returns "(name):(type)" of this attribute
     */
   def typeDescription: String = s"${attributeName}:${dataTypeName}"
-  def attributeName: String   = "?"
-  def dataTypeName: String    = dataType.typeName
-  def dataType: DataType      = DataType.UnknownType
+
+  /**
+    * Column name without qualifier
+    * @return
+    */
+  def attributeName: String = "?"
+  def dataTypeName: String  = dataType.typeName
+  def dataType: DataType    = DataType.UnknownType
 
   private def createInstance(args: Iterator[AnyRef]): Expression = {
     // TODO Build this LogicalPlan using Surface

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
@@ -15,15 +15,7 @@
 package wvlet.airframe.sql.model
 
 import wvlet.airframe.sql.catalog.DataType
-import wvlet.airframe.sql.catalog.DataType.{
-  AnyType,
-  ArrayType,
-  EmbeddedRecordType,
-  NamedType,
-  RecordType,
-  TimestampField,
-  TypeVariable
-}
+import wvlet.airframe.sql.catalog.DataType._
 import wvlet.log.LogSupport
 
 import java.util.Locale
@@ -360,14 +352,6 @@ object Expression {
     override def dataTypeName: String = {
       expr.dataTypeName
     }
-    override def typeDescription: String = {
-      alias match {
-        case Some(name) =>
-          s"${name}:${expr.dataTypeName}"
-        case _ =>
-          expr.typeDescription
-      }
-    }
 
     override def children: Seq[Expression] = Seq(expr)
     override def toString = s"SingleColumn(${alias.map(a => s"${expr} as ${a}").getOrElse(s"${expr}")})"
@@ -586,6 +570,9 @@ object Expression {
       window: Option[Window],
       nodeLocation: Option[NodeLocation]
   ) extends Expression {
+    // TODO: Resolve the function return type using a function catalog
+    // override def dataType: DataType = super.dataType
+
     override def children: Seq[Expression] = args ++ filter.toSeq ++ window.toSeq
     def functionName: String               = name.toString.toLowerCase(Locale.US)
     override def toString = s"FunctionCall(${name}, ${args.mkString(", ")}, distinct:${isDistinct}, window:${window})"

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
@@ -213,10 +213,9 @@ object Expression {
   }
 
   case class UnresolvedAttribute(name: String, nodeLocation: Option[NodeLocation]) extends Attribute {
-    override def toString: String        = s"UnresolvedAttribute(${name})"
-    override def typeDescription: String = s"${name}:?"
-    override def sqlExpr: String         = name
-    override lazy val resolved           = false
+    override def toString: String = s"UnresolvedAttribute(${name})"
+    override def sqlExpr: String  = name
+    override lazy val resolved    = false
 
     override def withQualifier(newQualifier: String): Attribute = this
   }
@@ -295,7 +294,7 @@ object Expression {
           c.map(_.typeDescription).mkString(", ")
         }
         .getOrElse {
-          s"${qualifier.map(q => s"${q.sqlExpr}").getOrElse("")}*"
+          s"${qualifier.map(q => s"${q.fullName}.").getOrElse("")}*"
         }
     }
     override def toString = {
@@ -824,13 +823,16 @@ object Expression {
 
   // Value constructor
   case class ArrayConstructor(values: Seq[Expression], nodeLocation: Option[NodeLocation]) extends Expression {
-    override def dataType: DataType = {
+    def elementType: DataType = {
       val elemTypes = values.map(_.dataType).distinct
       if (elemTypes.size == 1) {
-        ArrayType(elemTypes.head)
+        elemTypes.head
       } else {
-        ArrayType(AnyType)
+        AnyType
       }
+    }
+    override def dataType: DataType = {
+      ArrayType(elementType)
     }
     override def children: Seq[Expression] = values
   }

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
@@ -825,8 +825,8 @@ object LogicalPlan {
     override def inputAttributes: Seq[Attribute] = Seq.empty // TODO
     override def outputAttributes: Seq[Attribute] = {
       columns.map {
-        case _: ArrayConstructor =>
-          ResolvedAttribute(UUID.randomUUID().toString, DataType.AnyType, None, Nil, None) // TODO data type
+        case arr: ArrayConstructor =>
+          ResolvedAttribute(UUID.randomUUID().toString, arr.elementType, None, Nil, None)
         case other =>
           SingleColumn(other, None, None, other.nodeLocation)
       }

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
@@ -35,29 +35,10 @@ trait LogicalPlan extends TreeNode[LogicalPlan] with Product with SQLSig {
   def children: Seq[LogicalPlan]
 
   /**
-    * Expressions associated to this LogicalPlan node
+    * Return child expressions associated to this LogicalPlan node
     *
     * @return
-    */
-  def expressions: Seq[Expression] = {
-    def collectExpression(x: Any): Seq[Expression] = {
-      x match {
-        case e: Expression  => e :: Nil
-        case p: LogicalPlan => p.expressions
-        case Some(x)        => collectExpression(x)
-        case s: Iterable[_] => s.flatMap(collectExpression _).toSeq
-        case other          => Nil
-      }
-    }
-
-    productIterator.flatMap { x =>
-      collectExpression(x)
-    }.toSeq
-  }
-
-  /**
-    * Returns direct child expressions in this LogicalPlan node parmeters
-    * @return
+    *   child expressions of this node
     */
   def childExpressions: Seq[Expression] = {
     def collectExpression(x: Any): Seq[Expression] = {
@@ -450,7 +431,7 @@ trait LogicalPlan extends TreeNode[LogicalPlan] with Product with SQLSig {
   def outputAttributes: Seq[Attribute]
 
   // True if all input attributes are resolved.
-  lazy val resolved: Boolean    = expressions.forall(_.resolved) && resolvedChildren
+  lazy val resolved: Boolean    = childExpressions.forall(_.resolved) && resolvedChildren
   def resolvedChildren: Boolean = children.forall(_.resolved)
 
   def unresolvedExpressions: Seq[Expression] = {

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlanPrinter.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlanPrinter.scala
@@ -45,7 +45,7 @@ object LogicalPlanPrinter extends LogSupport {
           } else {
             def printAttr(s: Seq[Attribute]): String = {
               val lst = s.map(_.typeDescription).mkString(", ")
-              if (s.size > 1 || s.size == 1) {
+              if (s.size >= 1) {
                 s"(${lst})"
               } else {
                 lst

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlanPrinter.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlanPrinter.scala
@@ -13,8 +13,10 @@
  */
 
 package wvlet.airframe.sql.model
-import java.io.{PrintWriter, StringWriter}
+import wvlet.airframe.sql.catalog.DataType.RecordType
+import wvlet.airframe.sql.model.Expression.AllColumns
 
+import java.io.{PrintWriter, StringWriter}
 import wvlet.log.LogSupport
 import wvlet.airframe.sql.model.LogicalPlan.EmptyRelation
 
@@ -44,7 +46,9 @@ object LogicalPlanPrinter extends LogSupport {
             ""
           } else {
             def printAttr(s: Seq[Attribute]): String = {
-              val lst = s.map(_.typeDescription).mkString(", ")
+              val lst = s
+                .map(_.typeDescription)
+                .mkString(", ")
               if (s.size >= 1) {
                 s"(${lst})"
               } else {

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlanPrinter.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlanPrinter.scala
@@ -34,7 +34,7 @@ object LogicalPlanPrinter extends LogSupport {
       case EmptyRelation(_) =>
       // print nothing
       case _ =>
-        val ws = " " * level
+        val ws = "  " * level
 
         val inputAttrs  = m.inputAttributes
         val outputAttrs = m.outputAttributes
@@ -45,7 +45,7 @@ object LogicalPlanPrinter extends LogSupport {
           } else {
             def printAttr(s: Seq[Attribute]): String = {
               val lst = s.map(_.typeDescription).mkString(", ")
-              if (s.size > 1) {
+              if (s.size > 1 || s.size == 1) {
                 s"(${lst})"
               } else {
                 lst
@@ -59,7 +59,7 @@ object LogicalPlanPrinter extends LogSupport {
             out.println(prefix)
           case _ =>
             out.println(s"${prefix}")
-            val attrWs  = " " * (level + 1)
+            val attrWs  = "  " * (level + 1)
             val attrStr = attr.map(x => s"${attrWs}- ${x}").mkString("\n")
             out.println(attrStr)
         }

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlanPrinter.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlanPrinter.scala
@@ -36,10 +36,24 @@ object LogicalPlanPrinter extends LogSupport {
       case _ =>
         val ws = " " * level
 
-        val inputAttr  = m.inputAttributes.mkString(", ")
-        val outputAttr = m.outputAttributes.mkString(", ")
-        val attr       = m.expressions.map(_.toString)
-        val prefix     = s"${ws}[${m.modelName}]: (${inputAttr}) => (${outputAttr})"
+        val inputAttrs  = m.inputAttributes
+        val outputAttrs = m.outputAttributes
+        val attr        = m.childExpressions.map(_.toString)
+        val functionSig =
+          if (inputAttrs.isEmpty && outputAttrs.isEmpty) {
+            ""
+          } else {
+            def printAttr(s: Seq[Attribute]): String = {
+              val lst = s.map(_.typeDescription).mkString(", ")
+              if (s.size > 1) {
+                s"(${lst})"
+              } else {
+                lst
+              }
+            }
+            s": ${printAttr(inputAttrs)} => ${printAttr(outputAttrs)}"
+          }
+        val prefix = s"${ws}[${m.modelName}]${functionSig}"
         attr.length match {
           case 0 =>
             out.println(prefix)

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/ResolvedPlan.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/ResolvedPlan.scala
@@ -90,16 +90,6 @@ case class ResolvedAttribute(
     name == columnName
   }
 
-  override def attributeName: String = {
-    s"${qualifier.map(x => s"${x}.").getOrElse(".")}.${name}"
-  }
-
-  override def dataTypeName: String = dataType.toString
-
-  override def typeDescription: String = {
-    s"${name}:${dataType}"
-  }
-
   override def sqlExpr: String = attributeName
 
   override def toString = {

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/ResolvedPlan.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/ResolvedPlan.scala
@@ -58,7 +58,7 @@ case class SourceColumn(table: Catalog.Table, column: Catalog.TableColumn) {
 
 case class ResolvedAttribute(
     name: String,
-    dataType: DataType,
+    override val dataType: DataType,
     qualifier: Option[String],
     sourceColumns: Seq[SourceColumn],
     nodeLocation: Option[NodeLocation]
@@ -94,7 +94,7 @@ case class ResolvedAttribute(
     s"${qualifier.map(x => s"${x}.").getOrElse(".")}.${name}"
   }
 
-  override def typeName: String = dataType.toString
+  override def dataTypeName: String = dataType.toString
 
   override def typeDescription: String = {
     s"${name}:${dataType}"

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/ResolvedPlan.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/ResolvedPlan.scala
@@ -90,18 +90,30 @@ case class ResolvedAttribute(
     name == columnName
   }
 
+  override def attributeName: String = {
+    s"${qualifier.map(x => s"${x}.").getOrElse(".")}.${name}"
+  }
+
+  override def typeName: String = dataType.toString
+
+  override def typeDescription: String = {
+    s"${name}:${dataType}"
+  }
+
+  override def sqlExpr: String = attributeName
+
   override def toString = {
     (qualifier, sourceColumns) match {
       case (Some(q), columns) if columns.nonEmpty =>
         columns
           .map(_.fullName)
-          .mkString(s"${q},${name}:${dataType} <- [", ", ", "]")
+          .mkString(s"${q},${typeDescription} <- [", ", ", "]")
       case (None, columns) if columns.nonEmpty =>
         columns
           .map(_.fullName)
-          .mkString(s"${name}:${dataType} <- [", ", ", "]")
+          .mkString(s"${typeDescription} <- [", ", ", "]")
       case _ =>
-        s"${name}:${dataType}"
+        s"${typeDescription}"
     }
   }
   override lazy val resolved = true

--- a/airframe-sql/src/test/resources/wvlet/airframe/sql/catalog/types.txt
+++ b/airframe-sql/src/test/resources/wvlet/airframe/sql/catalog/types.txt
@@ -85,3 +85,4 @@ varchar(u)
 varchar(x)
 varchar(y)
 varchar(z)
+?

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
@@ -75,13 +75,10 @@ class TypeResolverTest extends AirSpec {
       sql: String,
       rules: List[AnalyzerContext => PlanRewriter] = TypeResolver.typerRules
   ): LogicalPlan = {
-    trace(s"original sql:\n${sql}")
-    trace(s"original plan:\n${SQLParser.parse(sql).pp}")
-
     val resolvedPlan = resolvePlan(sql, rules)
     val resolvedSql  = generateSql(resolvedPlan)
-    trace(s"new plan:\n${resolvedPlan.pp}")
-    trace(s"new sql:\n${resolvedSql}")
+    debug(s"[original]\n${sql}\n\n[resolved]\n${resolvedSql}")
+    trace(s"[original plan]\n${SQLParser.parse(sql).pp}\n[resolved plan]\n${resolvedPlan.pp}")
 
     // Round-trip plan should be able to be resolved
     resolvePlan(resolvedSql, rules)

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
@@ -989,8 +989,8 @@ class TypeResolverTest extends AirSpec {
 
       p.outputAttributes shouldBe List(
         ra1.withQualifier("A"),
-        ResolvedAttribute("key", DataType.AnyType, Some("t"), Nil, None),
-        ResolvedAttribute("value", DataType.AnyType, Some("t"), Nil, None)
+        ResolvedAttribute("key", DataType.StringType, Some("t"), Nil, None),
+        ResolvedAttribute("value", DataType.LongType, Some("t"), Nil, None)
       )
     }
   }

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/catalog/DataTypeTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/catalog/DataTypeTest.scala
@@ -44,9 +44,9 @@ class DataTypeTest extends AirSpec {
   }
 
   test("parse decimal types") {
-    parse("decimal(10,2)", DecimalType(10, 2))
-    parse("decimal(34,0)", DecimalType(34, 0))
-    parse("decimal(34, 0)", DecimalType(34, 0))
+    parse("decimal(10,2)", DecimalType.of(10, 2))
+    parse("decimal(34,0)", DecimalType.of(34, 0))
+    parse("decimal(34, 0)", DecimalType.of(34, 0))
   }
 
   test("parse timestamp types") {

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/model/LogicalPlanTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/model/LogicalPlanTest.scala
@@ -112,7 +112,7 @@ class LogicalPlanTest extends AirSpec {
     val newPlan = l.transformChildExpressions { case s: SingleColumn =>
       s.withAlias("x")
     }
-    newPlan.expressions.collect {
+    newPlan.childExpressions.collect {
       case s: SingleColumn if s.alias == Some("x") => true
     }.nonEmpty shouldBe true
   }
@@ -134,11 +134,11 @@ class LogicalPlanTest extends AirSpec {
       s.withAlias(s"x${count.getAndIncrement()}")
     }
 
-    newPlan.expressions.collect {
+    newPlan.childExpressions.collect {
       case s: SingleColumn if s.alias == Some("x0") => true
     }.nonEmpty shouldBe true
 
-    newPlan.children.head.expressions.collect {
+    newPlan.children.head.childExpressions.collect {
       case s: SingleColumn if s.alias == Some("x1") => true
     }.nonEmpty shouldBe true
   }
@@ -150,11 +150,11 @@ class LogicalPlanTest extends AirSpec {
       s.withAlias(s"x${count.getAndIncrement()}")
     }
 
-    newPlan.expressions.collect {
+    newPlan.childExpressions.collect {
       case s: SingleColumn if s.alias == Some("x1") => true
     }.nonEmpty shouldBe true
 
-    newPlan.children.head.expressions.collect {
+    newPlan.children.head.childExpressions.collect {
       case s: SingleColumn if s.alias == Some("x0") => true
     }.nonEmpty shouldBe true
   }


### PR DESCRIPTION
For ease of debugging, this PR adds DataType information to Expression node

- Display DataType wth `LogicalPlan.pp`
- Set DataType for simple Expressions
- Add Expression.{attributeName, dataType, dataTypeName, typeDescription} methods
- Change LogicalPlan.expressions -> childExperssions to clarify what will be returned
- Add DataType.Unknown(?) to show unresolved type of the expression
- Add EmbeddedRecordType to represent DataType of AllColumns and RowConstructor

With this change, the debug message will be like this:
```
[original]
SELECT id, t.key, t.value FROM A
CROSS JOIN UNNEST (
  array['c1', 'c2', 'c3'],
  array[1, 2, 3]
) AS t (key, value)


[resolved]
SELECT A.id, t.key, t.value FROM default.A CROSS JOIN UNNEST (ARRAY['c1', 'c2', 'c3'], ARRAY[1, 2, 3]) AS t(key, value)

[original plan]
[Project]: (key:string, value:long) => (id:?, t.key:?, t.value:?)
  - SingleColumn(Id(id))
  - SingleColumn(UnresolvedAttribute(t.key))
  - SingleColumn(UnresolvedAttribute(t.value))
  [CrossJoin]: (key:string, value:long) => (key:string, value:long)
    - NaturalJoin(Some(NodeLocation(1,32)))
    [TableRef]
      - A
    [AliasedRelation]:  => (key:string, value:long)
      - Id(t)
      [Unnest]:  => (7d1c9495-1ce0-48f4-9bde-10a25abd49ff:string, d040b972-75d1-4a47-9b7e-2461789fe154:long)
        - ArrayConstructor(List(Literal('c1'), Literal('c2'), Literal('c3')),Some(NodeLocation(3,3)))
        - ArrayConstructor(List(Literal(1), Literal(2), Literal(3)),Some(NodeLocation(4,3)))

[resolved plan]
[Project]: (id:long, name:string, key:string, value:long) => (id:long, key:string, value:long)
  - A,id:long <- [A.id]
  - key:string
  - value:long
  [CrossJoin]: (id:long, name:string, key:string, value:long) => (id:long, name:string, key:string, value:long)
    - NaturalJoin(Some(NodeLocation(1,32)))
    [TableScan]:  => (id:long, name:string)
    [AliasedRelation]:  => (key:string, value:long)
      - Id(t)
      [Unnest]:  => (23319ed4-ddf3-41f9-bc34-a981aaa0405d:string, e17498b2-506f-4029-ad3e-a866a72847d5:long)
        - ArrayConstructor(List(Literal('c1'), Literal('c2'), Literal('c3')),Some(NodeLocation(3,3)))
        - ArrayConstructor(List(Literal(1), Literal(2), Literal(3)),Some(NodeLocation(4,3)))
 ```
