### PR TITLE
airframe-sql: Resolve multiple columns from UNION in sub-query

### DIFF
--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
@@ -771,7 +771,7 @@ object LogicalPlan {
     override def outputAttributes: Seq[Attribute] = mergeOutputAttributes
     protected def mergeOutputAttributes: Seq[Attribute] = {
       // Collect all input attributes
-      val outputAttributes: Seq[Seq[Attribute]] = children.flatMap(_.outputAttributes.map(_.inputColumns))
+      val outputAttributes: Seq[Seq[Attribute]] = children.map(_.outputAttributes.flatMap(_.inputColumns))
 
       // Transpose a set of relation columns into a list of same columns
       // relations: (Ra(a1, a2, ...), Rb(b1, b2, ...))

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
@@ -245,7 +245,16 @@ class TypeResolverTest extends AirSpec with ResolverTestHelper {
               _,
               _
             ) =>
+      }
+    }
 
+    test("resolve multiple columns from union") {
+      val p = analyze("select id, name from (select id, name from A union all select id, name from B)")
+      p.outputAttributes shouldMatch {
+        case Seq(
+              MultiSourceColumn(Seq(`ra1`, `rb1`), None, _),
+              MultiSourceColumn(Seq(`ra2`, `rb2`), None, _)
+            ) =>
       }
     }
 


### PR DESCRIPTION
airframe-sql fails to resolve output columns of UNION if there are multiple columns:
```
[sql]
select id, name from (select id, name from A union all select id, name from B)
[plan]
[Project]: (id:long) => (id:long, name:?)
  - id:long := {*id:long <- A.id, *name:string <- A.name, *id:long <- B.id, *name:string <- B.name}
  - name:? := Id(name)
  [Union]: (id:long, name:string, id:long, name:string) => (id:long)
    [Project]: (id:long, name:string) => (id:long, name:string)
      - *id:long <- A.id
      - *name:string <- A.name
      [TableScan] default.A:  => (id:long, name:string)
    [Project]: (id:long, name:string) => (id:long, name:string)
      - *id:long <- B.id
      - *name:string <- B.name
      [TableScan] default.B:  => (id:long, name:string)

[unresolved expressions]
name:? := Id(name)
Id(name)
```