### PR TITLE
internal: Remove grouping of airframe updates

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -9,11 +9,6 @@ buildRoots = [
 
 pullRequests.includeMatchedLabels = ".*-update"
 
-# Grouping airframe updates into a single PR
-pullRequests.grouping = [
-  { name = "airframe", filter = [ { group = "org.wvlet.airframe" } ] }
-]
-
 # logback-core 1.3.x needs to be used for suporting Java8
 updates.pin  = [ { groupId = "ch.qos.logback", artifactId="logback-core", version = "1.3." } ]
 


### PR DESCRIPTION
The grouping capability of scala-steward is not ideal because the PR title doesn't contain the new version number. Removing this setting