### PR TITLE
[internal] Automatically generate release notes 

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,31 @@
+changelog:
+  categories:
+    - title: '🔥 Breaking Changes'
+      labels:
+        - 'breaking'
+    - title: '🚀 Features'
+      labels:
+        - 'feature'
+        - 'enhancement'
+    - title: '🐛 Bug Fixes'
+      labels:
+        - 'bug'
+    - title: '👋 Deprecated'
+      labels:
+        - 'deprecation'
+    - title: '🔗 Dependency Updates'
+      labels:
+        - 'library-update'
+        - 'dependencies'
+    - title: '🛠  Internal Updates'
+      labels:
+        - 'internal'
+        - 'kaizen'
+        - 'test-library-update'
+        - 'sbt-plugin-update'
+    - title: '📚 Docs'
+      labels:
+        - 'doc'
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,9 +1,6 @@
 name: Release Drafter
 
 on:
-  push:
-    branches:
-      - master
   # pull_request event is required only for autolabeler
   pull_request:
     # Only following types are handled by the action, but one can default to all as well
@@ -16,16 +13,14 @@ permissions:
   contents: read
 
 jobs:
-  update_release_draft:
+  update_PR_labels:
     permissions:
-      # write permission is required to create a github release
-      contents: write
       # write permission is required for autolabeler
       # otherwise, read permission is required at least
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      # Drafts your next Release notes as Pull Requests are merged into "master"
+      # Runs only pull-request labeler
       - uses: release-drafter/release-drafter@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-note.yml
+++ b/.github/workflows/release-note.yml
@@ -1,0 +1,18 @@
+name: Release Note
+
+on:
+  push:
+    tags:
+      - v*
+  workflow_dispatch:      
+
+jobs:
+  release:
+    name: Create a new release note
+    runs-on: ubuntu-latest
+    steps:         
+      - name: Create a release note
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" --repo="$GITHUB_REPOSITORY" --generate-notes

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Here is the list of milestones for Dotty support: [#1077](https://github.com/wvl
 
 ### Releasing
 
-For every commit merged to the master branch, a draft of the [release note](https://github.com/wvlet/airframe/releases) will be updated with [release-drafter](https://github.com/release-drafter/release-drafter).
+For every PR, [release-drafter](https://github.com/release-drafter/release-drafter) will automatically label PRs using the rules defined in [.github/release-drafter.yml](https://github.com/wvlet/airframe/blob/master/.github/release-drafter.yml). 
 
 To publish a new version, first, create a new release tag as follows:
 
@@ -68,13 +68,11 @@ $ git switch master
 $ git pull
 $ ruby ./scripts/release.rb
 ```
-This step will update docs/release-noteds.md and push a new git tag to the GitHub.
-After that, GitHub actions for releading artifacts to Sonatype will be triggered automatically.
+This step will update docs/release-noteds.md, push a new git tag to the GitHub, and
+create a new [GitHub relese note](https://github.com/wvlet/airframe/releases).
+After that, the artifacts will be published to Sonatype (a.k.a. Maven Central). It usually takes 10-30 minutes. 
 
-Next, edit and publish the draft of [the release note](https://github.com/wvlet/airframe/releases).
-If necessary, adjust the version number and target tag. 
-
-Do not create a new tag from GitHub release pages, because it will not trigger the GitHub Actions for the release.
+Note: Do not create a new tag from GitHub release pages, because it will not trigger the GitHub Actions for the release.
 
 ## LICENSE
 


### PR DESCRIPTION
- Updated the release process
- Add release note generator workflow
- Still use release-drafter only for labeling pull requests.