### PR TITLE
airframe-sql: Support in-expression sub-query in traverse and transform

### DIFF
--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/model/LogicalPlanTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/model/LogicalPlanTest.scala
@@ -158,4 +158,21 @@ class LogicalPlanTest extends AirSpec {
       case s: Attribute if s.alias == Some("x0") => true
     }.nonEmpty shouldBe true
   }
+
+  test("Transform in-expression sub-query") {
+    val l     = SQLParser.parse("select * from x where id in (select id from y limit 1)")
+    var found = false
+    l.traverse { case l: Limit =>
+      found = true
+    }
+    found shouldBe true
+
+    val newPlan = l.transform { case l: Limit =>
+      l.child
+    }
+
+    newPlan.traverse { case l: Limit =>
+      fail(s"Should not have limit")
+    }
+  }
 }


### PR DESCRIPTION
This will make possible to traverse/transform `LogicalPlan` in `Expression`.

Another idea is moving all traverse and transform methods (including `mapChildren`) to TreeNode with a signature change `LogicalPlan` -> `TreeNode[_]`. This will change the ability of those methods that can traverse/transform any nodes in the tree, not only `LogicalPlan`. Meaning, no need to have methods for `LogicalPlan` and `Expression` independently.

I'm not sure which is better. 🤔 