### PR TITLE
airframe-http-codegen: Scala 3 support

### DIFF
--- a/airframe-http-codegen/src/test/scala-2/wvlet/airframe/http/codegen/GenericServiceTest.scala
+++ b/airframe-http-codegen/src/test/scala-2/wvlet/airframe/http/codegen/GenericServiceTest.scala
@@ -14,6 +14,7 @@
 package wvlet.airframe.http.codegen
 import example.generic.{GenericRequestService, GenericService}
 import wvlet.airframe.http.HttpMessage.{Request, Response}
+import wvlet.airframe.http.Router
 import wvlet.airspec.AirSpec
 
 import scala.concurrent.Future
@@ -22,8 +23,7 @@ import scala.concurrent.Future
   */
 class GenericServiceTest extends AirSpec {
 
-  private val router =
-    RouteScanner.buildRouter(Seq(classOf[GenericService[Future]]))
+  private val router = RouteScanner.buildRouter(Seq(classOf[GenericService[Future]]))
 
   test("support F and Future return values in async clients") {
     debug(router)

--- a/airframe-http-codegen/src/test/scala/example/generic/GenericService.scala
+++ b/airframe-http-codegen/src/test/scala/example/generic/GenericService.scala
@@ -31,7 +31,7 @@ trait GenericService[F[_]] {
   def ops(in: String): Future[Response]
 
   @Endpoint(path = "/v1/hello_ops2")
-  def ops2(in: String): F[Response]
+  def ops2(in2: String): F[Response]
 
 }
 

--- a/airframe-http-codegen/src/test/scala/wvlet/airframe/http/codegen/GrpcClientGeneratorTest.scala
+++ b/airframe-http-codegen/src/test/scala/wvlet/airframe/http/codegen/GrpcClientGeneratorTest.scala
@@ -14,6 +14,7 @@
 package wvlet.airframe.http.codegen
 import example.grpc.{AliasTest, Greeter}
 import example.rpc.RPCExample
+import wvlet.airframe.http.Router
 import wvlet.airspec.AirSpec
 
 /**
@@ -22,7 +23,11 @@ class GrpcClientGeneratorTest extends AirSpec {
 
   test("generate sync gRPC client") {
     val code = HttpCodeGenerator.generate(
-      RouteScanner.buildRouter(Seq(classOf[RPCExample])),
+      if (isScala3) {
+        Router.of[RPCExample]
+      } else {
+        RouteScanner.buildRouter(Seq(classOf[RPCExample]))
+      },
       HttpClientGeneratorConfig("example.api:grpc:example.api.client")
     )
     debug(code)
@@ -30,7 +35,11 @@ class GrpcClientGeneratorTest extends AirSpec {
 
   test("generate gRPC client") {
     val code = HttpCodeGenerator.generate(
-      RouteScanner.buildRouter(Seq(classOf[Greeter])),
+      if (isScala3) {
+        Router.of[Greeter]
+      } else {
+        RouteScanner.buildRouter(Seq(classOf[Greeter]))
+      },
       HttpClientGeneratorConfig("example.grpc:grpc")
     )
     debug(code)
@@ -38,7 +47,11 @@ class GrpcClientGeneratorTest extends AirSpec {
 
   test("resolve alias types") {
     val code = HttpCodeGenerator.generate(
-      RouteScanner.buildRouter(Seq(classOf[AliasTest])),
+      if (isScala3) {
+        Router.of[AliasTest]
+      } else {
+        RouteScanner.buildRouter(Seq(classOf[AliasTest]))
+      },
       HttpClientGeneratorConfig("example.grpc:grpc")
     )
     debug(code)

--- a/airframe-http-codegen/src/test/scala/wvlet/airframe/http/codegen/HttpClientGeneratorTest.scala
+++ b/airframe-http-codegen/src/test/scala/wvlet/airframe/http/codegen/HttpClientGeneratorTest.scala
@@ -21,8 +21,12 @@ import wvlet.airspec.AirSpec
 /**
   */
 class HttpClientGeneratorTest extends AirSpec {
-  val router =
+  private val router = if (isScala3) {
+    // In Scala 3, reflection-based router will not be supported
+    Router.add[ResourceApi].add[QueryApi].add[BookApi]
+  } else {
     RouteScanner.buildRouter(Seq(classOf[ResourceApi], classOf[QueryApi], classOf[BookApi]))
+  }
 
   test("build router") {
     debug(router)

--- a/airframe-http-codegen/src/test/scala/wvlet/airframe/http/codegen/RPCClientGeneratorTest.scala
+++ b/airframe-http-codegen/src/test/scala/wvlet/airframe/http/codegen/RPCClientGeneratorTest.scala
@@ -14,10 +14,15 @@
 package wvlet.airframe.http.codegen
 
 import example.rpc.RPCExample
+import wvlet.airframe.http.Router
 import wvlet.airspec.AirSpec
 
 class RPCClientGeneratorTest extends AirSpec {
-  private val router = RouteScanner.buildRouter(Seq(classOf[RPCExample]))
+  private val router = if (isScala3) {
+    Router.of[RPCExample]
+  } else {
+    RouteScanner.buildRouter(Seq(classOf[RPCExample]))
+  }
 
   test("generate RPC client") {
     val config = HttpClientGeneratorConfig("example.rpc:rpc")

--- a/airframe-http-codegen/src/test/scala/wvlet/airframe/http/openapi/OpenAPITest.scala
+++ b/airframe-http-codegen/src/test/scala/wvlet/airframe/http/openapi/OpenAPITest.scala
@@ -291,29 +291,6 @@ class OpenAPITest extends AirSpec {
         |          required: true
         |          schema:
         |            type: string""".stripMargin,
-      """  /v1/get3/{id}:
-        |    get:
-        |      summary: get3
-        |      description: get3
-        |      operationId: get3
-        |      parameters:
-        |        - name: id
-        |          in: path
-        |          required: true
-        |          schema:
-        |            type: integer
-        |            format: int32
-        |        - name: p1
-        |          in: query
-        |          required: true
-        |          schema:
-        |            type: string
-        |        - name: p2
-        |          in: query
-        |          required: false
-        |          schema:
-        |            type: string
-        |            default: foo""".stripMargin,
       """  /v1/post1:
         |    post:
         |      summary: post1
@@ -549,6 +526,47 @@ class OpenAPITest extends AirSpec {
       } catch {
         case e: Throwable =>
           fail(s"Missing YAML fragment for:\n${x}")
+      }
+    }
+
+    test("optional method parameter") {
+      if (isScala3) {
+        pending("Need to find default method parameter in Scala 3")
+      }
+
+      val methodOptParam = Seq(
+        """  /v1/get3/{id}:
+          |    get:
+          |      summary: get3
+          |      description: get3
+          |      operationId: get3
+          |      parameters:
+          |        - name: id
+          |          in: path
+          |          required: true
+          |          schema:
+          |            type: integer
+          |            format: int32
+          |        - name: p1
+          |          in: query
+          |          required: true
+          |          schema:
+          |            type: string
+          |        - name: p2
+          |          in: query
+          |          required: false
+          |          schema:
+          |            type: string
+          |            default: foo""".stripMargin
+      )
+
+      methodOptParam.foreach { x =>
+        try {
+          yaml.contains(x) shouldBe true
+        } catch {
+          case e: Throwable =>
+            fail(s"Missing YAML fragment for:\n${x}")
+        }
       }
     }
 

--- a/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
+++ b/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
@@ -770,7 +770,9 @@ private[surface] class CompileTimeSurfaceFactory[Q <: Quotes](using quotes: Q) {
           !x.flags.is(Flags.Synthetic) &&
           !x.flags.is(Flags.Macro) &&
           !x.flags.is(Flags.Implicit) &&
-          !x.flags.is(Flags.FieldAccessor)
+          !x.flags.is(Flags.FieldAccessor) &&
+          // Exclude methods from Java
+          !x.flags.is(Flags.JavaDefined)
         }
         .filter { x =>
           val name = x.name

--- a/build.sbt
+++ b/build.sbt
@@ -678,7 +678,6 @@ lazy val httpCodeGen =
     .in(file("airframe-http-codegen"))
     .enablePlugins(PackPlugin)
     .settings(buildSettings)
-    .settings(scala2Only)
     .settings(
       name               := "airframe-http-codegen",
       description        := "REST and RPC code generator",

--- a/build.sbt
+++ b/build.sbt
@@ -264,8 +264,7 @@ lazy val projectDotty =
       fluentd,
       http.jvm,
       httpRouter,
-      // Surface.of(Class[_]) needs to be supported
-      // httpCodeGen
+      httpCodeGen,
       // Finagle is used in the http recorder
       // httpRecorder
       // // Finagle isn't supporting Scala 3


### PR DESCRIPTION
- Do not support reflection-based Routers in Scala 3. Will provide a Java-reflection based approach to find `object Api { def defaultRouter: Router[Api] = Router.of[API] }` in #2669 
- Skip supporting default method parameters in Scala 3
- Add http-codegen to projectDotty
