### PR TITLE
airframe-sql: Add RewriteRule to see TypeResolver behavior

### DIFF
--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/RewriteRule.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/RewriteRule.scala
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.sql.analyzer
+
+import wvlet.airframe.sql.analyzer.RewriteRule.PlanRewriter
+import wvlet.airframe.sql.model.LogicalPlan
+import wvlet.log.{LogSupport, Logger}
+
+trait RewriteRule extends LogSupport {
+  // Prepare a logger for debugging purpose
+  private val localLogger = Logger("wvlet.airframe.sql.analyzer.RewriteRule")
+
+  def name: String = this.getClass.getSimpleName.stripSuffix("$")
+  def apply(context: AnalyzerContext): PlanRewriter
+
+  def transform(plan: LogicalPlan, context: AnalyzerContext): LogicalPlan = {
+    val rule = this.apply(context)
+    // Recursively transform the tree form bottom to up
+    val resolved = plan.transformUp(rule)
+    if (!(plan eq resolved)) {
+      localLogger.trace(s"transformed with ${name}:\n[before]\n${plan.pp}\n[after]\n${resolved.pp}")
+    }
+    resolved
+  }
+}
+
+object RewriteRule {
+  type PlanRewriter = PartialFunction[LogicalPlan, LogicalPlan]
+}

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/SQLAnalyzer.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/SQLAnalyzer.scala
@@ -53,8 +53,6 @@ case class AnalyzerContext(
 /**
   */
 object SQLAnalyzer extends LogSupport {
-  type PlanRewriter = PartialFunction[LogicalPlan, LogicalPlan]
-  type Rule         = (AnalyzerContext) => PlanRewriter
 
   def analyze(sql: String, database: String, catalog: Catalog): LogicalPlan = {
     trace(s"analyze:\n${sql}")

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
@@ -321,7 +321,7 @@ object TypeResolver extends LogSupport {
     * @param inputAttributes
     * @return
     */
-  def findMatchInInputAttributes(
+  private def findMatchInInputAttributes(
       context: AnalyzerContext,
       expr: Expression,
       inputAttributes: Seq[Attribute],
@@ -395,7 +395,7 @@ object TypeResolver extends LogSupport {
   /**
     * Resolve untyped expressions
     */
-  def resolveExpression(
+  private def resolveExpression(
       context: AnalyzerContext,
       expr: Expression,
       inputAttributes: Seq[Attribute],

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 package wvlet.airframe.sql.model
-import wvlet.airframe.sql.analyzer.{QuerySignatureConfig, TypeResolver}
+import wvlet.airframe.sql.analyzer.{QuerySignatureConfig, RewriteRule, TypeResolver}
 import wvlet.airframe.sql.catalog.DataType
 
 import java.util.UUID

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
@@ -32,6 +32,7 @@ import wvlet.airframe.sql.model.{CTERelationRef, Expression, LogicalPlan, NodeLo
 import wvlet.airframe.sql.parser.{SQLGenerator, SQLParser}
 import wvlet.airframe.sql.{SQLError, SQLErrorCode}
 import wvlet.airspec.AirSpec
+import wvlet.log.Logger
 
 class TypeResolverTest extends AirSpec {
 
@@ -79,9 +80,11 @@ class TypeResolverTest extends AirSpec {
     debug(s"[original]\n${sql}\n\n[resolved]\n${resolvedSql}")
     trace(s"[original plan]\n${SQLParser.parse(sql).pp}\n[resolved plan]\n${resolvedPlan.pp}")
 
-    // Round-trip plan should be able to be resolved
-    resolvePlan(resolvedSql, rules)
-
+    // Suppress rewrite rule logs in the second run
+    Logger("wvlet.airframe.sql.analyzer.RewriteRule").suppressLogs {
+      // Round-trip plan should be able to be resolved
+      resolvePlan(resolvedSql, rules)
+    }
     resolvedPlan
   }
 

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/parser/SQLGeneratorTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/parser/SQLGeneratorTest.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.sql.parser
 
-import wvlet.airframe.sql.analyzer.{SQLAnalyzer, TypeResolver}
+import wvlet.airframe.sql.analyzer.{SQLAnalyzer, RewriteRule}
 import wvlet.airframe.sql.catalog.{Catalog, DataType, InMemoryCatalog}
 import wvlet.airframe.sql.catalog.Catalog.{CreateMode, TableColumn}
 import wvlet.airspec.AirSpec


### PR DESCRIPTION
Introduce RewriteRule to observe how individual rules rewrite LogicalPlan. This will be used for debugging #2646  

By setting a log level like this: 
airframe-sql/src/test/resources/log-test.properties
```
wvlet.airframe.sql.analyzer.RewriteRule=trace
```

You can see the transformation log:
```
transformed with resolveTableRef:
[before]
[Sort]: (id:?, name:?) => (id:?, name:?)
  - SortItem(id:long <- [A.id],None,None,Some(NodeLocation(1,41)))
  [Project]:  => (id:?, name:?)
    - SingleColumn(Id(id))
    - SingleColumn(Id(name))
    [TableRef]
      - default.A

[after]
[Sort]: (id:?, name:?) => (id:?, name:?)
  - SortItem(id:long <- [A.id],None,None,Some(NodeLocation(1,41)))
  [Project]: (id:long, name:string) => (id:?, name:?)
    - SingleColumn(Id(id))
    - SingleColumn(Id(name))
    [TableScan]:  => (id:long, name:string)
```