### PR TITLE
airframe-log: Fixes #2777 Use the default System.err for supporting sbtn

### DIFF
--- a/airframe-log/.jvm/src/main/scala/wvlet/log/LogEnv.scala
+++ b/airframe-log/.jvm/src/main/scala/wvlet/log/LogEnv.scala
@@ -1,8 +1,9 @@
 package wvlet.log
-import java.io.{FileDescriptor, FileOutputStream, PrintStream}
-import java.lang.management.ManagementFactory
-import javax.management.{InstanceAlreadyExistsException, ObjectName, MBeanServer}
 import wvlet.log.LogFormatter.SourceCodeLogFormatter
+
+import java.io.PrintStream
+import java.lang.management.ManagementFactory
+import javax.management.{InstanceAlreadyExistsException, MBeanServer, ObjectName}
 
 /**
   */
@@ -10,12 +11,15 @@ private[log] object LogEnv extends LogEnvBase {
   override def isScalaJS: Boolean        = false
   override def defaultLogLevel: LogLevel = LogLevel.INFO
 
-  override lazy val defaultConsoleOutput: PrintStream = {
+  override val defaultConsoleOutput: PrintStream = {
     // Note: In normal circumstances, using System.err here is fine, but
     // System.err can be replaced with other implementation
     // (e.g., airlift.Logging, which is used in Trino https://github.com/airlift/airlift/blob/master/log-manager/src/main/java/io/airlift/log/Logging.java),
-    // so we create a stderr stream explicitly here.
-    new PrintStream(new FileOutputStream(FileDescriptor.err))
+    // If that happens, we may need to create a stderr stream explicitly like this
+    // new PrintStream(new FileOutputStream(FileDescriptor.err))
+
+    // Use the standard System.err for sbtn native client
+    System.err
   }
   override def defaultHandler: java.util.logging.Handler = {
     new ConsoleLogHandler(SourceCodeLogFormatter)
@@ -35,7 +39,6 @@ private[log] object LogEnv extends LogEnvBase {
 
     // When class is an anonymous trait
     if (name.contains("$anon$")) {
-      import collection.JavaConverters._
       val interfaces = cl.getInterfaces
       if (interfaces != null && interfaces.length > 0) {
         // Use the first interface name instead of the anonymous name


### PR DESCRIPTION
Previously, airframe-log added a workaround for #1756, but it caused `sbtn` not to show any log output. 

By disabling the logging initialization in airlift log-manager, we no longer need this workaround. 