### PR TITLE
airframe-sql: Fix the resolver of set relations

### DIFF
--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
@@ -404,6 +404,7 @@ object TypeResolver extends LogSupport {
         case Some(columnPath) =>
           resolvedAttributes.foreach {
             case a: Attribute =>
+              // warn(s"lookup ${columnPath} in ${a} ===> ${a.matched(columnPath)}")
               resolvedExprs ++= a.matched(columnPath)
             case _ =>
           }

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
@@ -262,12 +262,7 @@ trait Attribute extends LeafExpression with LogSupport {
     */
   def matchesWith(columnPath: ColumnPath): Boolean = {
     def matchesWith(columnName: String): Boolean = {
-      inputColumns.exists {
-        case a: AllColumns =>
-          a.inputColumns.exists(_.name == columnName)
-        case a: Attribute =>
-          a.name == columnName
-      }
+      inputColumns.exists(_.name == columnName)
     }
 
     columnPath.table match {
@@ -285,15 +280,15 @@ trait Attribute extends LeafExpression with LogSupport {
     */
   def matched(columnPath: ColumnPath): Option[Attribute] = {
     def findMatched(columnName: String): Seq[Attribute] = {
-      if (this.name == columnName) {
-        Seq(this)
-      } else {
-        inputColumns.collect {
-          case a: AllColumns =>
-            a.inputColumns.filter(_.name == columnName)
-          case a: Attribute if a.name == columnName =>
+      this match {
+        case a: AllColumns =>
+          a.inputColumns.filter(_.name == columnName)
+        case a: Attribute =>
+          if (a.name == columnName) {
             Seq(a)
-        }.flatten
+          } else {
+            Seq.empty
+          }
       }
     }
 
@@ -383,7 +378,15 @@ object Expression {
 
   sealed trait Identifier extends LeafExpression {
     def value: String
-    override def attributeName: String = value
+    override def attributeName: String  = value
+    override lazy val resolved: Boolean = false
+    def toResolved: ResolvedIdentifier  = ResolvedIdentifier(this)
+  }
+  case class ResolvedIdentifier(id: Identifier) extends Identifier {
+    override def value: String                      = id.value
+    override def nodeLocation: Option[NodeLocation] = id.nodeLocation
+    override def sqlExpr: String                    = id.sqlExpr
+    override lazy val resolved: Boolean             = true
   }
   case class DigitId(value: String, nodeLocation: Option[NodeLocation]) extends Identifier {
     override def sqlExpr: String  = value

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
@@ -262,7 +262,14 @@ trait Attribute extends LeafExpression with LogSupport {
     */
   def matchesWith(columnPath: ColumnPath): Boolean = {
     def matchesWith(columnName: String): Boolean = {
-      inputColumns.exists(_.name == columnName)
+      this match {
+        case a: AllColumns =>
+          a.inputColumns.exists(_.name == columnName)
+        case a: Attribute if a.name == columnName =>
+          true
+        case _ =>
+          false
+      }
     }
 
     columnPath.table match {
@@ -283,12 +290,10 @@ trait Attribute extends LeafExpression with LogSupport {
       this match {
         case a: AllColumns =>
           a.inputColumns.filter(_.name == columnName)
-        case a: Attribute =>
-          if (a.name == columnName) {
-            Seq(a)
-          } else {
-            Seq.empty
-          }
+        case a: Attribute if a.name == columnName =>
+          Seq(a)
+        case _ =>
+          Seq.empty
       }
     }
 

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
@@ -253,12 +253,7 @@ trait Attribute extends LeafExpression with LogSupport {
     * Sub Attributes used to generate this Attribute
     * @return
     */
-  def inputColumns: Seq[Attribute] = {
-    children.map {
-      case a: Attribute  => a
-      case u: Expression => SingleColumn(u, qualifier, u.nodeLocation)
-    }
-  }
+  def inputColumns: Seq[Attribute]
 
   /**
     * Return true if this Attribute matches with a given column path
@@ -290,12 +285,16 @@ trait Attribute extends LeafExpression with LogSupport {
     */
   def matched(columnPath: ColumnPath): Option[Attribute] = {
     def findMatched(columnName: String): Seq[Attribute] = {
-      inputColumns.collect {
-        case a: AllColumns =>
-          a.inputColumns.filter(_.name == columnName)
-        case a: Attribute if a.name == columnName =>
-          Seq(a)
-      }.flatten
+      if (this.name == columnName) {
+        Seq(this)
+      } else {
+        inputColumns.collect {
+          case a: AllColumns =>
+            a.inputColumns.filter(_.name == columnName)
+          case a: Attribute if a.name == columnName =>
+            Seq(a)
+        }.flatten
+      }
     }
 
     val result: Seq[Attribute] = columnPath.table match {

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
@@ -13,6 +13,7 @@
  */
 package wvlet.airframe.sql.model
 import wvlet.airframe.sql.analyzer.{QuerySignatureConfig, TypeResolver}
+import wvlet.log.LogSupport
 
 import java.util.UUID
 
@@ -741,7 +742,7 @@ object LogicalPlan {
 // Where clause specifies join criteria
   case object ImplicitJoin extends JoinType("J")
 
-  sealed trait SetOperation extends Relation {
+  sealed trait SetOperation extends Relation with LogSupport {
     override def children: Seq[Relation]
 
     override def outputAttributes: Seq[Attribute] = mergeOutputAttributes
@@ -757,7 +758,7 @@ object LogicalPlan {
       sameColumnList.map { columns =>
         val head       = columns.head
         val qualifiers = columns.map(_.qualifier).distinct
-        MultiSourceColumn(
+        val col = MultiSourceColumn(
           inputs = columns.toSeq,
           qualifier = {
             // If all of the qualifiers are the same, use it.
@@ -769,6 +770,7 @@ object LogicalPlan {
           },
           None
         ).withAlias(head.name)
+        col
       }.toSeq
     }
   }

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
@@ -748,8 +748,7 @@ object LogicalPlan {
     override def outputAttributes: Seq[Attribute] = mergeOutputAttributes
     protected def mergeOutputAttributes: Seq[Attribute] = {
       // Collect all input attributes
-      val outputAttributes: IndexedSeq[IndexedSeq[Attribute]] =
-        children.map(_.outputAttributes.toIndexedSeq).toIndexedSeq
+      val outputAttributes: Seq[Seq[Attribute]] = children.flatMap(_.outputAttributes.map(_.inputColumns))
 
       // Transpose a set of relation columns into a list of same columns
       // relations: (Ra(a1, a2, ...), Rb(b1, b2, ...))
@@ -769,7 +768,9 @@ object LogicalPlan {
             }
           },
           None
-        ).withAlias(head.name)
+        )
+          // In set operations, if different column names are merged into one column, the first column name will be used
+          .withAlias(head.name)
         col
       }.toSeq
     }

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/ResolvedPlan.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/ResolvedPlan.scala
@@ -113,4 +113,3 @@ case class CTERelationRef(name: String, outputColumns: Seq[Attribute], nodeLocat
   }
   override def outputAttributes: Seq[Attribute] = outputColumns
 }
-

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/ResolvedPlan.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/ResolvedPlan.scala
@@ -15,6 +15,7 @@ package wvlet.airframe.sql.model
 
 import wvlet.airframe.sql.analyzer.QuerySignatureConfig
 import wvlet.airframe.sql.catalog.{Catalog, DataType}
+import wvlet.airframe.sql.model.Expression.Identifier
 import wvlet.airframe.sql.model.LogicalPlan.Relation
 import wvlet.log.LogSupport
 
@@ -112,3 +113,4 @@ case class CTERelationRef(name: String, outputColumns: Seq[Attribute], nodeLocat
   }
   override def outputAttributes: Seq[Attribute] = outputColumns
 }
+

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLInterpreter.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLInterpreter.scala
@@ -91,12 +91,12 @@ class SQLInterpreter(withNodeLocation: Boolean = true) extends SqlBaseBaseVisito
   }
 
   override def visitNamedQuery(ctx: NamedQueryContext): WithQuery = {
-    val name = visitIdentifier(ctx.name)
+    val name = visitIdentifier(ctx.name).toResolved
     val columnAliases = Option(ctx.columnAliases()).map { x =>
       x.identifier()
         .asScala
         .map { i =>
-          visitIdentifier(i)
+          visitIdentifier(i).toResolved
         }
         .toSeq
     }
@@ -335,7 +335,8 @@ class SQLInterpreter(withNodeLocation: Boolean = true) extends SqlBaseBaseVisito
     ctx.identifier() match {
       case i: IdentifierContext =>
         val columnNames = Option(ctx.columnAliases()).map(_.identifier().asScala.map(_.getText).toSeq)
-        AliasedRelation(r, visitIdentifier(i), columnNames, getLocation(ctx))
+        // table alias name is always resolved identifier
+        AliasedRelation(r, visitIdentifier(i).toResolved, columnNames, getLocation(ctx))
       case other =>
         r
     }

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
@@ -152,11 +152,8 @@ class TypeResolverTest extends AirSpec with ResolverTestHelper {
       p.inputAttributes shouldBe List(ra1, ra2, rb1, rb2)
       p.outputAttributes shouldMatch {
         case Seq(
-              MultiSourceColumn(
-                Seq(AllColumns(None, Some(Seq(`ra1`, `ra2`)), _), AllColumns(None, Some(Seq(`rb1`, `rb2`)), _)),
-                None,
-                _
-              )
+              MultiSourceColumn(Seq(`ra1`, `rb1`), None, _),
+              MultiSourceColumn(Seq(`ra2`, `rb2`), None, _)
             ) =>
       }
     }
@@ -165,16 +162,23 @@ class TypeResolverTest extends AirSpec with ResolverTestHelper {
       val p = analyze("select * from (select * from A union all select * from B)")
       p.inputAttributes shouldMatch {
         case Seq(
-              MultiSourceColumn(
-                Seq(
-                  AllColumns(None, Some(Seq(`ra1`, `ra2`)), _),
-                  AllColumns(None, Some(Seq(`rb1`, `rb2`)), _)
-                ),
+              MultiSourceColumn(Seq(`ra1`, `rb1`), None, _),
+              MultiSourceColumn(Seq(`ra2`, `rb2`), None, _)
+            ) =>
+      }
+      p.outputAttributes shouldMatch {
+        case Seq(
+              AllColumns(
                 None,
+                Some(
+                  Seq(
+                    MultiSourceColumn(Seq(`ra1`, `rb1`), None, _),
+                    MultiSourceColumn(Seq(`ra2`, `rb2`), None, _)
+                  )
+                ),
                 _
               )
             ) =>
-          ()
       }
     }
 


### PR DESCRIPTION
- Fixed input/output attributes of set operations 
- Added ResolvedIdentifier to to make Identifier unresolved at the beginning. With this change, we can detect unresolved identifier (p2) in this case:
```scala    
    test(s"ru2b: should fail to resolve overridden column name (p2) via union") {
      intercept[AssertionFailure] {
        analyze("select p2 from (select id as p1 from A union all select id as p2 from B)")
      }
    }
```
- Fixed some union query tests 