### PR TITLE
airframe-surface: Sort MethodSurface alphabetically

### DIFF
--- a/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
+++ b/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
@@ -669,7 +669,7 @@ private[surface] class CompileTimeSurfaceFactory[Q <: Quotes](using quotes: Q) {
       sys.error(s"recurcive type in method: ${targetType.typeSymbol.fullName}")
     } else {
       methodSeen += targetType
-      val localMethods = localMethodsOf(targetType).distinct
+      val localMethods = localMethodsOf(targetType).distinct.sortBy(_.name)
       val methodSurfaces = localMethods.map(m => (m, m.tree)).collect { case (m, df: DefDef) =>
         val mod   = Expr(modifierBitMaskOf(m))
         val owner = surfaceOf(targetType)


### PR DESCRIPTION
This is a workaround for Scala3 compile-time MethodSurface generator, in which the method order becomes unstable