### PR TITLE
fix(airframe-sql): Case should be ignored when resolving identifiers

### DIFF
--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/SQLAnonymizer.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/SQLAnonymizer.scala
@@ -42,11 +42,7 @@ object SQLAnonymizer extends LogSupport {
     SQLGenerator.print(anonymizedPlan)
   }
 
-  def anonymize(plan: LogicalPlan, dict: Map[Expression, Expression]): LogicalPlan = {
-    val anonymizationRule: PartialFunction[Expression, Expression] = {
-      case x if dict.contains(x) =>
-        dict(x)
-    }
+  def anonymize(plan: LogicalPlan, anonymizationRule: PartialFunction[Expression, Expression]): LogicalPlan = {
     // Target: Identifier, Literal, UnresolvedAttribute, Table
     plan.transformExpressions(anonymizationRule)
   }

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/SQLAnonymizer.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/SQLAnonymizer.scala
@@ -42,7 +42,11 @@ object SQLAnonymizer extends LogSupport {
     SQLGenerator.print(anonymizedPlan)
   }
 
-  def anonymize(plan: LogicalPlan, anonymizationRule: PartialFunction[Expression, Expression]): LogicalPlan = {
+  def anonymize(plan: LogicalPlan, dict: Map[Expression, Expression]): LogicalPlan = {
+    val anonymizationRule: PartialFunction[Expression, Expression] = {
+      case x if dict.contains(x) =>
+        dict(x)
+    }
     // Target: Identifier, Literal, UnresolvedAttribute, Table
     plan.transformExpressions(anonymizationRule)
   }

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
@@ -344,7 +344,8 @@ trait Attribute extends LeafExpression with LogSupport {
       tableName match {
         case Some(tableName) =>
           this match {
-            case r: ResolvedAttribute if r.qualifier.orElse(r.sourceColumn.map(_.table.name)).contains(tableName) =>
+            case r: ResolvedAttribute
+                if r.qualifier.orElse(r.sourceColumn.map(_.table.name)).exists(_.equalsIgnoreCase(tableName)) =>
               findMatched(None, columnName)
             case _ =>
               Nil
@@ -352,8 +353,8 @@ trait Attribute extends LeafExpression with LogSupport {
         case None =>
           this match {
             case a: AllColumns =>
-              a.inputColumns.filter(_.name == columnName)
-            case a: Attribute if a.name == columnName =>
+              a.inputColumns.filter(_.name.equalsIgnoreCase(columnName))
+            case a: Attribute if a.name.equalsIgnoreCase(columnName) =>
               Seq(a)
             case _ =>
               Seq.empty
@@ -365,7 +366,7 @@ trait Attribute extends LeafExpression with LogSupport {
       // TODO handle (catalog).(database).(table) names in the qualifier
       case ColumnPath(Some(databaseName), Some(tableName), columnName) =>
         if (databaseName == context.database) {
-          if (qualifier.exists(_ == tableName)) {
+          if (qualifier.contains(tableName)) {
             findMatched(None, columnName).map(_.withQualifier(qualifier))
           } else {
             findMatched(Some(tableName), columnName)

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
@@ -1061,4 +1061,9 @@ class TypeResolverTest extends AirSpec with ResolverTestHelper {
     p.outputAttributes.toList shouldBe List(ra2.withQualifier("A"))
   }
 
+  test("Resolve identifiers with no regards to case sensitivity") {
+    analyze("select A.id from A JOIN B ON A.id = B.id GROUP BY a.id")
+    // No ambiguity error
+  }
+
 }


### PR DESCRIPTION
When resolving types, the library should ignore case as most engines (ex: Trino) do not handle case-sensitive identifiers themselves. 