### PR TITLE
airframe-sql: Support EXTRACT function 

### DIFF
--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/SQLAnonymizer.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/SQLAnonymizer.scala
@@ -42,11 +42,7 @@ object SQLAnonymizer extends LogSupport {
     SQLGenerator.print(anonymizedPlan)
   }
 
-  def anonymize(plan: LogicalPlan, dict: Map[Expression, Expression]): LogicalPlan = {
-    val anonymizationRule: PartialFunction[Expression, Expression] = {
-      case x if dict.contains(x) =>
-        dict(x)
-    }
+  def anonymize(plan: LogicalPlan, anonymizationRule: PartialFunction[Expression, Expression]): LogicalPlan = {
     // Target: Identifier, Literal, UnresolvedAttribute, Table
     plan.transformExpressions(anonymizationRule)
   }

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/SQLAnonymizer.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/SQLAnonymizer.scala
@@ -42,7 +42,11 @@ object SQLAnonymizer extends LogSupport {
     SQLGenerator.print(anonymizedPlan)
   }
 
-  def anonymize(plan: LogicalPlan, anonymizationRule: PartialFunction[Expression, Expression]): LogicalPlan = {
+  def anonymize(plan: LogicalPlan, dict: Map[Expression, Expression]): LogicalPlan = {
+    val anonymizationRule: PartialFunction[Expression, Expression] = {
+      case x if dict.contains(x) =>
+        dict(x)
+    }
     // Target: Identifier, Literal, UnresolvedAttribute, Table
     plan.transformExpressions(anonymizationRule)
   }

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
@@ -1042,12 +1042,30 @@ object Expression {
   sealed trait IntervalField extends LeafExpression {
     override def toString(): String = getClass.getSimpleName
   }
-  case class Year(nodeLocation: Option[NodeLocation])   extends IntervalField
-  case class Month(nodeLocation: Option[NodeLocation])  extends IntervalField
-  case class Day(nodeLocation: Option[NodeLocation])    extends IntervalField
-  case class Hour(nodeLocation: Option[NodeLocation])   extends IntervalField
-  case class Minute(nodeLocation: Option[NodeLocation]) extends IntervalField
-  case class Second(nodeLocation: Option[NodeLocation]) extends IntervalField
+  case class Year(nodeLocation: Option[NodeLocation])            extends IntervalField
+  case class Quarter(nodeLocation: Option[NodeLocation])         extends IntervalField
+  case class Month(nodeLocation: Option[NodeLocation])           extends IntervalField
+  case class Week(nodeLocation: Option[NodeLocation])            extends IntervalField
+  case class Day(nodeLocation: Option[NodeLocation])             extends IntervalField
+  case class DayOfWeek(nodeLocation: Option[NodeLocation])       extends IntervalField {
+    override def toString(): String = "day_of_week"
+  }
+  case class DayOfYear(nodeLocation: Option[NodeLocation])     extends IntervalField {
+    override def toString(): String = "day_of_year"
+  }
+  case class YearOfWeek(nodeLocation: Option[NodeLocation])    extends IntervalField {
+    override def toString(): String = "year_of_week"
+  }
+  case class Hour(nodeLocation: Option[NodeLocation])            extends IntervalField
+  case class Minute(nodeLocation: Option[NodeLocation])          extends IntervalField
+  case class Second(nodeLocation: Option[NodeLocation])          extends IntervalField
+
+  case class TimezoneHour(nodeLocation: Option[NodeLocation])    extends IntervalField {
+    override def toString(): String = "timezone_hour"
+  }
+  case class TimezoneMinute(nodeLocation: Option[NodeLocation]) extends IntervalField {
+    override def toString(): String = "timezone_minute"
+  }
 
   // Value constructor
   case class ArrayConstructor(values: Seq[Expression], nodeLocation: Option[NodeLocation]) extends Expression {
@@ -1130,6 +1148,11 @@ object Expression {
     override def index: Option[Int]     = None
     override def toString: String       = s"GroupingKey(${index.map(i => s"${i}:").getOrElse("")}${child})"
     override lazy val resolved: Boolean = false
+  }
+
+  case class Extract(interval: IntervalField, expr: Expression, nodeLocation: Option[NodeLocation]) extends Expression {
+    override def children: Seq[Expression] = Seq(expr)
+    override def toString = s"Extract(interval:${interval}, ${expr})"
   }
 
 }

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLGenerator.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLGenerator.scala
@@ -374,7 +374,7 @@ object SQLGenerator extends LogSupport {
       case l: Literal =>
         l.sqlExpr
       case g: GroupingKey =>
-        g.sqlExpr
+        printExpression(g.child)
       case ParenthesizedExpression(expr, _) =>
         s"(${printExpression(expr)})"
       case a: Alias =>
@@ -412,6 +412,8 @@ object SQLGenerator extends LogSupport {
           }
           .getOrElse("")
         s"${name}(${d}${argList})${wd}"
+      case Extract(interval, expr, _) =>
+        s"EXTRACT(${interval} FROM ${printExpression(expr)})"
       case QName(parts, _) =>
         parts.mkString(".")
       case Cast(expr, tpe, tryCast, _) =>

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLInterpreter.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLInterpreter.scala
@@ -797,6 +797,27 @@ class SQLInterpreter(withNodeLocation: Boolean = true) extends SqlBaseBaseVisito
     }
   }
 
+  override def visitExtract(ctx: SqlBaseParser.ExtractContext): Expression = {
+    val intervalLocation = getLocation(ctx.identifier())
+    val expr = expression(ctx.valueExpression())
+    ctx.identifier().getText().toUpperCase() match {
+      case "YEAR" => Extract(Year(intervalLocation), expr, getLocation(ctx))
+      case "QUARTER" => Extract(Quarter(intervalLocation), expr, getLocation(ctx))
+      case "MONTH" => Extract(Month(intervalLocation), expr, getLocation(ctx))
+      case "WEEK" => Extract(Week(intervalLocation), expr, getLocation(ctx))
+      case "DAY" | "DAY_OF_MONTH" => Extract(Day(intervalLocation), expr, getLocation(ctx))
+      case "DAY_OF_WEEK" | "DOW" => Extract(DayOfWeek(intervalLocation), expr, getLocation(ctx))
+      case "DAY_OF_YEAR" | "DOY" => Extract(DayOfYear(intervalLocation), expr, getLocation(ctx))
+      case "YEAR_OF_WEEK" | "YOW" => Extract(YearOfWeek(intervalLocation), expr, getLocation(ctx))
+      case "HOUR" => Extract(Hour(intervalLocation), expr, getLocation(ctx))
+      case "MINUTE" => Extract(Minute(intervalLocation), expr, getLocation(ctx))
+      case "SECOND" => Extract(Second(intervalLocation), expr, getLocation(ctx))
+      case "TIMEZONE_HOUR" => Extract(TimezoneHour(intervalLocation), expr, getLocation(ctx))
+      case "TIMEZONE_MINUTE" => Extract(TimezoneMinute(intervalLocation), expr, getLocation(ctx))
+      case _ => throw unknown(ctx)
+    }
+  }
+
   override def visitArrayConstructor(ctx: ArrayConstructorContext): Expression = {
     val elems = ctx.expression().asScala.map(expression(_)).toSeq
     ArrayConstructor(elems, getLocation(ctx))

--- a/airframe-sql/src/test/resources/wvlet/airframe/sql/standard/queries.yml
+++ b/airframe-sql/src/test/resources/wvlet/airframe/sql/standard/queries.yml
@@ -192,3 +192,5 @@
       select 1 as c1
 - sql: |
       select count(1) from t having count(distinct id) > 5
+- sql: | 
+      select EXTRACT(QUARTER FROM FROM_UNIXTIME(time)), COUNT(*) FROM a GROUP BY EXTRACT(QUARTER FROM FROM_UNIXTIME(time))


### PR DESCRIPTION
Currently, queries containing `EXTRACT` cannot properly be parsed as `SQLInterpreter` does not override the `visitExtract` method. The default one ends up producing a `null` value when a function call is made inside the `EXTRACT` statement. An exception is later thrown by the parser when it encounters that `null` value.

This PR adds support for the `EXTRACT` functions. It also fixes an issue when generating grouping keys; function call would not be printed correctly.