### PR TITLE
airframe-sql: Further fix for resolveAggregationIndexes

### DIFF
--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
@@ -86,9 +86,12 @@ object TypeResolver extends LogSupport {
           case k @ GroupingKey(LongLiteral(i, _), _) if i <= selectItems.length =>
             // Use a simpler form of attributes
             val keyItem = selectItems(i.toInt - 1) match {
-              case a: Attribute =>
-                toResolvedAttribute(a.name, a)
-              case other => other
+              case SingleColumn(expr, _, _) =>
+                expr
+              case Alias(_, _, expr, _) =>
+                expr
+              case other =>
+                other
             }
             changed = true
             GroupingKey(keyItem, k.nodeLocation)
@@ -364,8 +367,6 @@ object TypeResolver extends LogSupport {
           r.sourceColumn
         case a: Alias =>
           findSourceColumn(a.expr)
-        case s: SingleColumn =>
-          findSourceColumn(s.expr)
         case _ => None
       }
     }

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
@@ -285,8 +285,17 @@ class TypeResolverTest extends AirSpec with ResolverTestHelper {
 
     test("group by index of column with alias") {
       val p = analyze("select id as i, count(*) from A group by 1")
+      p shouldMatch { case Aggregate(_, _, List(GroupingKey(SingleColumn(`ra1`, _, _), _)), _, _) =>
+      }
+    }
+
+    test("group by index of expression") {
+      val p = analyze("select substr(name, 1, 2), count(*) from A group by 1")
       p shouldMatch { case Aggregate(_, _, List(GroupingKey(c, _)), _, _) =>
-        c shouldBe ra1.copy(name = "i")
+        c shouldMatch { case f: FunctionCall =>
+          f.name shouldBe "substr"
+          f.args.head shouldBe ra2
+        }
       }
     }
 


### PR DESCRIPTION
My previous pull request (https://github.com/wvlet/airframe/pull/2674) caused unresolved grouping keys in some cases.

I think `resolveSortItemIndexes` may need the same fix, but not 100% sure.