### PR TITLE
airspec: Include scala-js-macrotas-executor explicitely for Scala.js

### DIFF
--- a/airspec/build.sbt
+++ b/airspec/build.sbt
@@ -350,7 +350,9 @@ lazy val airspec =
       Compile / packageSrc / mappings ++= (airspecDepsJS / Compile / packageSrc / mappings).value,
       libraryDependencies ++= Seq(
         ("org.scala-js"        %% "scalajs-test-interface" % scalaJSVersion).cross(CrossVersion.for3Use2_13),
-        ("org.portable-scala" %%% "portable-scala-reflect" % "1.1.2").cross(CrossVersion.for3Use2_13)
+        ("org.portable-scala" %%% "portable-scala-reflect" % "1.1.2").cross(CrossVersion.for3Use2_13),
+        // Needed to be explicitly included here for running Scala.js tests successfully
+        "org.scala-js" %%% "scala-js-macrotask-executor" % "1.1.0"
       )
     )
     // This should be Optional dependency, but using Provided dependency for bloop which doesn't support Optional.


### PR DESCRIPTION
AirSpec 22.12.5 fails to run tests in Scala.js because this dependency is missing