### PR TITLE
airspec: #2637 Support selecting nested test specs

### DIFF
--- a/airspec/src/main/scala/wvlet/airspec/runner/AirSpecMatcher.scala
+++ b/airspec/src/main/scala/wvlet/airspec/runner/AirSpecMatcher.scala
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airspec.runner
+
+import wvlet.log.LogSupport
+
+/**
+  * Find specs matching the pattern
+  */
+class AirSpecMatcher(pattern: String) extends LogSupport {
+
+  private val regexPatterns = pattern
+    .split("/")
+    .map(_.replaceAll("\\*", ".*"))
+    .map(x => s"(?i)${x}".r)
+    .toSeq
+
+  def matchWith(specName: String): Boolean = matchWith(specName.split("/").toSeq)
+
+  /**
+    * @param specName
+    *   a list of test spec names
+    * @return
+    */
+  def matchWith(specName: Seq[String]): Boolean = {
+
+    specName.zipAll(regexPatterns, "", "(?i).*".r).forall { case (part, regex) =>
+      if (part.isEmpty) {
+        true
+      } else {
+        val hasMatch = regex.findFirstIn(part).isDefined
+        hasMatch
+      }
+    }
+  }
+}
+
+object AirSpecMatcher {
+  def all: AirSpecMatcher = new AirSpecMatcher("*")
+}

--- a/airspec/src/main/scala/wvlet/airspec/runner/AirSpecSbtRunner.scala
+++ b/airspec/src/main/scala/wvlet/airspec/runner/AirSpecSbtRunner.scala
@@ -58,17 +58,11 @@ private[airspec] object AirSpecSbtRunner extends LogSupport {
   }
 
   case class AirSpecConfig(args: Array[String]) {
-    lazy val pattern: Option[Regex] = {
+    val specMatcher: AirSpecMatcher = {
       // For now, we only support regex-based test name matcher using the first argument
-      args.find(x => !x.startsWith("-")).flatMap { p =>
-        try {
-          // Support wildcard (*) for convenience
-          Some(s"(?i)${p.replaceAll("\\*", ".*")}".r)
-        } catch {
-          case e: Throwable =>
-            logger.warn(s"Invalid regular expression ${p}: ${e.getMessage}")
-            None
-        }
+      args.find(x => !x.startsWith("-")) match {
+        case Some(p) => new AirSpecMatcher(p)
+        case None    => AirSpecMatcher.all
       }
     }
   }

--- a/airspec/src/main/scala/wvlet/airspec/runner/AirSpecTaskRunner.scala
+++ b/airspec/src/main/scala/wvlet/airspec/runner/AirSpecTaskRunner.scala
@@ -79,19 +79,7 @@ private[airspec] class AirSpecTaskRunner(
       warn(s"No test definition is found in ${name}. Add at least one test(...) method call.")
     }
 
-    val selectedSpecs =
-      config.pattern match {
-        case Some(regex) =>
-          // Find matching methods
-          testDefs.filter { m =>
-            // Concatenate (parent class name)? + class name + method name for handy search
-            val fullName = s"${specName(None, spec)}.${m.name}"
-            regex.findFirstIn(fullName).isDefined
-          }
-        case None =>
-          testDefs
-      }
-
+    val selectedSpecs = testDefs.filter(task => config.specMatcher.matchWith(task.name))
     selectedSpecs
   }
 

--- a/airspec/src/main/scala/wvlet/airspec/runner/AirSpecTaskRunner.scala
+++ b/airspec/src/main/scala/wvlet/airspec/runner/AirSpecTaskRunner.scala
@@ -241,7 +241,8 @@ private[airspec] class AirSpecTaskRunner(
           parentContext = parentContext,
           currentSpec = spec,
           testName = m.name,
-          currentSession = childSession
+          currentSession = childSession,
+          config = config
         )
       spec.pushContext(context)
       context

--- a/airspec/src/main/scala/wvlet/airspec/spi/AirSpecContext.scala
+++ b/airspec/src/main/scala/wvlet/airspec/spi/AirSpecContext.scala
@@ -46,6 +46,13 @@ trait AirSpecContext {
     s"${parent}${specName}"
   }
 
+  def fullTestName: String = {
+    parentContext match {
+      case Some(p) => s"${p.fullTestName}/${testName}"
+      case None    => testName
+    }
+  }
+
   /**
     * Get the test method name currently running. For a global context, this will return '<init>'.
     */

--- a/airspec/src/test/scala/wvlet/airspec/runner/AirSpecMatcherTest.scala
+++ b/airspec/src/test/scala/wvlet/airspec/runner/AirSpecMatcherTest.scala
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airspec.runner
+
+import wvlet.airspec.AirSpec
+
+class AirSpecMatcherTest extends AirSpec {
+
+  private val t1 = "hello airspec"
+  private val t2 = "hello airspec/nested test"
+  private val t3 = "hello airspec/nested test/A"
+  private val t4 = "hello airspec/nested test/B"
+  private val s1 = "different spec"
+  private val s2 = "different spec/nested test"
+  private val s3 = "different spec/nested test/A"
+  private val s4 = "different spec/nested test/B"
+
+  private val specs: List[String] = List(
+    t1,
+    t2,
+    t3,
+    t4,
+    s1,
+    s2,
+    s3,
+    s4
+  )
+
+  test("match all patterns") {
+    val m = AirSpecMatcher.all
+    specs.filter(m.matchWith(_)) shouldBe List(t1, t2, t3, t4, s1, s2, s3, s4)
+  }
+
+  test("match only first spec name") {
+    val m = new AirSpecMatcher("hello")
+    specs.filter(m.matchWith(_)) shouldBe List(t1, t2, t3, t4)
+  }
+
+  test("match only first spec name with a different name") {
+    val m = new AirSpecMatcher("different")
+    specs.filter(m.matchWith(_)) shouldBe List(s1, s2, s3, s4)
+  }
+
+  test("match until child spec name") {
+    val m = new AirSpecMatcher("hello/nested")
+    specs.filter(m.matchWith(_)) shouldBe List(t1, t2, t3, t4)
+  }
+
+  test("match until descendant spec name A") {
+    val m = new AirSpecMatcher("hello/nested/A")
+    specs.filter(m.matchWith(_)) shouldBe List(t1, t2, t3)
+  }
+
+  test("match until descendant spec name B") {
+    val m = new AirSpecMatcher("hello/nested/B")
+    specs.filter(m.matchWith(_)) shouldBe List(t1, t2, t4)
+  }
+}

--- a/airspec/src/test/scala/wvlet/airspec/runner/AirSpecMatcherTest.scala
+++ b/airspec/src/test/scala/wvlet/airspec/runner/AirSpecMatcherTest.scala
@@ -66,4 +66,10 @@ class AirSpecMatcherTest extends AirSpec {
     val m = new AirSpecMatcher("hello/nested/B")
     specs.filter(m.matchWith(_)) shouldBe List(t1, t2, t4)
   }
+
+  test("skip when only a middle test name is given") {
+    val m = new AirSpecMatcher("nested")
+    specs.filter(m.matchWith(_)) shouldBe empty
+  }
+
 }

