### PR TITLE
airframe-sql: Fix qualifier resolution

### DIFF
--- a/airframe-parquet/src/main/scala/wvlet/airframe/parquet/ParquetQueryPlanner.scala
+++ b/airframe-parquet/src/main/scala/wvlet/airframe/parquet/ParquetQueryPlanner.scala
@@ -53,8 +53,8 @@ object ParquetQueryPlanner extends LogSupport {
           parseRelation(input, queryPlan).selectAllColumns
         case Project(input, selectItems, _) =>
           val columns = selectItems.map {
-            case SingleColumn(id: Identifier, _, _, _) =>
-              id.value
+            case a: wvlet.airframe.sql.model.Attribute =>
+              a.name
             case other =>
               throw new IllegalArgumentException(s"Invalid select item: ${other}")
           }

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/CTEResolver.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/CTEResolver.scala
@@ -46,7 +46,7 @@ object CTEResolver extends LogSupport {
             }
             // Add a projection for renaming columns
             val selectItems = resolvedQuery.outputAttributes.zip(aliases).map { case (col, alias) =>
-              SingleColumn(col, Some(alias.sqlExpr), None, col.nodeLocation)
+              SingleColumn(col, None, col.nodeLocation).withAlias(alias.value)
             }
             Project(resolvedQuery, selectItems, resolvedQuery.nodeLocation)
         }

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/Optimizer.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/Optimizer.scala
@@ -55,10 +55,10 @@ object Optimizer extends LogSupport {
     */
   def pruneRelationColumns(relation: Relation, context: AnalyzerContext): Relation = {
     relation match {
-      case t @ TableScan(table, columns, _) if context.parentAttributes.nonEmpty =>
+      case t @ TableScan(fullName, table, columns, _) if context.parentAttributes.nonEmpty =>
         val parentAttributes = context.parentAttributes.get
         val accessedColumns  = columns.filter { col => parentAttributes.exists(x => x.name == col.name) }
-        TableScan(table, accessedColumns, t.nodeLocation)
+        TableScan(fullName, table, accessedColumns, t.nodeLocation)
       case _ => relation
     }
   }

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/RewriteRule.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/RewriteRule.scala
@@ -15,7 +15,7 @@ package wvlet.airframe.sql.analyzer
 
 import wvlet.airframe.sql.analyzer.RewriteRule.PlanRewriter
 import wvlet.airframe.sql.model.LogicalPlan
-import wvlet.log.{LogSupport, Logger}
+import wvlet.log.{LogLevel, LogSupport, Logger}
 
 trait RewriteRule extends LogSupport {
   // Prepare a logger for debugging purpose
@@ -28,7 +28,7 @@ trait RewriteRule extends LogSupport {
     val rule = this.apply(context)
     // Recursively transform the tree form bottom to up
     val resolved = plan.transformUp(rule)
-    if (!(plan eq resolved)) {
+    if (localLogger.isEnabled(LogLevel.TRACE) && !(plan eq resolved) && plan != resolved) {
       localLogger.trace(s"transformed with ${name}:\n[before]\n${plan.pp}\n[after]\n${resolved.pp}")
     }
     resolved

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/SQLAnalyzer.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/SQLAnalyzer.scala
@@ -76,7 +76,7 @@ object SQLAnalyzer extends LogSupport {
         targetPlan.transform(r)
       }
 
-      trace(s"new plan:\n${optimizedPlan.pp}")
+      trace(s"Optimized plan:\n${optimizedPlan.pp}")
       optimizedPlan
     }
   }

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/SQLAnonymizer.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/SQLAnonymizer.scala
@@ -87,7 +87,13 @@ object SQLAnonymizer extends LogSupport {
         case q: QName =>
           m += q -> QName(q.parts.map(qnameTable.lookup), q.nodeLocation)
         case u: UnresolvedAttribute =>
-          val v = UnresolvedAttribute(u.name.split("\\.").toSeq.map(qnameTable.lookup).mkString("."), u.nodeLocation)
+          val parts = u.name.split("\\.").toSeq.map(qnameTable.lookup)
+          val qualifier = if (parts.length > 1) {
+            Some(parts.dropRight(1).mkString("."))
+          } else {
+            None
+          }
+          val v = UnresolvedAttribute(qualifier, parts.last, u.nodeLocation)
           m += u -> v
       }
       this

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
@@ -298,14 +298,15 @@ object TypeResolver extends LogSupport {
         resolvedColumns += other
     }
     val output = resolvedColumns.result()
-    output
+    // Run one-more resolution (e.g., SingleColumn -> ResolvedAttribute)
+    output.map(resolveAttribute)
   }
 
   def resolveAttribute(attribute: Attribute): Attribute = {
     attribute match {
-      case SingleColumn(r: ResolvedAttribute, alias, qualifier, _) =>
+      case SingleColumn(a: Attribute, alias, qualifier, _) =>
         // Preserve column alias and qualifiers
-        r.withAlias(alias).withQualifier(qualifier)
+        a.withAlias(alias).setQualifierIfEmpty(qualifier)
       case other => other
     }
   }

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
@@ -366,7 +366,7 @@ object TypeResolver extends LogSupport {
         val allColumns = resolvedAttributes.map {
           case s @ SingleColumn(m: MultiSourceColumn, alias, qualifier, _) =>
             // Pull-up MultiColumn to simplify the expression
-            m.copy(alias = m.alias.orElse(s.alias), qualifier = qualifier)
+            m.copy(alias = m.alias.orElse(s.alias)).setQualifierIfEmpty(qualifier)
           case m: MultiSourceColumn =>
             // MultiColumn is already resolved
             m

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
@@ -395,8 +395,8 @@ object TypeResolver extends LogSupport {
     }
 
     trace(
-      s"findMatchInInputAttributes:\n[input]\n${expr}\n\n[output]\n${results
-          .mkString(", ")}\n\n[inputAttributes]:\n ${inputAttributes.mkString("\n ")}"
+      s"[findMatchInInputAttributes]\n - input:  ${expr}\n - output: ${results
+          .mkString(", ")}\n[inputAttributes]:\n ${inputAttributes.mkString("\n ")}"
     )
     results
   }

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
@@ -280,7 +280,7 @@ object TypeResolver extends LogSupport {
     ): Seq[Attribute] = {
       val resolvedColumns = Seq.newBuilder[Attribute]
       outputColumns.map {
-        case a @ Alias(name, expr, _) =>
+        case a @ Alias(qualifier, name, expr, _) =>
           val resolved = resolveExpression(context, expr, inputAttributes)
           if (expr eq resolved) {
             resolvedColumns += a
@@ -306,7 +306,7 @@ object TypeResolver extends LogSupport {
 
   def resolveAttribute(attribute: Attribute): Attribute = {
     attribute match {
-      case a @ Alias(name, attr: Attribute, _) =>
+      case a @ Alias(qualifier, name, attr: Attribute, _) =>
         val resolved = resolveAttribute(attr)
         if (attr eq resolved) {
           a

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
@@ -326,6 +326,8 @@ object TypeResolver extends LogSupport {
       e match {
         case r: ResolvedAttribute =>
           r.sourceColumn
+        case a: Alias =>
+          findSourceColumn(a.expr)
         case _ => None
       }
     }

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
@@ -354,7 +354,7 @@ object TypeResolver extends LogSupport {
         name,
         expr.dataType,
         None,
-        Seq.empty,
+        None,
         expr.nodeLocation
       )
     }

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
@@ -321,7 +321,6 @@ object TypeResolver extends LogSupport {
       }
       // Run one-more resolution (e.g., SingleColumn -> ResolvedAttribute)
       val output = resolvedColumns.result().map(resolveAttribute)
-      // warn(s"resolveOutputColumns:\n[original]\n${outputColumns}\n[result]\n${output}")
       output
     }
   }

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
@@ -147,8 +147,9 @@ object TypeResolver extends LogSupport {
 
   object resolveSortItems extends RewriteRule {
     def apply(context: AnalyzerContext): PlanRewriter = { case s @ Sort(child, sortItems, _) =>
-      val resolvedChild   = resolveRelation(context, child)
-      val inputAttributes = resolvedChild.outputAttributes
+      val resolvedChild = resolveRelation(context, child)
+      // Sort can access the input relation of the child
+      val inputAttributes = resolvedChild.inputAttributes
       val resolvedSortItems = sortItems.map { sortItem =>
         val e = resolveExpression(context, sortItem.sortKey, inputAttributes)
         sortItem.copy(sortKey = e)

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
@@ -393,8 +393,9 @@ object TypeResolver extends LogSupport {
       case i: Identifier =>
         lookup(i.value).map {
           // No need to resolve Attribute expressions
-          case a: Attribute => a
-          case expr         =>
+          case a: Attribute =>
+            a
+          case expr =>
             // Resolve expr as ResolvedAttribute so as not to pull-up too much details
             toResolvedAttribute(i.value, expr)
         }

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
@@ -19,8 +19,6 @@ import wvlet.airframe.sql.model.LogicalPlan._
 import wvlet.airframe.sql.model._
 import wvlet.log.LogSupport
 
-import scala.util.chaining.scalaUtilChainingOps
-
 /**
   * Resolve untyped [[LogicalPlan]]s and [[Expression]]s into typed ones.
   */
@@ -307,17 +305,7 @@ object TypeResolver extends LogSupport {
     attribute match {
       case SingleColumn(r: ResolvedAttribute, alias, qualifier, _) =>
         // Preserve column alias and qualifiers
-        r.pipe { attr =>
-          alias match {
-            case Some(x) => attr.withAlias(x)
-            case None    => attr
-          }
-        }.pipe { attr =>
-            qualifier match {
-              case Some(x) => attr.withQualifier(x)
-              case None    => attr
-            }
-          }
+        r.withAlias(alias).withQualifier(qualifier)
       case other => other
     }
   }

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
@@ -30,13 +30,13 @@ object TypeResolver extends LogSupport {
     TypeResolver.resolveCTETableRef ::
       TypeResolver.resolveAggregationIndexes ::
       TypeResolver.resolveAggregationKeys ::
-      TypeResolver.resolveSortItemIndexes ::
-      TypeResolver.resolveSortItems ::
       TypeResolver.resolveTableRef ::
       TypeResolver.resolveJoinUsing ::
       TypeResolver.resolveSubquery ::
       TypeResolver.resolveRegularRelation ::
       TypeResolver.resolveColumns ::
+      TypeResolver.resolveSortItemIndexes ::
+      TypeResolver.resolveSortItems ::
       Nil
   }
 

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
@@ -305,8 +305,8 @@ object TypeResolver extends LogSupport {
   def resolveAttribute(attribute: Attribute): Attribute = {
     attribute match {
       case SingleColumn(a: Attribute, alias, qualifier, _) =>
-        // Preserve column alias and qualifiers
-        a.withAlias(alias).setQualifierIfEmpty(qualifier)
+        // Optimizes the nested attributes, but preserves column alias and qualifier in the parent
+        a.withAlias(alias).withQualifier(qualifier)
       case other => other
     }
   }
@@ -353,9 +353,9 @@ object TypeResolver extends LogSupport {
 
     val results = expr match {
       case i: Identifier =>
-        lookup(i.value).map(toResolvedAttribute(i.value, _))
+        lookup(i.value).map(toResolvedAttribute(i.value, _)).distinct
       case u @ UnresolvedAttribute(qual, name, _) =>
-        lookup(name).map(toResolvedAttribute(name, _).withQualifier(qual))
+        lookup(name).map(toResolvedAttribute(name, _).withQualifier(qual)).distinct
       case a @ AllColumns(_, None, _) =>
         // Resolve the inputs of AllColumn as ResolvedAttribute
         // so as not to pull up too much details

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
@@ -314,8 +314,7 @@ object Expression {
     override def toString = {
       columns match {
         case Some(attrs) if attrs.nonEmpty =>
-          // Show the detailed node type for the ease of debugging
-          val inputs = attrs.map(_.typeDescriptionWithNodeType).mkString(", ")
+          val inputs = attrs.map(_.typeDescription).mkString(", ")
           s"AllColumns(${inputs})"
         case _ =>
           s"AllColumns(${qualifier.map(q => s"${q}.").getOrElse("")}*)"

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
@@ -548,7 +548,7 @@ object Expression {
   ) extends Attribute {
     require(inputs.nonEmpty, s"The inputs of MultiSourceColumn should not be empty: ${this}")
 
-    override def toString: String          = s"MultiSourceColumn(${fullName} := ${inputs.mkString(", ")})"
+    override def toString: String          = s"MultiSourceColumn(${fullName} := {${inputs.mkString(", ")}})"
     override def children: Seq[Expression] = inputs
 
     override def name: String = {

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
@@ -212,6 +212,12 @@ trait Attribute extends LeafExpression with LogSupport {
   def qualifier: Option[String]
   def withQualifier(newQualifier: String): Attribute = withQualifier(Some(newQualifier))
   def withQualifier(newQualifier: Option[String]): Attribute
+  def setQualifierIfEmpty(newQualifier: Option[String]): Attribute = {
+    qualifier match {
+      case Some(q) => this
+      case None => this.withQualifier(newQualifier)
+    }
+  }
 
   import Expression.Alias
   def alias: Option[String] = {
@@ -467,7 +473,7 @@ object Expression {
     }
 
     override def toString: String = {
-      s"${name} := ${expr.sqlExpr}"
+      s"<${name}> := ${expr}"
     }
     override def dataType: DataType = expr.dataType
 
@@ -493,7 +499,7 @@ object Expression {
     override def dataType: DataType = expr.dataType
 
     override def children: Seq[Expression] = Seq(expr)
-    override def toString                  = s"SingleColumn(${fullName}:${dataTypeName} := ${expr})"
+    override def toString                  = s"${fullName}:${dataTypeName} := ${expr}"
 
     override def sqlExpr: String = expr.sqlExpr
     override def withQualifier(newQualifier: Option[String]): Attribute = {
@@ -514,7 +520,7 @@ object Expression {
   ) extends Attribute {
     require(inputs.nonEmpty, s"The inputs of MultiSourceColumn should not be empty: ${this}")
 
-    override def toString: String          = s"${fullName}:${dataTypeName} <- {${inputs.mkString(", ")}}"
+    override def toString: String          = s"${fullName}:${dataTypeName} := {${inputs.mkString(", ")}}"
     override def children: Seq[Expression] = inputs
 
     override def name: String = {

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
@@ -835,7 +835,7 @@ object Expression {
     override def dataType: DataType  = DataType.StringType
     override def stringValue: String = value
     override def sqlExpr: String     = s"'${value}'"
-    override def toString            = s"Literal('${value}')"
+    override def toString            = s"StringLiteral('${value}')"
   }
   case class TimeLiteral(value: String, nodeLocation: Option[NodeLocation]) extends Literal with LeafExpression {
     override def dataType: DataType  = DataType.TimestampType(TimestampField.TIME, false)
@@ -865,13 +865,13 @@ object Expression {
     override def dataType: DataType  = DataType.DoubleType
     override def stringValue: String = value.toString
     override def sqlExpr             = value.toString
-    override def toString            = s"Literal(${value.toString})"
+    override def toString            = s"DoubleLiteral(${value.toString})"
   }
   case class LongLiteral(value: Long, nodeLocation: Option[NodeLocation]) extends Literal with LeafExpression {
     override def dataType: DataType  = DataType.LongType
     override def stringValue: String = value.toString
     override def sqlExpr             = value.toString
-    override def toString            = s"Literal(${value.toString})"
+    override def toString            = s"LongLiteral(${value.toString})"
   }
   case class IntervalLiteral(
       value: String,

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
@@ -559,7 +559,7 @@ object Expression {
   ) extends Attribute {
     require(inputs.nonEmpty, s"The inputs of MultiSourceColumn should not be empty: ${this}")
 
-    override def toString: String          = s"MultiSourceColumn(${fullName} := {${inputs.mkString(", ")}})"
+    override def toString: String          = s"${fullName}:${dataTypeName} <- {${inputs.mkString(", ")}}"
     override def children: Seq[Expression] = inputs
 
     override def name: String = {

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
@@ -182,9 +182,9 @@ trait BinaryExpression extends Expression {
 case class ColumnPath(database: Option[String], table: Option[String], columnName: String)
 
 object ColumnPath {
-  def fromQName(contextDatabase: String, name: String): Option[ColumnPath] = {
+  def fromQName(contextDatabase: String, fullName: String): Option[ColumnPath] = {
     // TODO Should we handle quotation in the name or just reject?
-    name.split("\\.").toList match {
+    fullName.split("\\.").toList match {
       case List(db, t, c) if db == contextDatabase =>
         Some(ColumnPath(Some(db), Some(t), c))
       case List(t, c) =>
@@ -208,7 +208,7 @@ trait Attribute extends LeafExpression with LogSupport {
   }
   def prefix: String = qualifier.map(q => s"${q}.").getOrElse("")
 
-  // (database name)?.(table name)
+  // (database name)?.(table name) given in the original SQL
   def qualifier: Option[String]
   def withQualifier(newQualifier: String): Attribute = withQualifier(Some(newQualifier))
   def withQualifier(newQualifier: Option[String]): Attribute

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
@@ -332,22 +332,16 @@ object Expression {
     }
   }
 
-  case class UnresolvedAttribute(name: String, nodeLocation: Option[NodeLocation]) extends Attribute {
-    private val parts: Seq[String] = name.split("\\.").toSeq
-    override def toString: String  = s"UnresolvedAttribute(${name})"
-    override def sqlExpr: String   = name
-    override lazy val resolved     = false
-
-    override def qualifier: Option[String] = {
-      if (parts.size > 1) {
-        Some(parts.dropRight(1).mkString("."))
-      } else {
-        None
-      }
-    }
+  case class UnresolvedAttribute(
+      override val qualifier: Option[String],
+      name: String,
+      nodeLocation: Option[NodeLocation]
+  ) extends Attribute {
+    override def toString: String = s"UnresolvedAttribute(${fullName})"
+    override def sqlExpr: String  = name
+    override lazy val resolved    = false
     override def withQualifier(newQualifier: Option[String]): UnresolvedAttribute = {
-      val q = newQualifier.map(q => s"${q}.").getOrElse("")
-      this.copy(name = s"${q}${parts.last}")
+      this.copy(qualifier = newQualifier)
     }
     override def alias: Option[String]                          = None
     override def withAlias(newAlias: Option[String]): Attribute = this

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
@@ -398,6 +398,11 @@ object Expression {
     override def children: Seq[Expression] = columns
     override def toString: String          = s"JoinUsing(${columns.mkString(",")})"
   }
+  case class ResolvedJoinUsing(keys: Seq[MultiSourceColumn], nodeLocation: Option[NodeLocation]) extends JoinCriteria {
+    override def children: Seq[Expression] = keys
+    override def toString: String          = s"ResolvedJoinUsing(${keys.mkString(",")})"
+    override lazy val resolved: Boolean    = true
+  }
   case class JoinOn(expr: Expression, nodeLocation: Option[NodeLocation]) extends JoinCriteria with UnaryExpression {
     override def child: Expression = expr
   }

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
@@ -532,7 +532,7 @@ object LogicalPlan {
         }
       }
       val columns = (0 until values.head.size).map { i =>
-        SingleColumn(MultiSourceColumn(values.map(_(i)), None, None, None), None, None, None)
+        MultiSourceColumn(values.map(_(i)), None, None)
       }
       columns
     }
@@ -670,10 +670,9 @@ object LogicalPlan {
             // TODO No need to re-wrap by SingleColumn for ResolvedAttribute, SingleColumn and MultiColumn?
             SingleColumn(
               in,
-              Some(alias.sqlExpr),
               None,
               alias.nodeLocation
-            )
+            ).withAlias(alias.value)
           }
         case None =>
           query.outputAttributes
@@ -715,7 +714,7 @@ object LogicalPlan {
               if (dupAttrs.isEmpty) {
                 r
               } else {
-                SingleColumn(MultiSourceColumn(Seq(r) ++ dupAttrs, None, None, None), None, None, None)
+                MultiSourceColumn(Seq(r) ++ dupAttrs, None, None)
               }
             case r => r
           }
@@ -769,7 +768,6 @@ object LogicalPlan {
         val qualifiers = columns.map(_.qualifier).distinct
         MultiSourceColumn(
           inputs = columns.toSeq,
-          alias = Some(head.name),
           qualifier = {
             // If all of the qualifiers are the same, use it.
             if (qualifiers.size == 1) {
@@ -779,7 +777,7 @@ object LogicalPlan {
             }
           },
           None
-        )
+        ).withAlias(head.name)
       }.toSeq
     }
   }
@@ -831,7 +829,7 @@ object LogicalPlan {
         case arr: ArrayConstructor =>
           ResolvedAttribute(UUID.randomUUID().toString, arr.elementType, None, None, None)
         case other =>
-          SingleColumn(other, None, None, other.nodeLocation)
+          SingleColumn(other, None, other.nodeLocation)
       }
     }
     override def sig(config: QuerySignatureConfig): String =

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
@@ -15,6 +15,7 @@ package wvlet.airframe.sql.model
 import wvlet.airframe.sql.{SQLError, SQLErrorCode}
 import wvlet.airframe.sql.analyzer.{QuerySignatureConfig, RewriteRule, TypeResolver}
 import wvlet.airframe.sql.catalog.DataType
+import wvlet.log.LogSupport
 
 import java.util.UUID
 
@@ -502,19 +503,20 @@ object LogicalPlan {
       val attrs = child.outputAttributes.map { a =>
         a.withQualifier(alias.value)
       }
-      columnNames match {
-        case Some(columnNames) =>
-          attrs.zip(columnNames).map { case (a, columnName) =>
-            a.withQualifier(alias.value) match {
-              case r: ResolvedAttribute   => r.copy(name = columnName)
-              case s: SingleColumn        => s.copy(alias = Some(columnName))
-              case u: UnresolvedAttribute => u.copy(name = columnName)
-              case others                 => others
-            }
-          }
-        case None =>
-          attrs
-      }
+//      val result = columnNames match {
+//        case Some(columnNames) =>
+//          attrs.zip(columnNames).map { case (a, columnName) =>
+//            a.withQualifier(alias.value) match {
+//              case r: ResolvedAttribute   => r.copy(name = columnName)
+//              case s: SingleColumn        => s.copy(alias = Some(columnName))
+//              case u: UnresolvedAttribute => u.copy(name = columnName)
+//              case others                 => others
+//            }
+//          }
+//        case None =>
+//          attrs
+//      }
+      attrs
     }
   }
 
@@ -850,7 +852,7 @@ object LogicalPlan {
       nodeLocation: Option[NodeLocation]
   ) extends UnaryRelation {
     override def outputAttributes: Seq[Attribute] =
-      columnAliases.map(x => UnresolvedAttribute(x.value, None))
+      columnAliases.map(x => UnresolvedAttribute(Some(tableAlias.value), x.value, None))
     override def sig(config: QuerySignatureConfig): String =
       s"LV(${child.sig(config)})"
   }

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
@@ -603,7 +603,7 @@ object LogicalPlan {
 
     override def outputAttributes: Seq[Attribute] = {
       // TODO Remove redundant resolution
-      selectItems // .map(TypeResolver.resolveAttribute)
+      selectItems.map(TypeResolver.resolveAttribute)
     }
   }
 

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
@@ -827,7 +827,7 @@ object LogicalPlan {
     override def outputAttributes: Seq[Attribute] = {
       columns.map {
         case arr: ArrayConstructor =>
-          ResolvedAttribute(UUID.randomUUID().toString, arr.elementType, None, Nil, None)
+          ResolvedAttribute(UUID.randomUUID().toString, arr.elementType, None, None, None)
         case other =>
           SingleColumn(other, None, None, other.nodeLocation)
       }

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
@@ -766,7 +766,7 @@ object LogicalPlan {
         val head       = columns.head
         val qualifiers = columns.map(_.qualifier).distinct
         MultiColumn(
-          inputs = columns,
+          inputs = columns.toSeq,
           alias = Some(head.name),
           qualifier = {
             // If all of the qualifiers are the same, use it.
@@ -778,7 +778,7 @@ object LogicalPlan {
           },
           None
         )
-      }
+      }.toSeq
     }
   }
 

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
@@ -12,10 +12,7 @@
  * limitations under the License.
  */
 package wvlet.airframe.sql.model
-import wvlet.airframe.sql.{SQLError, SQLErrorCode}
-import wvlet.airframe.sql.analyzer.{QuerySignatureConfig, RewriteRule, TypeResolver}
-import wvlet.airframe.sql.catalog.DataType
-import wvlet.log.LogSupport
+import wvlet.airframe.sql.analyzer.{QuerySignatureConfig, TypeResolver}
 
 import java.util.UUID
 
@@ -709,23 +706,9 @@ object LogicalPlan {
           }
           // report join keys (merged) and other attributes
           joinKeys ++ otherAttributes
-        case je: JoinOnEq =>
+        case _ =>
+          // Report including duplicated name columns
           inputAttributes
-
-        //         // Aggregates duplicated keys
-//          val dups         = je.duplicateKeys
-//          val uniqueInputs = inputAttributes.filter(x => !dups.contains(x))
-//          uniqueInputs.map {
-//            case r: ResolvedAttribute =>
-//              val dupAttrs = dups.collect { case x: ResolvedAttribute if x.name == r.name => x }
-//              if (dupAttrs.isEmpty) {
-//                r
-//              } else {
-//                MultiSourceColumn(Seq(r) ++ dupAttrs, None, None)
-//              }
-//            case r => r
-//          }
-        case _ => inputAttributes
       }
     }
 

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
@@ -603,7 +603,7 @@ object LogicalPlan {
 
     override def outputAttributes: Seq[Attribute] = {
       // TODO Remove redundant resolution
-      selectItems.map(TypeResolver.resolveAttribute)
+      selectItems // .map(TypeResolver.resolveAttribute)
     }
   }
 

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
@@ -702,6 +702,12 @@ object LogicalPlan {
     }
     override def outputAttributes: Seq[Attribute] = {
       cond match {
+        case ju: ResolvedJoinUsing =>
+          val joinKeys = ju.keys
+          val otherAttributes = inputAttributes.filter { x =>
+            !joinKeys.exists(jk => jk.name == x.name)
+          }
+          joinKeys ++ otherAttributes
         case je: JoinOnEq =>
           // Aggregates duplicated keys
           val dups         = je.duplicateKeys

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
@@ -599,8 +599,8 @@ object LogicalPlan {
       s"P[${proj}](${child.sig(config)})"
     }
 
-    // TODO
     override def outputAttributes: Seq[Attribute] = {
+      // TODO Remove redundant resolution
       selectItems.map(TypeResolver.resolveAttribute)
     }
   }

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
@@ -707,21 +707,24 @@ object LogicalPlan {
           val otherAttributes = inputAttributes.filter { x =>
             !joinKeys.exists(jk => jk.name == x.name)
           }
+          // report join keys (merged) and other attributes
           joinKeys ++ otherAttributes
         case je: JoinOnEq =>
-          // Aggregates duplicated keys
-          val dups         = je.duplicateKeys
-          val uniqueInputs = inputAttributes.filter(x => !dups.contains(x))
-          uniqueInputs.map {
-            case r: ResolvedAttribute =>
-              val dupAttrs = dups.collect { case x: ResolvedAttribute if x.name == r.name => x }
-              if (dupAttrs.isEmpty) {
-                r
-              } else {
-                MultiSourceColumn(Seq(r) ++ dupAttrs, None, None)
-              }
-            case r => r
-          }
+          inputAttributes
+
+        //         // Aggregates duplicated keys
+//          val dups         = je.duplicateKeys
+//          val uniqueInputs = inputAttributes.filter(x => !dups.contains(x))
+//          uniqueInputs.map {
+//            case r: ResolvedAttribute =>
+//              val dupAttrs = dups.collect { case x: ResolvedAttribute if x.name == r.name => x }
+//              if (dupAttrs.isEmpty) {
+//                r
+//              } else {
+//                MultiSourceColumn(Seq(r) ++ dupAttrs, None, None)
+//              }
+//            case r => r
+//          }
         case _ => inputAttributes
       }
     }

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
@@ -503,20 +503,18 @@ object LogicalPlan {
       val attrs = child.outputAttributes.map { a =>
         a.withQualifier(alias.value)
       }
-//      val result = columnNames match {
-//        case Some(columnNames) =>
-//          attrs.zip(columnNames).map { case (a, columnName) =>
-//            a.withQualifier(alias.value) match {
-//              case r: ResolvedAttribute   => r.copy(name = columnName)
-//              case s: SingleColumn        => s.copy(alias = Some(columnName))
-//              case u: UnresolvedAttribute => u.copy(name = columnName)
-//              case others                 => others
-//            }
-//          }
-//        case None =>
-//          attrs
-//      }
-      attrs
+      val result = columnNames match {
+        case Some(columnNames) =>
+          attrs.zip(columnNames).map { case (a, columnName) =>
+            a match {
+              case a: Attribute => a.withAlias(columnName)
+              case others       => others
+            }
+          }
+        case None =>
+          attrs
+      }
+      result
     }
   }
 

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
@@ -530,7 +530,7 @@ object LogicalPlan {
         }
       }
       val columns = (0 until values.head.size).map { i =>
-        SingleColumn(MultiColumn(values.map(_(i)), None, None, None), None, None, None)
+        SingleColumn(MultiSourceColumn(values.map(_(i)), None, None, None), None, None, None)
       }
       columns
     }
@@ -713,7 +713,7 @@ object LogicalPlan {
               if (dupAttrs.isEmpty) {
                 r
               } else {
-                SingleColumn(MultiColumn(Seq(r) ++ dupAttrs, None, None, None), None, None, None)
+                SingleColumn(MultiSourceColumn(Seq(r) ++ dupAttrs, None, None, None), None, None, None)
               }
             case r => r
           }
@@ -765,7 +765,7 @@ object LogicalPlan {
       sameColumnList.map { columns =>
         val head       = columns.head
         val qualifiers = columns.map(_.qualifier).distinct
-        MultiColumn(
+        MultiSourceColumn(
           inputs = columns.toSeq,
           alias = Some(head.name),
           qualifier = {

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/ResolvedPlan.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/ResolvedPlan.scala
@@ -134,7 +134,7 @@ case class ResolvedAttribute(
           .map(_.fullName)
           .mkString(s"${typeDescription} <- [", ", ", "]")
       case _ =>
-        s"${typeDescription}"
+        s"${prefix}${typeDescription}"
     }
   }
   override lazy val resolved = true

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/ResolvedPlan.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/ResolvedPlan.scala
@@ -69,10 +69,15 @@ case class ResolvedAttribute(
     with LogSupport {
 
   override def sqlExpr: String = {
-    s"${qualifier.map(q => s"${q}.").getOrElse("")}${name}"
+    if (isAlias && sourceColumn.isDefined) {
+      s"${prefix}${sourceColumn.get.column.name} AS ${name}"
+    } else {
+      s"${prefix}${name}"
+    }
   }
 
-  override def alias: Option[String] = Some(name)
+  private def isAlias: Boolean       = sourceColumn.exists(_.column.name != name)
+  override def alias: Option[String] = if (isAlias) Some(name) else None
 
   override def withAlias(newAlias: Option[String]): Attribute = {
     newAlias match {

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/ResolvedPlan.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/ResolvedPlan.scala
@@ -73,14 +73,20 @@ case class ResolvedAttribute(
   }
 
   override def alias: Option[String] = Some(name)
-  def withAlias(newName: String): ResolvedAttribute = {
-    if (isRawColumn && sourceColumn.exists(_.column.name != newName)) {
-      // When renaming from the source column name, qualifier should be removed
-      this.copy(name = newName, qualifier = None)
-    } else {
-      this.copy(name = newName)
+
+  override def withAlias(newAlias: Option[String]): Attribute = {
+    newAlias match {
+      case Some(newName) =>
+        if (isRawColumn && sourceColumn.exists(_.column.name != newName)) {
+          // When renaming from the source column name, qualifier should be removed
+          this.copy(name = newName, qualifier = None)
+        } else {
+          this.copy(name = newName)
+        }
+      case None => this
     }
   }
+
   private def isRawColumn: Boolean = {
     (qualifier, sourceColumn) match {
       case (Some(q), Some(src)) =>
@@ -92,8 +98,8 @@ case class ResolvedAttribute(
     }
   }
 
-  override def withQualifier(newQualifier: String): Attribute = {
-    this.copy(qualifier = Some(newQualifier))
+  override def withQualifier(newQualifier: Option[String]): Attribute = {
+    this.copy(qualifier = newQualifier)
   }
 
   override def inputColumns: Seq[Attribute] = Seq(this)

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/ResolvedPlan.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/ResolvedPlan.scala
@@ -78,35 +78,6 @@ case class ResolvedAttribute(
   override def withQualifier(newQualifier: Option[String]): Attribute = {
     this.copy(qualifier = newQualifier)
   }
-
-  // private def isAlias: Boolean       = sourceColumn.exists(_.column.name != name)
-//  override def alias: Option[String] = if (isAlias) Some(name) else None
-//
-//  override def withAlias(newAlias: Option[String]): Attribute = {
-//    newAlias match {
-//      case Some(newName) =>
-//        this.copy(name = newName)
-////        if (isRawColumn && sourceColumn.exists(_.column.name != newName)) {
-////          // When renaming from the source column name, qualifier should be removed
-////          this.copy(name = newName, qualifier = None)
-////        } else {
-////          this.copy(name = newName)
-////        }
-//      case None => this
-//    }
-//  }
-
-  private def isRawColumn: Boolean = {
-    (qualifier, sourceColumn) match {
-      case (Some(q), Some(src)) =>
-        q == src.table.name && name == src.column.name
-      case (None, Some(src)) =>
-        src.column.name == name
-      case _ =>
-        false
-    }
-  }
-
   override def inputColumns: Seq[Attribute] = Seq(this)
 
   override def toString = {

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/ResolvedPlan.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/ResolvedPlan.scala
@@ -71,31 +71,34 @@ case class ResolvedAttribute(
     s"${qualifier.map(q => s"${q}.").getOrElse("")}${name}"
   }
 
+  override def alias: Option[String] = Some(name)
   def withAlias(newName: String): ResolvedAttribute = {
     this.copy(name = newName)
   }
+
+  override def inputColumns: Seq[Attribute] = Seq(this)
 
   def relationNames: Seq[String] = qualifier match {
     case Some(q) => Seq(q)
     case _       => sourceColumns.map(_.table.name)
   }
 
-  /**
-    * Returns true if this resolved attribute matches with a given table name and colum name
-    */
-  def matchesWith(tableName: String, columnName: String): Boolean = {
-    relationNames match {
-      case Nil => columnName == name
-      case tableNames =>
-        tableNames.exists { tbl =>
-          tbl == tableName && matchesWith(columnName)
-        }
-    }
-  }
-
-  def matchesWith(columnName: String): Boolean = {
-    name == columnName
-  }
+//  /**
+//    * Returns true if this resolved attribute matches with a given table name and colum name
+//    */
+//  def matchesWith(tableName: String, columnName: String): Boolean = {
+//    relationNames match {
+//      case Nil => columnName == name
+//      case tableNames =>
+//        tableNames.exists { tbl =>
+//          tbl == tableName && matchesWith(columnName)
+//        }
+//    }
+//  }
+//
+//  def matchesWith(columnName: String): Boolean = {
+//    name == columnName
+//  }
 
   override def toString = {
     (qualifier, sourceColumns) match {

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/ResolvedPlan.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/ResolvedPlan.scala
@@ -77,7 +77,7 @@ case class ResolvedAttribute(
 
   override def sqlExpr: String = {
     if (isAlias && sourceColumn.isDefined) {
-      s"${prefix}${sourceColumn.get.fullName} AS ${name}"
+      s"${prefix}${sourceColumn.get.column.name} AS ${name}"
     } else {
       s"${prefix}${name}"
     }

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLGenerator.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLGenerator.scala
@@ -374,16 +374,13 @@ object SQLGenerator extends LogSupport {
         printExpression(k)
       case ParenthesizedExpression(expr, _) =>
         s"(${printExpression(expr)})"
-      case SingleColumn(ex, alias, _, _) =>
-        val col = printExpression(ex)
-        alias
-          .map(x => s"${col} AS ${x}")
-          .getOrElse(col)
-      case MultiSourceColumn(inputs, name, _, _) =>
-        name match {
-          case Some(name) => name
-          case None       => inputs.collectFirst { case a: Attribute => a }.map(printExpression).getOrElse(unknown(e))
-        }
+      case a: Alias =>
+        val e = printExpression(a.expr)
+        s"${e} AS ${a.name}"
+      case SingleColumn(ex, _, _) =>
+        printExpression(ex)
+      case m: MultiSourceColumn =>
+        m.sqlExpr
       case AllColumns(prefix, _, _) =>
         prefix.map(p => s"${p}.*").getOrElse("*")
       case a: Attribute =>

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLGenerator.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLGenerator.scala
@@ -118,7 +118,7 @@ object SQLGenerator extends LogSupport {
     if (containsDistinctPlan(context)) {
       b += "DISTINCT"
     }
-    b += (s.selectItems.map(printExpression).mkString(", "))
+    b += (s.selectItems.map(printSelectItem).mkString(", "))
 
     findNonEmpty(nonFilterChild).map { f =>
       b += "FROM"
@@ -355,6 +355,15 @@ object SQLGenerator extends LogSupport {
     }
   }
 
+  def printSelectItem(e: Expression): String = {
+    e match {
+      case a: ResolvedAttribute =>
+        a.sqlExpr
+      case other =>
+        printExpression(other)
+    }
+  }
+
   def printExpression(e: Expression): String = {
     e match {
       case i: Identifier =>
@@ -377,10 +386,8 @@ object SQLGenerator extends LogSupport {
         }
       case AllColumns(prefix, _, _) =>
         prefix.map(p => s"${p}.*").getOrElse("*")
-      case ResolvedAttribute(name, _, Some(qualifier), _, _) =>
-        s"${qualifier}.${name}"
       case a: Attribute =>
-        a.name
+        a.fullName
       case SortItem(key, ordering, nullOrdering, _) =>
         val k  = printExpression(key)
         val o  = ordering.map(x => s" ${x}").getOrElse("")

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLGenerator.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLGenerator.scala
@@ -193,7 +193,7 @@ object SQLGenerator extends LogSupport {
       case TableRef(t, _) =>
         printExpression(t)
       case t: TableScan =>
-        t.table.fullName
+        t.fullName
       case Limit(in, l, _) =>
         val s = seqBuilder
         s += printRelation(in, context)

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLGenerator.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLGenerator.scala
@@ -225,10 +225,11 @@ object SQLGenerator extends LogSupport {
           case _               => printRelation(right)
         }
         val c = cond match {
-          case NaturalJoin(_)        => ""
-          case JoinUsing(columns, _) => s" USING (${columns.map(_.sqlExpr).mkString(", ")})"
-          case JoinOn(expr, _)       => s" ON ${printExpression(expr)}"
-          case JoinOnEq(keys, _)     => s" ON ${printExpression(Expression.concatWithEq(keys))}"
+          case NaturalJoin(_)                => ""
+          case JoinUsing(columns, _)         => s" USING (${columns.map(_.sqlExpr).mkString(", ")})"
+          case ResolvedJoinUsing(columns, _) => s" USING (${columns.map(_.fullName).mkString(", ")})"
+          case JoinOn(expr, _)               => s" ON ${printExpression(expr)}"
+          case JoinOnEq(keys, _)             => s" ON ${printExpression(Expression.concatWithEq(keys))}"
         }
         joinType match {
           case InnerJoin      => s"${l} JOIN ${r}${c}"

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLGenerator.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLGenerator.scala
@@ -370,7 +370,7 @@ object SQLGenerator extends LogSupport {
         alias
           .map(x => s"${col} AS ${x}")
           .getOrElse(col)
-      case MultiColumn(inputs, name, _, _) =>
+      case MultiSourceColumn(inputs, name, _, _) =>
         name match {
           case Some(name) => name
           case None       => inputs.collectFirst { case a: Attribute => a }.map(printExpression).getOrElse(unknown(e))

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLInterpreter.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLInterpreter.scala
@@ -384,7 +384,8 @@ class SQLInterpreter(withNodeLocation: Boolean = true) extends SqlBaseBaseVisito
   }
 
   override def visitDereference(ctx: DereferenceContext): Attribute = {
-    UnresolvedAttribute(s"${ctx.base.getText}.${ctx.fieldName.getText}", getLocation(ctx))
+    val qualifier = if (ctx.base.getText.isEmpty) None else Some(ctx.base.getText)
+    UnresolvedAttribute(qualifier, ctx.fieldName.getText, getLocation(ctx))
   }
 
   override def visitSelectAll(ctx: SelectAllContext): Attribute = {

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLInterpreter.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLInterpreter.scala
@@ -398,7 +398,8 @@ class SQLInterpreter(withNodeLocation: Boolean = true) extends SqlBaseBaseVisito
     val alias = Option(ctx.AS())
       .map(x => expression(ctx.identifier()))
       .orElse(Option(ctx.identifier()).map(expression(_)))
-    SingleColumn(expression(ctx.expression()), alias.map(_.sqlExpr), None, getLocation(ctx))
+    SingleColumn(expression(ctx.expression()), None, getLocation(ctx))
+      .withAlias(alias.map(_.sqlExpr))
   }
 
   override def visitExpression(ctx: ExpressionContext): Expression = {

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/SQLAnalyzerTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/SQLAnalyzerTest.scala
@@ -92,7 +92,7 @@ class SQLAnalyzerTest extends AirSpec {
     plan.resolved shouldBe true
     plan.outputAttributes.toList shouldMatch {
       // Attribute should not have a qualifier
-      case List(Alias("person_id", r, _)) => {
+      case List(Alias(_, "person_id", r, _)) => {
         r.attributeName shouldBe "id"
         r.dataType shouldBe DataType.LongType
       }
@@ -125,7 +125,7 @@ class SQLAnalyzerTest extends AirSpec {
         Some(SourceColumn(tbl1, tbl1.column("address"))),
         None
       )
-    attr(3) shouldMatch { case Alias("phone_num", a, _) =>
+    attr(3) shouldMatch { case Alias(_, "phone_num", a, _) =>
       a shouldMatch { case ResolvedAttribute("phone", DataType.StringType, _, _, _) =>
       // c shouldBe SourceColumn(tbl2, tbl2.column("phone"))
       }

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/SQLAnalyzerTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/SQLAnalyzerTest.scala
@@ -52,8 +52,8 @@ class SQLAnalyzerTest extends AirSpec {
     val plan = SQLAnalyzer.analyze("select id, name from a", "public", catalog)
     plan.resolved shouldBe true
     plan.outputAttributes.toList shouldBe List(
-      ResolvedAttribute("id", DataType.LongType, None, Seq(SourceColumn(tbl1, tbl1.column("id"))), None),
-      ResolvedAttribute("name", DataType.StringType, None, Seq(SourceColumn(tbl1, tbl1.column("name"))), None)
+      ResolvedAttribute("id", DataType.LongType, None, Some(SourceColumn(tbl1, tbl1.column("id"))), None),
+      ResolvedAttribute("name", DataType.StringType, None, Some(SourceColumn(tbl1, tbl1.column("name"))), None)
     )
   }
 
@@ -65,13 +65,13 @@ class SQLAnalyzerTest extends AirSpec {
         None,
         Some(
           Seq(
-            ResolvedAttribute("id", DataType.LongType, None, Seq(SourceColumn(tbl1, tbl1.column("id"))), None),
-            ResolvedAttribute("name", DataType.StringType, None, Seq(SourceColumn(tbl1, tbl1.column("name"))), None),
+            ResolvedAttribute("id", DataType.LongType, None, Some(SourceColumn(tbl1, tbl1.column("id"))), None),
+            ResolvedAttribute("name", DataType.StringType, None, Some(SourceColumn(tbl1, tbl1.column("name"))), None),
             ResolvedAttribute(
               "address",
               DataType.StringType,
               None,
-              Seq(SourceColumn(tbl1, tbl1.column("address"))),
+              Some(SourceColumn(tbl1, tbl1.column("address"))),
               None
             )
           )
@@ -85,7 +85,7 @@ class SQLAnalyzerTest extends AirSpec {
     val plan = SQLAnalyzer.analyze("select id as person_id from a", "public", catalog)
     plan.resolved shouldBe true
     plan.outputAttributes.toList shouldBe List(
-      ResolvedAttribute("person_id", DataType.LongType, None, Seq(SourceColumn(tbl1, tbl1.column("id"))), None)
+      ResolvedAttribute("person_id", DataType.LongType, None, Some(SourceColumn(tbl1, tbl1.column("id"))), None)
     )
   }
 
@@ -97,20 +97,20 @@ class SQLAnalyzerTest extends AirSpec {
     )
     plan.resolved shouldBe true
     plan.outputAttributes.toList shouldBe List(
-      ResolvedAttribute("id", DataType.LongType, Some("a"), Seq(SourceColumn(tbl1, tbl1.column("id"))), None),
-      ResolvedAttribute("name", DataType.StringType, Some("a"), Seq(SourceColumn(tbl1, tbl1.column("name"))), None),
+      ResolvedAttribute("id", DataType.LongType, Some("a"), Some(SourceColumn(tbl1, tbl1.column("id"))), None),
+      ResolvedAttribute("name", DataType.StringType, Some("a"), Some(SourceColumn(tbl1, tbl1.column("name"))), None),
       ResolvedAttribute(
         "address",
         DataType.StringType,
         Some("a"),
-        Seq(SourceColumn(tbl1, tbl1.column("address"))),
+        Some(SourceColumn(tbl1, tbl1.column("address"))),
         None
       ),
       ResolvedAttribute(
         "person_id",
         DataType.StringType,
         Some("b"),
-        Seq(SourceColumn(tbl2, tbl2.column("phone"))),
+        Some(SourceColumn(tbl2, tbl2.column("phone"))),
         None
       )
     )

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/SQLAnalyzerTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/SQLAnalyzerTest.scala
@@ -52,8 +52,8 @@ class SQLAnalyzerTest extends AirSpec {
     val plan = SQLAnalyzer.analyze("select id, name from a", "public", catalog)
     plan.resolved shouldBe true
     plan.outputAttributes.toList shouldBe List(
-      ResolvedAttribute("id", DataType.LongType, None, Some(SourceColumn(tbl1, tbl1.column("id"))), None),
-      ResolvedAttribute("name", DataType.StringType, None, Some(SourceColumn(tbl1, tbl1.column("name"))), None)
+      ResolvedAttribute("id", DataType.LongType, Some("a"), Some(SourceColumn(tbl1, tbl1.column("id"))), None),
+      ResolvedAttribute("name", DataType.StringType, Some("a"), Some(SourceColumn(tbl1, tbl1.column("name"))), None)
     )
   }
 
@@ -65,12 +65,18 @@ class SQLAnalyzerTest extends AirSpec {
         None,
         Some(
           Seq(
-            ResolvedAttribute("id", DataType.LongType, None, Some(SourceColumn(tbl1, tbl1.column("id"))), None),
-            ResolvedAttribute("name", DataType.StringType, None, Some(SourceColumn(tbl1, tbl1.column("name"))), None),
+            ResolvedAttribute("id", DataType.LongType, Some("a"), Some(SourceColumn(tbl1, tbl1.column("id"))), None),
+            ResolvedAttribute(
+              "name",
+              DataType.StringType,
+              Some("a"),
+              Some(SourceColumn(tbl1, tbl1.column("name"))),
+              None
+            ),
             ResolvedAttribute(
               "address",
               DataType.StringType,
-              None,
+              Some("a"),
               Some(SourceColumn(tbl1, tbl1.column("address"))),
               None
             )
@@ -85,13 +91,14 @@ class SQLAnalyzerTest extends AirSpec {
     val plan = SQLAnalyzer.analyze("select id as person_id from a", "public", catalog)
     plan.resolved shouldBe true
     plan.outputAttributes.toList shouldBe List(
+      // Attribute should not have a qualifier
       ResolvedAttribute("person_id", DataType.LongType, None, Some(SourceColumn(tbl1, tbl1.column("id"))), None)
     )
   }
 
   test("resolve join attributes") {
     val plan = SQLAnalyzer.analyze(
-      "select a.id, a.name, a.address, b.phone as person_id from a, b where a.id = b.id",
+      "select a.id, a.name, a.address, b.phone as phone_num from a, b where a.id = b.id",
       "public",
       catalog
     )
@@ -107,9 +114,9 @@ class SQLAnalyzerTest extends AirSpec {
         None
       ),
       ResolvedAttribute(
-        "person_id",
+        "phone_num",
         DataType.StringType,
-        Some("b"),
+        None, // This must be None because it's renamed from b.phone as phone_num
         Some(SourceColumn(tbl2, tbl2.column("phone"))),
         None
       )

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
@@ -344,11 +344,11 @@ class TypeResolverTest extends AirSpec {
       p shouldMatch {
         case Aggregate(
               _,
-              List(c1, c2 @ SingleColumn(f: FunctionCall, _, _)),
+              List(c1, Alias(_, "cnt", SingleColumn(f: FunctionCall, _, _), _)),
               List(GroupingKey(`ra1`, _)),
               Some(GreaterThan(col, LongLiteral(10, _), _)),
               _
-            ) if c1.name == "id" && c2.name == "cnt" && f.functionName == "count" =>
+            ) if c1.name == "id" && f.functionName == "count" =>
           f.args shouldMatch { case List(AllColumns(_, Some(cols), _)) =>
             cols.toSet shouldBe Set(ra1, ra2)
           }

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
@@ -29,7 +29,15 @@ import wvlet.airframe.sql.model.LogicalPlan.{
   Sort,
   With
 }
-import wvlet.airframe.sql.model.{CTERelationRef, Expression, LogicalPlan, NodeLocation, ResolvedAttribute, SourceColumn}
+import wvlet.airframe.sql.model.{
+  CTERelationRef,
+  ColumnPath,
+  Expression,
+  LogicalPlan,
+  NodeLocation,
+  ResolvedAttribute,
+  SourceColumn
+}
 import wvlet.airframe.sql.parser.{SQLGenerator, SQLParser}
 import wvlet.airframe.sql.{SQLError, SQLErrorCode}
 import wvlet.airspec.AirSpec
@@ -247,10 +255,9 @@ class TypeResolverTest extends AirSpec {
     }
 
     test("ru4: resolve aggregation key with union") {
-      val p = analyze("select count(*), id from (select * from A union all select * from B) group by id")
-      p.asInstanceOf[Aggregate].groupingKeys(0).child shouldMatch {
-        case MultiSourceColumn(List(`ra1`, `rb1`), Some("id"), _, _) => ()
-      }
+      val p   = analyze("select count(*), id from (select * from A union all select * from B) group by id")
+      val agg = p shouldMatch { case a: Aggregate => a }
+      agg.groupingKeys(0).child shouldMatch { case MultiSourceColumn(Seq(`ra1`, `rb1`), Some("id"), _, _) => }
     }
 
     test("resolve union with expression") {

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
@@ -393,8 +393,8 @@ class TypeResolverTest extends AirSpec {
       p.outputAttributes.toList shouldMatch {
         // The output should use aliases from the source columns
         case List(AllColumns(None, Some(Seq(c1, c2)), _)) =>
-          c1 shouldBe ra1.copy(name = "p1", qualifier = Some("q1"))
-          c2 shouldBe ra2.copy(name = "p2", qualifier = Some("q1"))
+          c1 shouldMatch { case Alias(Some("q1"), "p1", `ra1`, _) => }
+          c2 shouldMatch { case Alias(Some("q1"), "p2", `ra2`, _) => }
       }
     }
 

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
@@ -123,10 +123,10 @@ class TypeResolverTest extends AirSpec {
     SQLGenerator.print(p)
   }
 
-  private val ra1 = ResolvedAttribute("id", DataType.LongType, Some("A"), Some(SourceColumn(tableA, a1)), None)
-  private val ra2 = ResolvedAttribute("name", DataType.StringType, Some("A"), Some(SourceColumn(tableA, a2)), None)
-  private val rb1 = ResolvedAttribute("id", DataType.LongType, Some("B"), Some(SourceColumn(tableB, b1)), None)
-  private val rb2 = ResolvedAttribute("name", DataType.StringType, Some("B"), Some(SourceColumn(tableB, b2)), None)
+  private val ra1 = ResolvedAttribute("id", DataType.LongType, None, Some(SourceColumn(tableA, a1)), None)
+  private val ra2 = ResolvedAttribute("name", DataType.StringType, None, Some(SourceColumn(tableA, a2)), None)
+  private val rb1 = ResolvedAttribute("id", DataType.LongType, None, Some(SourceColumn(tableB, b1)), None)
+  private val rb2 = ResolvedAttribute("name", DataType.StringType, None, Some(SourceColumn(tableB, b2)), None)
 
   test("resolveTableRef") {
     test("resolve all columns") {
@@ -148,7 +148,7 @@ class TypeResolverTest extends AirSpec {
   test("resolve full table name") {
     val p = analyze("select default.A.id from A")
     p.outputAttributes shouldBe List(
-      ra1.withQualifier("A")
+      ra1.withQualifier("default.A")
     )
   }
 

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
@@ -499,17 +499,20 @@ class TypeResolverTest extends AirSpec {
           |having count(1) > 160
           |""".stripMargin)
 
-      val joins = p.collectExpressions { case _: JoinOnEq =>
+      val joinKeys = p.collectExpressions { case u: ResolvedJoinUsing =>
         true
       }
-      joins shouldMatch { case List(JoinOnEq(Seq(c1, c2), _), JoinOnEq(Seq(c3, c4), _)) =>
-        c1 shouldBe ra1.withQualifier("a")
-        c2 shouldBe rb1.withQualifier("b")
-        c3 shouldMatch { case MultiSourceColumn(Seq(e1, e2), _, _) =>
-          e1 shouldBe ra1.withQualifier("a")
-          e2 shouldBe rb1.withQualifier("b")
-        }
-        c4 shouldBe rc1.withQualifier("c")
+      joinKeys shouldMatch {
+        case List(
+              ResolvedJoinUsing(Seq(MultiSourceColumn(Seq(c1, c2), _, _)), _),
+              ResolvedJoinUsing(Seq(MultiSourceColumn(Seq(c3, c4, c5), _, _)), _)
+            ) =>
+          c1 shouldBe ra1.withQualifier("a")
+          c2 shouldBe rb1.withQualifier("b")
+
+          c3 shouldBe ra1.withQualifier("a")
+          c4 shouldBe rb1.withQualifier("b")
+          c5 shouldBe rc1.withQualifier("c")
       }
     }
 

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
@@ -250,8 +250,8 @@ class TypeResolverTest extends AirSpec {
         c2 shouldBe rb1.withAlias("p1")
       }
       p.outputAttributes shouldMatch { case Seq(m @ MultiSourceColumn(Seq(c1, c2), Some("q1"), _)) =>
-        c1 shouldBe ra1.withAlias("p1")
-        c2 shouldBe rb1.withAlias("p1")
+        c1 shouldBe ra1.withAlias("p1").withQualifier("q1")
+        c2 shouldBe rb1.withAlias("p1").withQualifier("q1")
       }
     }
 

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
@@ -834,7 +834,7 @@ class TypeResolverTest extends AirSpec {
       val p = analyze("""SELECT id, name FROM A ORDER BY 1""".stripMargin)
       p.asInstanceOf[Sort].orderBy.toList shouldMatch { case List(SortItem(c, None, None, _)) =>
         c.attributeName shouldBe "id"
-        c.dataType shouldBe DataType.StringType
+        c.dataType shouldBe DataType.LongType
       }
     }
 

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
@@ -115,10 +115,10 @@ class TypeResolverTest extends AirSpec {
     SQLGenerator.print(p)
   }
 
-  private val ra1 = ResolvedAttribute("id", DataType.LongType, Some("A"), Seq(SourceColumn(tableA, a1)), None)
-  private val ra2 = ResolvedAttribute("name", DataType.StringType, Some("A"), Seq(SourceColumn(tableA, a2)), None)
-  private val rb1 = ResolvedAttribute("id", DataType.LongType, Some("B"), Seq(SourceColumn(tableB, b1)), None)
-  private val rb2 = ResolvedAttribute("name", DataType.StringType, Some("B"), Seq(SourceColumn(tableB, b2)), None)
+  private val ra1 = ResolvedAttribute("id", DataType.LongType, Some("A"), Some(SourceColumn(tableA, a1)), None)
+  private val ra2 = ResolvedAttribute("name", DataType.StringType, Some("A"), Some(SourceColumn(tableA, a2)), None)
+  private val rb1 = ResolvedAttribute("id", DataType.LongType, Some("B"), Some(SourceColumn(tableB, b1)), None)
+  private val rb2 = ResolvedAttribute("name", DataType.StringType, Some("B"), Some(SourceColumn(tableB, b2)), None)
 
   test("resolveTableRef") {
     test("resolve all columns") {
@@ -852,8 +852,8 @@ class TypeResolverTest extends AirSpec {
 
       p.outputAttributes shouldBe List(
         ra1.withQualifier("A"),
-        ResolvedAttribute("key", DataType.StringType, Some("t"), Nil, None),
-        ResolvedAttribute("value", DataType.LongType, Some("t"), Nil, None)
+        ResolvedAttribute("key", DataType.StringType, Some("t"), None, None),
+        ResolvedAttribute("value", DataType.LongType, Some("t"), None, None)
       )
     }
   }

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
@@ -496,40 +496,37 @@ class TypeResolverTest extends AirSpec {
       }
     }
 
-    test("join with on") {
+    test("j3: join with on") {
       val p = analyze("select id, A.name from A join B on A.id = B.id")
-      p.outputAttributes shouldMatch {
-        case List(SingleColumn(m @ MultiSourceColumn(List(c1, c2), _, _), None, _), c3) =>
-          m.name shouldBe "id"
-          c1 shouldBe ra1.withQualifier("A")
-          c2 shouldBe rb1.withQualifier("B")
-          c3 shouldBe ra2.withQualifier("A")
+      p.outputAttributes shouldMatch { case List(m @ MultiSourceColumn(List(c1, c2), _, _), c3) =>
+        m.name shouldBe "id"
+        c1 shouldBe ra1.withQualifier("A")
+        c2 shouldBe rb1.withQualifier("B")
+        c3 shouldBe ra2.withQualifier("A")
       }
     }
 
-    test("join with on condition for aliased columns") {
+    test("j4: join with on condition for aliased columns") {
       val p = analyze("select id, a.name from A a join B b on a.id = b.id")
-      p.outputAttributes shouldMatch {
-        case List(SingleColumn(m @ MultiSourceColumn(List(c1, c2), _, _), None, _), c3) =>
-          m.name shouldBe "id"
-          c1 shouldBe ra1.withQualifier("a")
-          c2 shouldBe rb1.withQualifier("b")
-          c3 shouldBe ra2.withQualifier("a")
+      p.outputAttributes shouldMatch { case List(m @ MultiSourceColumn(List(c1, c2), _, _), c3) =>
+        m.name shouldBe "id"
+        c1 shouldBe ra1.withQualifier("a")
+        c2 shouldBe rb1.withQualifier("b")
+        c3 shouldBe ra2.withQualifier("a")
       }
     }
 
-    test("join with on condition for qualified columns") {
+    test("j5: join with on condition for qualified columns") {
       val p = analyze("select id, default.A.name from default.A join default.B on default.A.id = default.B.id")
-      p.outputAttributes shouldMatch {
-        case List(SingleColumn(m @ MultiSourceColumn(List(c1, c2), _, _), None, _), c3) =>
-          m.name shouldBe "id"
-          c1 shouldBe ra1.withQualifier("A")
-          c2 shouldBe rb1.withQualifier("B")
-          c3 shouldBe ra2.withQualifier("A")
+      p.outputAttributes shouldMatch { case List(m @ MultiSourceColumn(List(c1, c2), _, _), c3) =>
+        m.name shouldBe "id"
+        c1 shouldBe ra1.withQualifier("A")
+        c2 shouldBe rb1.withQualifier("B")
+        c3 shouldBe ra2.withQualifier("A")
       }
     }
 
-    test("join with different column names") {
+    test("j6: join with different column names") {
       val p = analyze("select pid, name from A join (select id pid from B) on A.id = B.pid")
       p.outputAttributes shouldMatch {
         case List(

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
@@ -482,7 +482,7 @@ class TypeResolverTest extends AirSpec {
   test("join: resolve join attributes") {
     test("j1: join with USING") {
       val p = analyze("select id, A.name from A join B using(id)")
-      p.outputAttributes shouldMatch { case List(m @ MultiSourceColumn(List(c1, c2), _, _), c3) =>
+      p.outputAttributes shouldMatch { case Seq(m @ MultiSourceColumn(Seq(c1, c2), _, _), c3) =>
         m.name shouldBe "id"
         c1 shouldBe ra1.withQualifier("A")
         c2 shouldBe rb1.withQualifier("B")

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
@@ -465,19 +465,18 @@ class TypeResolverTest extends AirSpec {
     e.message.contains("UnresolvedAttribute") shouldBe false
   }
 
-  test("resolve join attributes") {
-    test("join with USING") {
+  test("join: resolve join attributes") {
+    test("j1: join with USING") {
       val p = analyze("select id, A.name from A join B using(id)")
-      p.outputAttributes shouldMatch {
-        case List(SingleColumn(m @ MultiSourceColumn(List(c1, c2), _, _), None, _), c3) =>
-          m.name shouldBe "id"
-          c1 shouldBe ra1.withQualifier("A")
-          c2 shouldBe rb1.withQualifier("B")
-          c3 shouldBe ra2.withQualifier("A")
+      p.outputAttributes shouldMatch { case List(m @ MultiSourceColumn(List(c1, c2), _, _), c3) =>
+        m.name shouldBe "id"
+        c1 shouldBe ra1.withQualifier("A")
+        c2 shouldBe rb1.withQualifier("B")
+        c3 shouldBe ra2.withQualifier("A")
       }
     }
 
-    test("resolve USING with 3 tables") {
+    test("j2: resolve USING with 3 tables") {
       val p = analyze("""select a.id, count(1)
           |from A a
           |join B b using (id)

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
@@ -324,7 +324,7 @@ class TypeResolverTest extends AirSpec {
       }
     }
 
-    test("group by with renamed keys") {
+    test("a2: group by with renamed keys") {
       val p = analyze("select xxx, count(*) from (select id as xxx from A) group by 1")
       p shouldMatch {
         case Aggregate(

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
@@ -146,7 +146,7 @@ class TypeResolverTest extends AirSpec {
   }
 
   test("resolve full table name") {
-    val p = analyze("select default.A.id from A")
+    val p = analyze("select default.A.id from default.A")
     p.outputAttributes shouldBe List(
       ra1.withQualifier("default.A")
     )

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
@@ -193,7 +193,7 @@ class TypeResolverTest extends AirSpec {
       val p = analyze("select id from A union all select id from A")
       p.inputAttributes shouldBe List(ra1, ra2, ra1, ra2)
       p.outputAttributes shouldBe List(
-        MultiSourceColumn(List(ra1, ra1), Some("id"), Some("A"), None)
+        MultiSourceColumn(List(ra1, ra1), Some("id"), None, None)
       )
     }
 

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
@@ -248,7 +248,7 @@ class TypeResolverTest extends AirSpec {
         c1 shouldBe ra1.withAlias("p1")
         c2 shouldBe rb1.withAlias("p1")
       }
-      p.outputAttributes shouldMatch { case Seq(m @ MultiSourceColumn(Seq(c1, c2), None, Some("q1"), _)) =>
+      p.outputAttributes shouldMatch { case Seq(m @ MultiSourceColumn(Seq(c1, c2), None, None, _)) =>
         c1 shouldBe ra1.withAlias("p1").withQualifier("q1")
         c2 shouldBe rb1.withAlias("p1").withQualifier("q1")
       }

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
@@ -554,7 +554,7 @@ class TypeResolverTest extends AirSpec {
       }
     }
 
-    test("refer to duplicated key of equi join") {
+    test("j7: refer to duplicated key of equi join") {
       val p = analyze("select B.id from A inner join B on A.id = B.id")
       p.outputAttributes shouldMatch { case List(SingleColumn(MultiSourceColumn(List(c1, c2), _, _), None, _)) =>
         c1 shouldBe ra1.withQualifier("A")
@@ -814,15 +814,15 @@ class TypeResolverTest extends AirSpec {
     }
   }
 
-  test("resolve order by") {
-    test("resolve simple order by") {
+  test("sort: resolve order by") {
+    test("s1: resolve simple order by") {
       val p = analyze("""SELECT id, name FROM A ORDER BY id""".stripMargin)
       p.asInstanceOf[Sort].orderBy.toList shouldMatch { case List(SortItem(`ra1`, None, None, _)) =>
         ()
       }
     }
 
-    test("resolve order by alias") {
+    test("s2: resolve order by alias") {
       val p = analyze("""SELECT * FROM (SELECT id as p1, name FROM A) ORDER BY p1""".stripMargin)
       p.asInstanceOf[Sort].orderBy.toList shouldMatch { case List(SortItem(c, None, None, _)) =>
         c.attributeName shouldBe "p1"
@@ -830,7 +830,7 @@ class TypeResolverTest extends AirSpec {
       }
     }
 
-    test("resolve order by index") {
+    test("s3: resolve order by index") {
       val p = analyze("""SELECT id, name FROM A ORDER BY 1""".stripMargin)
       p.asInstanceOf[Sort].orderBy.toList shouldMatch { case List(SortItem(c, None, None, _)) =>
         c.attributeName shouldBe "id"
@@ -838,7 +838,7 @@ class TypeResolverTest extends AirSpec {
       }
     }
 
-    test("resolve order by with duplicated join key") {
+    test("s4: resolve order by with duplicated join key") {
       val p = analyze("""SELECT A.id FROM A INNER JOIN B on A.id = B.id ORDER BY B.id DESC""".stripMargin)
       p.asInstanceOf[Sort].orderBy.toList shouldMatch {
         case List(SortItem(MultiSourceColumn(List(c1, c2), _, _), Some(Descending), None, _)) =>

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
@@ -559,14 +559,18 @@ class TypeResolverTest extends AirSpec {
 
     test("j7: refer to duplicated key of equi join") {
       val p = analyze("select B.id from A inner join B on A.id = B.id")
-      p.outputAttributes shouldMatch { case List(SingleColumn(MultiSourceColumn(List(c1, c2), _, _), None, _)) =>
-        c1 shouldBe ra1.withQualifier("A")
-        c2 shouldBe rb1.withQualifier("B")
+      p.outputAttributes shouldMatch {
+        case List(ResolvedAttribute("id", DataType.LongType, Some("B"), Some(SourceColumn(`tableB`, `b1`)), _)) =>
       }
     }
 
-    test("3-way joins") {
-      pending("TODO")
+    test("j8: 3-way joins") {
+      val p = analyze("select A.id, B.id, C.id from A join B on A.id = B.id join C on B.id = C.id")
+      p.outputAttributes shouldMatch { case List(c1, c2, c3) =>
+        c1 shouldBe ra1.withQualifier("A")
+        c2 shouldBe rb1.withQualifier("B")
+        c3 shouldBe rc1.withQualifier("C")
+      }
     }
   }
 

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
@@ -248,9 +248,9 @@ class TypeResolverTest extends AirSpec {
         c1 shouldBe ra1.withAlias("p1")
         c2 shouldBe rb1.withAlias("p1")
       }
-      p.outputAttributes shouldMatch { case Seq(m @ MultiSourceColumn(Seq(c1, c2), None, _)) =>
-        c1 shouldBe ra1.withAlias("p1").withQualifier("q1")
-        c2 shouldBe rb1.withAlias("p1").withQualifier("q1")
+      p.outputAttributes shouldMatch { case Seq(m @ MultiSourceColumn(Seq(c1, c2), Some("q1"), _)) =>
+        c1 shouldBe ra1.withAlias("p1")
+        c2 shouldBe rb1.withAlias("p1")
       }
     }
 

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
@@ -527,11 +527,11 @@ class TypeResolverTest extends AirSpec {
     }
 
     test("j6: join with different column names") {
-      val p = analyze("select pid, name from A join (select id pid from B) on A.id = B.pid")
+      val p = analyze("select pid, name from A join (select id as pid from B) on A.id = pid")
       p.outputAttributes shouldMatch {
         case List(
-              ResolvedAttribute("pid", DataType.LongType, Some("B"), Seq(SourceColumn(`tableB`, `b1`)), _),
-              ResolvedAttribute("name", DataType.StringType, Some("A"), Seq(SourceColumn(`tableA`, `a2`)), _)
+              ResolvedAttribute("pid", DataType.LongType, None, Some(SourceColumn(`tableB`, `b1`)), _),
+              ResolvedAttribute("name", DataType.StringType, Some("A"), Some(SourceColumn(`tableA`, `a2`)), _)
             ) =>
           ()
       }

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
@@ -849,7 +849,7 @@ class TypeResolverTest extends AirSpec {
   test("resolve UNNEST") {
     test("resolve UNNEST array column") {
       val p = analyze("SELECT id, n FROM A CROSS JOIN UNNEST (name) AS t (n)")
-      p.outputAttributes shouldMatch { case List(c1, c2) =>
+      p.outputAttributes shouldMatch { case List(c1: Attribute, c2: Attribute) =>
         c1.fullName shouldBe "A.id"
         c2.fullName shouldBe "t.n"
       }
@@ -902,7 +902,7 @@ class TypeResolverTest extends AirSpec {
 
   test("resolve select * from (select 1)") {
     val p = analyze("select * from (select 1)")
-    p.outputAttributes shouldMatch { case List(AllColumns(None, Some(List(r)), _)) =>
+    p.outputAttributes shouldMatch { case List(AllColumns(None, Some(List(r: Attribute)), _)) =>
       r.dataType shouldBe DataType.LongType
     }
   }

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
@@ -316,11 +316,11 @@ class TypeResolverTest extends AirSpec {
       }
     }
 
-    test("resolve qualified column used in GROUP BY clause") {
+    test("a1: resolve qualified column used in GROUP BY clause") {
       val p = analyze("SELECT a.cnt, a.name FROM (SELECT count(id) cnt, name FROM A GROUP BY name) a")
-      p.outputAttributes shouldMatch {
-        case List(SingleColumn(FunctionCall("count", Seq(c1), _, _, _, _), _, _, _), c2) =>
-          List(c1, c2) shouldBe List(ra1, ra2.withQualifier("a"))
+      p.outputAttributes shouldMatch { case Seq(c1, c2) =>
+        c1 shouldMatch { case ResolvedAttribute("cnt", DataType.LongType, Some("a"), None, _) => }
+        c2 shouldBe ra2.withQualifier("a")
       }
     }
 

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
@@ -517,32 +517,30 @@ class TypeResolverTest extends AirSpec {
     }
 
     test("j3: join with on") {
-      val p = analyze("select id, A.name from A join B on A.id = B.id")
-      p.outputAttributes shouldMatch { case List(m @ MultiSourceColumn(List(c1, c2), _, _), c3) =>
-        m.name shouldBe "id"
+      val p = analyze("select A.id, A.name, B.name from A join B on A.id = B.id")
+      p.outputAttributes shouldMatch { case List(c1, c2, c3) =>
         c1 shouldBe ra1.withQualifier("A")
-        c2 shouldBe rb1.withQualifier("B")
-        c3 shouldBe ra2.withQualifier("A")
+        c2 shouldBe ra2.withQualifier("A")
+        c3 shouldBe rb2.withQualifier("B")
       }
     }
 
     test("j4: join with on condition for aliased columns") {
-      val p = analyze("select id, a.name from A a join B b on a.id = b.id")
-      p.outputAttributes shouldMatch { case List(m @ MultiSourceColumn(List(c1, c2), _, _), c3) =>
-        m.name shouldBe "id"
+      val p = analyze("select a.id, a.name, b.name from A a join B b on a.id = b.id")
+      p.outputAttributes shouldMatch { case List(c1, c2, c3) =>
         c1 shouldBe ra1.withQualifier("a")
-        c2 shouldBe rb1.withQualifier("b")
-        c3 shouldBe ra2.withQualifier("a")
+        c2 shouldBe ra2.withQualifier("a")
+        c3 shouldBe rb2.withQualifier("b")
       }
     }
 
     test("j5: join with on condition for qualified columns") {
-      val p = analyze("select id, default.A.name from default.A join default.B on default.A.id = default.B.id")
-      p.outputAttributes shouldMatch { case List(m @ MultiSourceColumn(List(c1, c2), _, _), c3) =>
-        m.name shouldBe "id"
+      val p =
+        analyze("select A.id, A.name, B.name from default.A join default.B on default.A.id = default.B.id")
+      p.outputAttributes shouldMatch { case List(c1, c2, c3) =>
         c1 shouldBe ra1.withQualifier("A")
-        c2 shouldBe rb1.withQualifier("B")
-        c3 shouldBe ra2.withQualifier("A")
+        c2 shouldBe ra2.withQualifier("A")
+        c3 shouldBe rb2.withQualifier("B")
       }
     }
 

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
@@ -173,11 +173,11 @@ class TypeResolverTest extends AirSpec {
   }
 
   test("resolve set operations") {
-    test("resolve union") {
+    test("u1: resolve union") {
       val p = analyze("select id from A union all select id from B")
       p.inputAttributes shouldBe List(ra1, ra2, rb1, rb2)
       p.outputAttributes shouldBe List(
-        SingleColumn(MultiColumn(List(ra1, rb1), Some("id"), None, None), None, None, None)
+        MultiColumn(List(ra1, rb1), Some("id"), None, None)
       )
     }
 

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
@@ -240,16 +240,14 @@ class TypeResolverTest extends AirSpec {
     }
 
     test("resolve union with column alias and qualifier") {
-      val p = analyze("select q1.p1 from (select id as p1 from A union all select id from B) q1")
-      p.inputAttributes shouldMatch {
-        case List(SingleColumn(MultiColumn(List(c1, c2), Some("p1"), _, _), None, Some("q1"), _)) =>
-          c1 shouldBe ra1.withAlias("p1")
-          c2 shouldBe rb1
+      val p = analyze("select q1.p1 from (select id as p1 from A union all select id as p1 from B) q1")
+      p.inputAttributes shouldMatch { case List(MultiColumn(List(c1, c2), Some("p1"), _, _)) =>
+        c1 shouldBe ra1.withAlias("p1")
+        c2 shouldBe rb1.withAlias("p1")
       }
-      p.outputAttributes shouldMatch {
-        case List(SingleColumn(MultiColumn(List(c1, c2), Some("q1.p1"), _, _), None, None, _)) =>
-          c1 shouldBe ra1.withAlias("p1")
-          c2 shouldBe rb1
+      p.outputAttributes shouldMatch { case List(MultiColumn(List(c1, c2), Some("q1.p1"), _, _)) =>
+        c1 shouldBe ra1.withAlias("p1")
+        c2 shouldBe rb1.withAlias("p1")
       }
     }
 
@@ -539,7 +537,7 @@ class TypeResolverTest extends AirSpec {
       val p = analyze("select pid, name from A join (select id pid from B) on A.id = B.pid")
       p.outputAttributes shouldMatch {
         case List(
-              ResolvedAttribute("pid", DataType.LongType, None, Seq(SourceColumn(`tableB`, `b1`)), _),
+              ResolvedAttribute("pid", DataType.LongType, Some("B"), Seq(SourceColumn(`tableB`, `b1`)), _),
               ResolvedAttribute("name", DataType.StringType, Some("A"), Seq(SourceColumn(`tableA`, `a2`)), _)
             ) =>
           ()

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/model/ExpressionTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/model/ExpressionTest.scala
@@ -29,7 +29,7 @@ class ExpressionTest extends AirSpec {
 
     val newExpr = expr.transformExpression {
       case s @ SingleColumn(f: FunctionCall, _, _) if f.functionName == "count" =>
-        s.withAlias("xxx")
+        s.withQualifier("xxx")
     }
 
     newExpr shouldBe SingleColumn(f, Some("xxx"), None)
@@ -67,7 +67,7 @@ class ExpressionTest extends AirSpec {
 
     val newExpr = expr.transformUpExpression {
       case s @ SingleColumn(f: FunctionCall, _, _) if f.functionName == "count" =>
-        s.withAlias("xxx")
+        s.withQualifier("xxx")
     }
 
     newExpr shouldBe SingleColumn(f, Some("xxx"), None)

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/model/ExpressionTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/model/ExpressionTest.scala
@@ -24,16 +24,15 @@ class ExpressionTest extends AirSpec {
     val expr = SingleColumn(
       f,
       None,
-      None,
       None
     )
 
     val newExpr = expr.transformExpression {
-      case s @ SingleColumn(f: FunctionCall, _, _, _) if f.functionName == "count" =>
+      case s @ SingleColumn(f: FunctionCall, _, _) if f.functionName == "count" =>
         s.withAlias("xxx")
     }
 
-    newExpr shouldBe SingleColumn(f, Some("xxx"), None, None)
+    newExpr shouldBe SingleColumn(f, Some("xxx"), None)
   }
 
   test("transform up in breadth-first order") {
@@ -63,16 +62,15 @@ class ExpressionTest extends AirSpec {
     val expr = SingleColumn(
       f,
       None,
-      None,
       None
     )
 
     val newExpr = expr.transformUpExpression {
-      case s @ SingleColumn(f: FunctionCall, _, _, _) if f.functionName == "count" =>
+      case s @ SingleColumn(f: FunctionCall, _, _) if f.functionName == "count" =>
         s.withAlias("xxx")
     }
 
-    newExpr shouldBe SingleColumn(f, Some("xxx"), None, None)
+    newExpr shouldBe SingleColumn(f, Some("xxx"), None)
   }
 
   test("transform up in depth-first order") {

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/model/LogicalPlanTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/model/LogicalPlanTest.scala
@@ -113,7 +113,7 @@ class LogicalPlanTest extends AirSpec {
       s.withAlias("x")
     }
     newPlan.childExpressions.collect {
-      case s: SingleColumn if s.alias == Some("x") => true
+      case s: Attribute if s.alias == Some("x") => true
     }.nonEmpty shouldBe true
   }
 
@@ -123,7 +123,7 @@ class LogicalPlanTest extends AirSpec {
       s.withAlias("x")
     }
     newPlan.collectExpressions {
-      case s: SingleColumn if s.alias == Some("x") => true
+      case s: Attribute if s.alias == Some("x") => true
     }.size shouldBe 2
   }
 
@@ -135,11 +135,11 @@ class LogicalPlanTest extends AirSpec {
     }
 
     newPlan.childExpressions.collect {
-      case s: SingleColumn if s.alias == Some("x0") => true
+      case s: Attribute if s.alias == Some("x0") => true
     }.nonEmpty shouldBe true
 
     newPlan.children.head.childExpressions.collect {
-      case s: SingleColumn if s.alias == Some("x1") => true
+      case s: Attribute if s.alias == Some("x1") => true
     }.nonEmpty shouldBe true
   }
 
@@ -151,11 +151,11 @@ class LogicalPlanTest extends AirSpec {
     }
 
     newPlan.childExpressions.collect {
-      case s: SingleColumn if s.alias == Some("x1") => true
+      case s: Attribute if s.alias == Some("x1") => true
     }.nonEmpty shouldBe true
 
     newPlan.children.head.childExpressions.collect {
-      case s: SingleColumn if s.alias == Some("x0") => true
+      case s: Attribute if s.alias == Some("x0") => true
     }.nonEmpty shouldBe true
   }
 }

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/parser/SQLGeneratorTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/parser/SQLGeneratorTest.scala
@@ -52,29 +52,29 @@ class SQLGeneratorTest extends AirSpec {
   test("print resolved subquery plan") {
     val resolvedPlan = SQLAnalyzer.analyze("select id from (select id from A)", "default", demoCatalog)
     val sql          = SQLGenerator.print(resolvedPlan)
-    sql shouldBe "SELECT id FROM (SELECT id FROM default.A)"
+    sql shouldBe "SELECT id FROM (SELECT A.id FROM default.A)"
   }
 
   test("print resolved UNION subquery plan") {
     val resolvedPlan =
       SQLAnalyzer.analyze("select id from (select id from A union all select id from A)", "default", demoCatalog)
     val sql = SQLGenerator.print(resolvedPlan)
-    sql shouldBe "SELECT id FROM (SELECT id FROM default.A UNION ALL SELECT id FROM default.A)"
+    sql shouldBe "SELECT id FROM (SELECT A.id FROM default.A UNION ALL SELECT A.id FROM default.A)"
   }
 
   test("print resolved CTE plan") {
     val resolvedPlan = SQLAnalyzer.analyze("with p as (select id from A) select * from p", "default", demoCatalog)
     val sql          = SQLGenerator.print(resolvedPlan)
-    sql shouldBe "WITH p AS (SELECT id FROM default.A) SELECT * FROM p"
+    sql shouldBe "WITH p AS (SELECT A.id FROM default.A) SELECT * FROM p"
   }
 
   test("generate aggregation without grouping keys") {
     val resolvedPlan =
       SQLAnalyzer.analyze("select count(1) from A having count(distinct id) > 10", "default", demoCatalog)
-    val sql = SQLGenerator.print(resolvedPlan).toLowerCase
+    val sql = SQLGenerator.print(resolvedPlan)
 
-    sql.contains("group by") shouldBe false
-    sql.contains("having count(distinct id) > 10") shouldBe true
+    sql.contains("GROUP BY") shouldBe false
+    sql.contains("HAVING count(DISTINCT A.id) > 10") shouldBe true
   }
 
   test("generate select with column alias") {
@@ -82,7 +82,7 @@ class SQLGeneratorTest extends AirSpec {
       SQLAnalyzer.analyze("select id as xid from A", "default", demoCatalog)
     val sql = SQLGenerator.print(resolvedPlan).toLowerCase
 
-    sql.contains("select id as xid") shouldBe true
+    sql.contains("select a.id as xid") shouldBe true
   }
 
   test("generate join with USING") {

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/parser/SQLGeneratorTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/parser/SQLGeneratorTest.scala
@@ -90,7 +90,7 @@ class SQLGeneratorTest extends AirSpec {
       SQLAnalyzer.analyze("select id from A inner join A as B using (id)", "default", demoCatalog)
     val sql = SQLGenerator.print(resolvedPlan).toLowerCase
 
-    sql.contains("on a.id = b.id") shouldBe true
+    sql.contains("using (id)") shouldBe true
   }
 
   test("generate join with keys with qualifier") {

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/parser/SQLGeneratorTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/parser/SQLGeneratorTest.scala
@@ -108,8 +108,6 @@ class SQLGeneratorTest extends AirSpec {
       )
 
     val sql = SQLGenerator.print(resolvedPlan)
-    info(sql)
-    info(resolvedPlan.pp)
     sql.contains("ON t1.id = t2.id") shouldBe true
   }
 

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/parser/SQLGeneratorTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/parser/SQLGeneratorTest.scala
@@ -46,26 +46,26 @@ class SQLGeneratorTest extends AirSpec {
   test("print resolved plan") {
     val resolvedPlan = SQLAnalyzer.analyze("select * from A", "default", demoCatalog)
     val sql          = SQLGenerator.print(resolvedPlan)
-    sql shouldBe "SELECT * FROM default.A"
+    sql shouldBe "SELECT * FROM A"
   }
 
   test("print resolved subquery plan") {
     val resolvedPlan = SQLAnalyzer.analyze("select id from (select id from A)", "default", demoCatalog)
     val sql          = SQLGenerator.print(resolvedPlan)
-    sql shouldBe "SELECT id FROM (SELECT A.id FROM default.A)"
+    sql shouldBe "SELECT id FROM (SELECT id FROM A)"
   }
 
   test("print resolved UNION subquery plan") {
     val resolvedPlan =
       SQLAnalyzer.analyze("select id from (select id from A union all select id from A)", "default", demoCatalog)
     val sql = SQLGenerator.print(resolvedPlan)
-    sql shouldBe "SELECT id FROM (SELECT A.id FROM default.A UNION ALL SELECT A.id FROM default.A)"
+    sql shouldBe "SELECT id FROM (SELECT id FROM A UNION ALL SELECT id FROM A)"
   }
 
   test("print resolved CTE plan") {
     val resolvedPlan = SQLAnalyzer.analyze("with p as (select id from A) select * from p", "default", demoCatalog)
     val sql          = SQLGenerator.print(resolvedPlan)
-    sql shouldBe "WITH p AS (SELECT A.id FROM default.A) SELECT * FROM p"
+    sql shouldBe "WITH p AS (SELECT id FROM A) SELECT * FROM p"
   }
 
   test("generate aggregation without grouping keys") {
@@ -74,7 +74,7 @@ class SQLGeneratorTest extends AirSpec {
     val sql = SQLGenerator.print(resolvedPlan)
 
     sql.contains("GROUP BY") shouldBe false
-    sql.contains("HAVING count(DISTINCT A.id) > 10") shouldBe true
+    sql.contains("HAVING count(DISTINCT id) > 10") shouldBe true
   }
 
   test("generate select with column alias") {
@@ -82,7 +82,7 @@ class SQLGeneratorTest extends AirSpec {
       SQLAnalyzer.analyze("select id as xid from A", "default", demoCatalog)
     val sql = SQLGenerator.print(resolvedPlan)
 
-    sql.contains("SELECT id AS xid FROM default.A") shouldBe true
+    sql.contains("SELECT id AS xid FROM A") shouldBe true
   }
 
   test("generate join with USING") {

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/parser/SQLGeneratorTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/parser/SQLGeneratorTest.scala
@@ -80,9 +80,9 @@ class SQLGeneratorTest extends AirSpec {
   test("generate select with column alias") {
     val resolvedPlan =
       SQLAnalyzer.analyze("select id as xid from A", "default", demoCatalog)
-    val sql = SQLGenerator.print(resolvedPlan).toLowerCase
+    val sql = SQLGenerator.print(resolvedPlan)
 
-    sql.contains("select a.id as xid") shouldBe true
+    sql.contains("SELECT id AS xid FROM default.A") shouldBe true
   }
 
   test("generate join with USING") {
@@ -108,6 +108,7 @@ class SQLGeneratorTest extends AirSpec {
       )
 
     val sql = SQLGenerator.print(resolvedPlan)
+    warn(sql)
     sql.contains("ON t1.id = t2.id") shouldBe true
   }
 

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/parser/SQLGeneratorTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/parser/SQLGeneratorTest.scala
@@ -93,4 +93,24 @@ class SQLGeneratorTest extends AirSpec {
     sql.contains("on a.id = b.id") shouldBe true
   }
 
+  test("generate join with keys with qualifier") {
+    val resolvedPlan =
+      SQLAnalyzer.analyze(
+        """select count(*)
+          |  from
+          |    (select * from A) t1
+          |  join
+          |    (select * from A) t2
+          |  on t1.id = t2.id
+          |""".stripMargin,
+        "default",
+        demoCatalog
+      )
+
+    val sql = SQLGenerator.print(resolvedPlan)
+    info(sql)
+    info(resolvedPlan.pp)
+    sql.contains("ON t1.id = t2.id") shouldBe true
+  }
+
 }

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/parser/SQLGeneratorTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/parser/SQLGeneratorTest.scala
@@ -108,7 +108,6 @@ class SQLGeneratorTest extends AirSpec {
       )
 
     val sql = SQLGenerator.print(resolvedPlan)
-    warn(sql)
     sql.contains("ON t1.id = t2.id") shouldBe true
   }
 

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ val targetScalaVersions = SCALA_3 :: uptoScala2
 // Add this for using snapshot versions
 // ThisBuild / resolvers += Resolver.sonatypeRepo("snapshots")
 
-val AIRSPEC_VERSION                 = "22.12.4"
+val AIRSPEC_VERSION                 = "22.12.5"
 val SCALACHECK_VERSION              = "1.17.0"
 val MSGPACK_VERSION                 = "0.9.3"
 val SCALA_PARSER_COMBINATOR_VERSION = "2.1.1"

--- a/build.sbt
+++ b/build.sbt
@@ -133,8 +133,11 @@ ThisBuild / publishTo := sonatypePublishToBundle.value
 
 val jsBuildSettings = Seq[Setting[_]](
   // #2117 For using java.util.UUID.randomUUID() in Scala.js
-  libraryDependencies += ("org.scala-js" %%% "scalajs-java-securerandom" % "1.0.0" % Test)
-    .cross(CrossVersion.for3Use2_13),
+  libraryDependencies ++= Seq(
+    ("org.scala-js" %%% "scalajs-java-securerandom" % "1.0.0" % Test).cross(CrossVersion.for3Use2_13),
+    // TODO It should be included in AirSpec
+    "org.scala-js" %%% "scala-js-macrotask-executor" % "1.1.0" % Test
+  ),
   coverageEnabled := false
 )
 


### PR DESCRIPTION
## Purpose
- Propagate qualifiers (table name) properly so that join keys can be resolved correctly.
- Merge the common logic for Attribute handling (AllColumn, SingleColumn, MultiColumn, Unresolved/ResolvedAttribute)

## Major changes
- Renamed MultiColumn -> MultiSourceColumn to clarify the meaning
- TypeResolver.resolveTableScan -> Do not add qualifiers to ResolvedAttribute. Qualifiers can be added if they are given in the original SQL
- Fixed Join outputAttributes: 
  - JoinUsing(keys, ..): merge join keys as MultiSourceColumn. Added ResolveJoinUsing(...) 
  - JoinOn(cond): Output all input child relation outputs
- Changed Attribute class structure
  - Add common methods (e.g., qualifier, withQualifier, withAlias, etc.)
  - ResolvedAttribute is changed to take a single source column because we can merge multiple ResolvedAttributes with MultiSourceColumn
  - Removed alias parameters. Added Alias expression instead for simplicity
  - Moved matches, matched methods into Attribute base class
    - Use ColumnPath(database, table, column) pairs to properly match columns. With this change, Attributes belonging to different tables can be found as expected
  - UnresolvedAttribute now can take a qualifier given in the original SQL
  - Improved toString to distinguish different Attribute types:
    - SingleColumn:   `(fullName):(dataType) := (expr)`
    - MultSourceColumn: `(fullName):(dataType) := { c1, c2, ...}`
    - Alias: `<fullName> := (expr)`
    - ResolvedAttribute `*(fullName):(dataType) <- (sourceColumn)` 
- Simplified Set operation's `outputAttributes` method by using transpose and the newly added Attribute methods

## TypeResolver changes
- TypeResolver
  - Fixed join, sort, and projection column resolvers to use new Attribute
  - Extracted attribute match and merge logic to Attribute class methods. 
  - When resolving attributes, if there is a source column without any change, propagate it to the resolved attribute
  - Optimize nested SingleColumn(ResolvedAttribute, ...) as a single ResolvedAttribute
  - Reorder resolver rules. GroupBy, SortBy need to be processed last after resolving select items

## Minor changes
- SQLGenerator
  - Changed the behavior within SELECT ... and other part (e.g., GROUP BY ...).   In generating select items, printSelectItem will be used first to avoid using alias (e.g., c as a1) in ORDER BY, GROUP BY clauses.