### PR TITLE
airframe-sql: Fix Expression.traverseExpression for Attribute nodes

### DIFF
--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
@@ -404,6 +404,7 @@ object TypeResolver extends LogSupport {
         case Some(columnPath) =>
           resolvedAttributes.foreach {
             case a: Attribute =>
+              // warn(s"lookup ${columnPath} in ${a} ===> ${a.matched(columnPath)}")
               resolvedExprs ++= a.matched(columnPath)
             case _ =>
           }

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
@@ -248,6 +248,10 @@ trait Attribute extends LeafExpression with LogSupport {
     }
   }
 
+  /**
+    * Sub Attributes used to generate this Attribute
+    * @return
+    */
   def inputColumns: Seq[Attribute] = {
     children.map {
       case a: Attribute  => a
@@ -448,8 +452,17 @@ object Expression {
       nodeLocation: Option[NodeLocation]
   ) extends Attribute
       with LogSupport {
-    override def name: String              = "*"
-    override def children: Seq[Expression] = columns.getOrElse(Seq.empty)
+    override def name: String = "*"
+
+    override def children: Seq[Expression] = {
+      // AllColumns is a reference to the input attributes.
+      // Return empty so as not to traverse children from here.
+      Seq.empty
+    }
+    override def inputColumns: Seq[Attribute] = {
+      columns.getOrElse(Seq.empty)
+    }
+
     override def dataType: DataType = {
       columns
         .map(cols => EmbeddedRecordType(cols.map(x => NamedType(x.name, x.dataType))))
@@ -458,10 +471,6 @@ object Expression {
 
     override def withQualifier(newQualifier: Option[String]): Attribute = {
       this.copy(qualifier = newQualifier)
-    }
-
-    override def inputColumns: Seq[Attribute] = {
-      columns.getOrElse(Seq.empty)
     }
 
     override def toString = {
@@ -558,8 +567,19 @@ object Expression {
   ) extends Attribute {
     require(inputs.nonEmpty, s"The inputs of MultiSourceColumn should not be empty: ${this}")
 
-    override def toString: String          = s"${fullName}:${dataTypeName} := {${inputs.mkString(", ")}}"
-    override def children: Seq[Expression] = inputs
+    override def toString: String = s"${fullName}:${dataTypeName} := {${inputs.mkString(", ")}}"
+
+    override def inputColumns: Seq[Attribute] = {
+      inputs.map {
+        case a: Attribute => a
+        case e: Expression =>
+          SingleColumn(e, qualifier, e.nodeLocation)
+      }
+    }
+    override def children: Seq[Expression] = {
+      // MultiSourceColumn is a reference to the multiple columns. Do not traverse here
+      Seq.empty
+    }
 
     override def sqlExpr: String = fullName
 

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
@@ -139,7 +139,8 @@ sealed trait Expression extends TreeNode[Expression] with Product {
     if (rule.isDefinedAt(this)) {
       rule.apply(this)
     }
-    productIterator.foreach(recursiveTraverse)
+    // Unlike transform, this will traverse the selected children by the Expression
+    children.foreach(recursiveTraverse)
   }
 
   def collectExpressions(cond: PartialFunction[Expression, Boolean]): List[Expression] = {

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/ResolvedPlan.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/ResolvedPlan.scala
@@ -15,6 +15,7 @@ package wvlet.airframe.sql.model
 
 import wvlet.airframe.sql.analyzer.QuerySignatureConfig
 import wvlet.airframe.sql.catalog.{Catalog, DataType}
+import wvlet.airframe.sql.model.Expression.Identifier
 import wvlet.airframe.sql.model.LogicalPlan.Relation
 import wvlet.log.LogSupport
 

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLInterpreter.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLInterpreter.scala
@@ -91,12 +91,12 @@ class SQLInterpreter(withNodeLocation: Boolean = true) extends SqlBaseBaseVisito
   }
 
   override def visitNamedQuery(ctx: NamedQueryContext): WithQuery = {
-    val name = visitIdentifier(ctx.name)
+    val name = visitIdentifier(ctx.name).toResolved
     val columnAliases = Option(ctx.columnAliases()).map { x =>
       x.identifier()
         .asScala
         .map { i =>
-          visitIdentifier(i)
+          visitIdentifier(i).toResolved
         }
         .toSeq
     }
@@ -335,7 +335,8 @@ class SQLInterpreter(withNodeLocation: Boolean = true) extends SqlBaseBaseVisito
     ctx.identifier() match {
       case i: IdentifierContext =>
         val columnNames = Option(ctx.columnAliases()).map(_.identifier().asScala.map(_.getText).toSeq)
-        AliasedRelation(r, visitIdentifier(i), columnNames, getLocation(ctx))
+        // table alias name is always resolved identifier
+        AliasedRelation(r, visitIdentifier(i).toResolved, columnNames, getLocation(ctx))
       case other =>
         r
     }

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
@@ -16,33 +16,11 @@ package wvlet.airframe.sql.analyzer
 import wvlet.airframe.sql.catalog.Catalog._
 import wvlet.airframe.sql.catalog.{Catalog, DataType, InMemoryCatalog}
 import wvlet.airframe.sql.model.Expression._
-import wvlet.airframe.sql.model.LogicalPlan.{
-  Aggregate,
-  Distinct,
-  Except,
-  Filter,
-  InnerJoin,
-  Intersect,
-  Join,
-  Project,
-  Query,
-  Sort,
-  With
-}
-import wvlet.airframe.sql.model.{
-  Attribute,
-  CTERelationRef,
-  ColumnPath,
-  Expression,
-  LogicalPlan,
-  NodeLocation,
-  ResolvedAttribute,
-  SourceColumn
-}
-import wvlet.airframe.sql.parser.{SQLGenerator, SQLParser}
+import wvlet.airframe.sql.model.LogicalPlan._
+import wvlet.airframe.sql.model._
 import wvlet.airframe.sql.{SQLError, SQLErrorCode}
 import wvlet.airspec.AirSpec
-import wvlet.log.Logger
+import wvlet.airspec.spi.AssertionFailure
 
 class TypeResolverTest extends AirSpec with ResolverTestHelper {
 
@@ -153,7 +131,7 @@ class TypeResolverTest extends AirSpec with ResolverTestHelper {
   }
 
   test("resolve set operations") {
-    test("u1: resolve union") {
+    test("q1: resolve union") {
       val p = analyze("select id from A union all select id from B")
       p.inputAttributes shouldBe List(ra1, ra2, rb1, rb2)
       p.outputAttributes shouldBe List(
@@ -161,7 +139,7 @@ class TypeResolverTest extends AirSpec with ResolverTestHelper {
       )
     }
 
-    test("u2: resolve union from the same source") {
+    test("q2: resolve union from the same source") {
       val p = analyze("select id from A union all select id from A")
       p.inputAttributes shouldBe List(ra1, ra2, ra1, ra2)
       p.outputAttributes shouldBe List(
@@ -169,16 +147,13 @@ class TypeResolverTest extends AirSpec with ResolverTestHelper {
       )
     }
 
-    test("resolve union with select *") {
+    test("q3: resolve union with select *") {
       val p = analyze("select * from A union all select * from B")
       p.inputAttributes shouldBe List(ra1, ra2, rb1, rb2)
       p.outputAttributes shouldMatch {
         case Seq(
-              MultiSourceColumn(
-                Seq(AllColumns(None, Some(Seq(`ra1`, `ra2`)), _), AllColumns(None, Some(Seq(`rb1`, `rb2`)), _)),
-                None,
-                _
-              )
+              MultiSourceColumn(Seq(`ra1`, `rb1`), None, _),
+              MultiSourceColumn(Seq(`ra2`, `rb2`), None, _)
             ) =>
       }
     }
@@ -187,16 +162,23 @@ class TypeResolverTest extends AirSpec with ResolverTestHelper {
       val p = analyze("select * from (select * from A union all select * from B)")
       p.inputAttributes shouldMatch {
         case Seq(
-              MultiSourceColumn(
-                Seq(
-                  AllColumns(None, Some(Seq(`ra1`, `ra2`)), _),
-                  AllColumns(None, Some(Seq(`rb1`, `rb2`)), _)
-                ),
+              MultiSourceColumn(Seq(`ra1`, `rb1`), None, _),
+              MultiSourceColumn(Seq(`ra2`, `rb2`), None, _)
+            ) =>
+      }
+      p.outputAttributes shouldMatch {
+        case Seq(
+              AllColumns(
                 None,
+                Some(
+                  Seq(
+                    MultiSourceColumn(Seq(`ra1`, `rb1`), None, _),
+                    MultiSourceColumn(Seq(`ra2`, `rb2`), None, _)
+                  )
+                ),
                 _
               )
             ) =>
-          ()
       }
     }
 
@@ -213,6 +195,23 @@ class TypeResolverTest extends AirSpec with ResolverTestHelper {
       }
     }
 
+    test("ru2a: resolve union with different column aliases") {
+      val p = analyze("select p1 from (select id as p1 from A union all select id from B)")
+      p.inputAttributes shouldMatch { case Seq(m @ MultiSourceColumn(Seq(c1, c2), None, _)) =>
+        c1 shouldBe ra1.withAlias("p1")
+        c2 shouldBe rb1
+      }
+      p.outputAttributes shouldMatch { case Seq(MultiSourceColumn(Seq(c1, c2), None, _)) =>
+        c1 shouldBe ra1.withAlias("p1")
+        c2 shouldBe rb1
+      }
+    }
+    test(s"ru2b: should fail to resolve overridden column name (p2) via union") {
+      intercept[AssertionFailure] {
+        analyze("select p2 from (select id as p1 from A union all select id as p2 from B)")
+      }
+    }
+
     test("ru3: resolve union with column alias and qualifier") {
       val p = analyze("select q1.p1 from (select id as p1 from A union all select id as p1 from B) q1")
       p.inputAttributes shouldMatch { case Seq(m @ MultiSourceColumn(Seq(c1, c2), _, _)) =>
@@ -221,8 +220,8 @@ class TypeResolverTest extends AirSpec with ResolverTestHelper {
         c2 shouldBe rb1.withAlias("p1")
       }
       p.outputAttributes shouldMatch { case Seq(m @ MultiSourceColumn(Seq(c1, c2), Some("q1"), _)) =>
-        c1 shouldBe ra1.withAlias("p1").withQualifier("q1")
-        c2 shouldBe rb1.withAlias("p1").withQualifier("q1")
+        c1 shouldBe ra1.withAlias("p1")
+        c2 shouldBe rb1.withAlias("p1")
       }
     }
 


### PR DESCRIPTION
Traverse only given children in traverseExpressions so as not to traverse references in AllColumns and MultiSourceColumns
