### PR TITLE
airframe-sql: Fix concatenation support

### DIFF
--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/SQLAnonymizer.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/SQLAnonymizer.scala
@@ -42,11 +42,7 @@ object SQLAnonymizer extends LogSupport {
     SQLGenerator.print(anonymizedPlan)
   }
 
-  def anonymize(plan: LogicalPlan, dict: Map[Expression, Expression]): LogicalPlan = {
-    val anonymizationRule: PartialFunction[Expression, Expression] = {
-      case x if dict.contains(x) =>
-        dict(x)
-    }
+  def anonymize(plan: LogicalPlan, anonymizationRule: PartialFunction[Expression, Expression]): LogicalPlan = {
     // Target: Identifier, Literal, UnresolvedAttribute, Table
     plan.transformExpressions(anonymizationRule)
   }

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/SQLAnonymizer.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/SQLAnonymizer.scala
@@ -42,7 +42,11 @@ object SQLAnonymizer extends LogSupport {
     SQLGenerator.print(anonymizedPlan)
   }
 
-  def anonymize(plan: LogicalPlan, anonymizationRule: PartialFunction[Expression, Expression]): LogicalPlan = {
+  def anonymize(plan: LogicalPlan, dict: Map[Expression, Expression]): LogicalPlan = {
+    val anonymizationRule: PartialFunction[Expression, Expression] = {
+      case x if dict.contains(x) =>
+        dict(x)
+    }
     // Target: Identifier, Literal, UnresolvedAttribute, Table
     plan.transformExpressions(anonymizationRule)
   }

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLInterpreter.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLInterpreter.scala
@@ -536,6 +536,17 @@ class SQLInterpreter(withNodeLocation: Boolean = true) extends SqlBaseBaseVisito
     visitQueryNoWith(ctx.queryNoWith())
   }
 
+  override def visitConcatenation(ctx: ConcatenationContext): Expression = {
+    FunctionCall(
+      "concat",
+      ctx.valueExpression().asScala.map(expression(_)).toSeq,
+      isDistinct = false,
+      Option.empty,
+      Option.empty,
+      getLocation(ctx)
+    )
+  }
+
   override def visitPredicated(ctx: PredicatedContext): Expression = {
     val e = expression(ctx.valueExpression)
     if (ctx.predicate != null) {

--- a/airframe-sql/src/test/resources/wvlet/airframe/sql/standard/queries.yml
+++ b/airframe-sql/src/test/resources/wvlet/airframe/sql/standard/queries.yml
@@ -224,3 +224,5 @@
       select EXTRACT(TIMEZONE_HOUR FROM FROM_UNIXTIME(time)), COUNT(*) FROM a
 - sql: |
       select EXTRACT(timezone_minute FROM FROM_UNIXTIME(time)), COUNT(*) FROM a
+- sql: |
+      select user_agent || 'x', count(*) from impression group by 1


### PR DESCRIPTION
The concatenation operator is not currently handled by `SQLInterpreter`. Since `x || a` is equivalent to `CONCAT(x, a)`, we simply map the operator to a function call.