### PR TITLE
airframe-sql: Qualify outputColumns if AllColumns has qualifier

### DIFF
--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
@@ -519,7 +519,12 @@ object Expression {
         case None => Nil
       }
     }
-    override def outputColumns: Seq[Attribute] = inputColumns
+    override def outputColumns: Seq[Attribute] = {
+      qualifier match {
+        case Some(x) => inputColumns.map(_.withQualifier(x))
+        case None    => inputColumns
+      }
+    }
 
     override def dataType: DataType = {
       columns

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
@@ -998,4 +998,9 @@ class TypeResolverTest extends AirSpec with ResolverTestHelper {
       c shouldBe ra1
     }
   }
+
+  test("Resolve qualified AllColumns") {
+    val p = analyze("select t2.name from A t1 inner join (select * from B) t2 using (id)")
+    p.outputAttributes shouldBe List(rb2.withQualifier("t2"))
+  }
 }


### PR DESCRIPTION
To make it possible to resolve columns outside a sub-query that has qualified `AllColumns` like this:
```sql
select t2.name from A t1 inner join (select * from B) t2 using (id)
```
`t2.name` in the select clause cannot be resolved in this SQL.