--- a/airspec/src/test/scala/wvlet/airspec/runner/NestTest.scala
+++ b/airspec/src/test/scala/wvlet/airspec/runner/NestTest.scala
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airspec.runner
+
+import wvlet.airspec.AirSpec
+
+class NestTest extends AirSpec {
+
+  test("A") {
+    test("1") {}
+    test("2") {}
+  }
+
+  test("B") {
+    test("1") {}
+    test("2") {}
+  }
+
+}

--- a/docs/airspec.md
+++ b/docs/airspec.md
@@ -157,7 +157,7 @@ AirSpec supports pattern matching for running only specific tests:
 $ sbt
 
 > test                                   # Run all tests
-> testOnly -- (pattern)                  # Run all test matching the pattern (class name or test name)
+> testOnly -- (pattern)                  # Run all test matching the pattern (/-delimtied test name)
 > testOnly -- (class pattern)*(pattern)  # Search both class and test names
 
 # sbt's default test functionalities:
@@ -165,9 +165,16 @@ $ sbt
 > testOnly (class name)                  # Run tests only in specific classes matching a pattern (wildcard is supported)
 ```
 
-`pattern` is used for partial matching with test names. It also supports wildcard (`*`) and regular expressions (experimental).
-Basically AirSpec will find matches from the list of all `(test class full name):(test function name)` strings.
-Cases of test names will be ignored in the search.
+The `pattern` is a slash (`/`)-separated test names. You can also use wildcard (`*`) and regular expressions in the pattern. If the test cases are nested, AirSpec represents test names as `(parent test name)/(child test name)/...`. so you can run specific nested test with patterns like:   
+
+```scala
+test("test A") { // Matches with 'test A'. All child tests will be executed
+  test("1") { ... }  // Matches with 'test A/1' 
+  test("2") { ... } // Matches with 'test A/2'
+}
+```
+
+Test names will be checked as case-insensitive partial match, so you only need to specify substrings of test names like `A`, `A/1`, 'a/2', etc. to simplify the pattern matching. 
 
 ![image](https://wvlet.org/airframe/img/airspec/airspec.png)
 


### PR DESCRIPTION
Support selecting nested test cases with `(test name)/(child test name)/...` syntax. 

Could you take a look? @takezoe @exoego 