### PR TITLE
airframe-sql: Unqualify outputColumns if AllColumns doesn't have qualifier

### DIFF
--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
@@ -520,10 +520,7 @@ object Expression {
       }
     }
     override def outputColumns: Seq[Attribute] = {
-      qualifier match {
-        case Some(x) => inputColumns.map(_.withQualifier(x))
-        case None    => inputColumns
-      }
+      inputColumns.map(_.withQualifier(qualifier))
     }
 
     override def dataType: DataType = {


### PR DESCRIPTION
https://github.com/wvlet/airframe/pull/2763 wasn't enough 🙇‍♂️

Unqualifying is also necessary if `AllColumns` doesn't have a qualifier.