### PR TITLE
airframe-http: Build Router at runtime using RxRouterProvider for Scala 3 support

### DIFF
--- a/airframe-http-codegen/src/main/scala/wvlet/airframe/http/codegen/HttpCodeGenerator.scala
+++ b/airframe-http-codegen/src/main/scala/wvlet/airframe/http/codegen/HttpCodeGenerator.scala
@@ -189,8 +189,13 @@ class HttpCodeGenerator(
 
   private def buildRouter(apiPackageNames: Seq[String], classLoader: URLClassLoader): Router = {
     info(s"Target API packages: ${apiPackageNames.mkString(", ")}")
-    val router = RouteScanner.buildRouter(apiPackageNames, classLoader)
-    router
+    val rxRouter = RouteScanner.buildRxRouter(apiPackageNames, classLoader)
+    if (rxRouter.routes.isEmpty) {
+      warn(s"Scanning classes implementing @RPC or @Endpoint from the classpath...")
+      RouteScanner.buildRouter(apiPackageNames, classLoader)
+    } else {
+      Router.fromRxRouter(rxRouter)
+    }
   }
 
   @command(description = "Generate HTTP client code using a JSON configuration file")

--- a/airframe-http-codegen/src/test/scala/example/nested/v1/MyApi.scala
+++ b/airframe-http-codegen/src/test/scala/example/nested/v1/MyApi.scala
@@ -15,6 +15,7 @@ package example.nested.v1
 
 import example.nested.v1.MyApi.{HelloRequest, HelloResponse, Message}
 import wvlet.airframe.http.RPC
+import wvlet.airframe.http.router.{RxRouter, RxRouterProvider}
 
 /**
   */
@@ -24,7 +25,9 @@ trait MyApi {
   def helloMsg: Seq[Message]                      = Seq.empty
 }
 
-object MyApi {
+object MyApi extends RxRouterProvider {
+  override def router: RxRouter = RxRouter.of[MyApi]
+
   case class Message(msg: String)
   case class HelloRequest(name: String)
   case class HelloResponse(message: String)

--- a/airframe-http-codegen/src/test/scala/example/nested/v2/MyApi.scala
+++ b/airframe-http-codegen/src/test/scala/example/nested/v2/MyApi.scala
@@ -15,6 +15,7 @@ package example.nested.v2
 
 import example.nested.v2.MyApi.{HelloRequest, HelloResponse}
 import wvlet.airframe.http.RPC
+import wvlet.airframe.http.router.{RxRouter, RxRouterProvider}
 
 /**
   */
@@ -23,7 +24,8 @@ trait MyApi {
   def hello(request: HelloRequest): HelloResponse = HelloResponse("hello v2")
 }
 
-object MyApi {
+object MyApi extends RxRouterProvider {
+  override def router: RxRouter = RxRouter.of[MyApi]
   case class HelloRequest(name: String)
   case class HelloResponse(message: String, version: String = "v2")
 }

--- a/airframe-http-codegen/src/test/scala/wvlet/airframe/http/codegen/NestedApiTest.scala
+++ b/airframe-http-codegen/src/test/scala/wvlet/airframe/http/codegen/NestedApiTest.scala
@@ -24,9 +24,11 @@ class NestedApiTest extends AirSpec {
     code.contains("Seq[example.nested.v1.MyApi.Message]]") shouldBe true
   }
 
+  private val router = RouteScanner.buildRxRouter(Seq("example.nested"))
+
   test("generate gRPC client for nested packages") {
     val code = HttpCodeGenerator.generate(
-      RouteScanner.buildRouter(Seq(classOf[example.nested.v1.MyApi], classOf[example.nested.v2.MyApi])),
+      router,
       HttpClientGeneratorConfig("example.nested:grpc")
     )
     check(code)
@@ -34,7 +36,7 @@ class NestedApiTest extends AirSpec {
 
   test("generate http client for nested packages") {
     val code = HttpCodeGenerator.generate(
-      RouteScanner.buildRouter(Seq(classOf[example.nested.v1.MyApi], classOf[example.nested.v2.MyApi])),
+      router,
       HttpClientGeneratorConfig("example.nested:sync")
     )
     check(code)
@@ -42,7 +44,7 @@ class NestedApiTest extends AirSpec {
 
   test("generate http async client for nested packages") {
     val code = HttpCodeGenerator.generate(
-      RouteScanner.buildRouter(Seq(classOf[example.nested.v1.MyApi], classOf[example.nested.v2.MyApi])),
+      router,
       HttpClientGeneratorConfig("example.nested:async")
     )
     check(code)
@@ -50,7 +52,7 @@ class NestedApiTest extends AirSpec {
 
   test("generate http js client for nested packages") {
     val code = HttpCodeGenerator.generate(
-      RouteScanner.buildRouter(Seq(classOf[example.nested.v1.MyApi], classOf[example.nested.v2.MyApi])),
+      router,
       HttpClientGeneratorConfig("example.nested:scalajs")
     )
     check(code)

--- a/airframe-http-codegen/src/test/scala/wvlet/airframe/http/codegen/RPCClientGeneratorTest.scala
+++ b/airframe-http-codegen/src/test/scala/wvlet/airframe/http/codegen/RPCClientGeneratorTest.scala
@@ -18,7 +18,7 @@ import wvlet.airspec.AirSpec
 
 class RPCClientGeneratorTest extends AirSpec {
   private val router: RxRouter = {
-    RouteScanner.buildRxRouter(Seq("example.rpc"), Thread.currentThread().getContextClassLoader)
+    RouteScanner.buildRxRouter(Seq("example.rpc"))
   }
 
   test("generate RPC client") {

--- a/airframe-http-codegen/src/test/scala/wvlet/airframe/http/codegen/RxRouterProviderTest.scala
+++ b/airframe-http-codegen/src/test/scala/wvlet/airframe/http/codegen/RxRouterProviderTest.scala
@@ -19,7 +19,7 @@ import wvlet.airspec.AirSpec
 class RxRouterProviderTest extends AirSpec {
 
   private val router: RxRouter = {
-    RouteScanner.buildRxRouter(Seq("example.rpc"), Thread.currentThread().getContextClassLoader)
+    RouteScanner.buildRxRouter(Seq("example.rpc"))
   }
 
   test("Build router from RxRouterProvider") {

--- a/airframe-http-grpc/src/test/scala/wvlet/airframe/http/grpc/GrpcErrorLogTest.scala
+++ b/airframe-http-grpc/src/test/scala/wvlet/airframe/http/grpc/GrpcErrorLogTest.scala
@@ -20,6 +20,7 @@ import wvlet.airframe.http.Router
 import wvlet.airframe.http.HttpAccessLogWriter
 import wvlet.airspec.AirSpec
 import wvlet.airframe.rx.{Rx, RxStream}
+import wvlet.log.Logger
 
 import scala.util.{Failure, Try}
 
@@ -43,10 +44,12 @@ object GrpcErrorLogTest extends AirSpec {
     }
   }
 
+  private val router = Router.of[DemoApiDebug]
+
   protected override def design = {
     gRPC.server
       .withName("demo-api-debug")
-      .withRouter(Router.add[DemoApiDebug])
+      .withRouter(router)
       .withRequestLoggerProvider { (config: GrpcServerConfig) =>
         GrpcRequestLogger
           .newLogger(config.name, inMemoryLogWriter)
@@ -65,6 +68,7 @@ object GrpcErrorLogTest extends AirSpec {
   }
 
   test("request logger test") { (client: DemoApiClient) =>
+    debug(router)
     test("unary method error log") {
       val logs = captureAll {
         client.hello("gRPC")

--- a/airframe-http-netty/src/test/scala/wvlet/airframe/http/netty/NettyRxFilterTest.scala
+++ b/airframe-http-netty/src/test/scala/wvlet/airframe/http/netty/NettyRxFilterTest.scala
@@ -13,14 +13,14 @@
  */
 package wvlet.airframe.http.netty
 
-import wvlet.airframe.Design
 import wvlet.airframe.http.client.SyncClient
-import wvlet.airframe.http.{Http, HttpMessage, RPCException, RPCStatus, RxEndpoint, RxFilter}
+import wvlet.airframe.http.{Http, HttpMessage, RPC, RPCException, RPCStatus, RxEndpoint, RxFilter}
 import wvlet.airframe.http.router.RxRouter
 import wvlet.airframe.rx.Rx
 import wvlet.airspec.AirSpec
 
 object NettyRxFilterTest extends AirSpec {
+  @RPC
   class MyRPC {
     def hello(msg: String): String = s"Hello ${msg}!"
   }
@@ -52,14 +52,21 @@ object NettyRxFilterTest extends AirSpec {
     (client: SyncClient) =>
       test("when no auth header") {
         val ex = intercept[RPCException] {
-          client.send(Http.POST("/hello").withJson("""{"msg":"Netty"}"""))
+          client.send(
+            Http.POST("/wvlet.airframe.http.netty.NettyRxFilterTest.MyRPC/hello").withJson("""{"msg":"Netty"}""")
+          )
         }
         ex.status shouldBe RPCStatus.UNAUTHENTICATED_U13
         ex.message shouldBe "authentication failed"
       }
 
       test("with auth header") {
-        val resp = client.send(Http.POST("/hello").withJson("""{"msg":"Netty"}""").withAuthorization("Bearer xxxx"))
+        val resp = client.send(
+          Http
+            .POST("/wvlet.airframe.http.netty.NettyRxFilterTest.MyRPC/hello").withJson(
+              """{"msg":"Netty"}"""
+            ).withAuthorization("Bearer xxxx")
+        )
         resp.contentString shouldBe "Hello Netty!"
       }
   }
@@ -67,7 +74,9 @@ object NettyRxFilterTest extends AirSpec {
   test("throw RPCException in a filter", design = Netty.server.withRouter(router2).designWithSyncClient) {
     (client: SyncClient) =>
       val ex = intercept[RPCException] {
-        client.send(Http.POST("/hello").withJson("""{"msg":"Netty"}"""))
+        client.send(
+          Http.POST("/wvlet.airframe.http.netty.NettyRxFilterTest.MyRPC/hello").withJson("""{"msg":"Netty"}""")
+        )
       }
       ex.status shouldBe RPCStatus.UNAUTHENTICATED_U13
       ex.message shouldBe "authentication failed"

--- a/airframe-http-netty/src/test/scala/wvlet/airframe/http/netty/NettyRxRPCServerTest.scala
+++ b/airframe-http-netty/src/test/scala/wvlet/airframe/http/netty/NettyRxRPCServerTest.scala
@@ -14,13 +14,14 @@
 package wvlet.airframe.http.netty
 
 import wvlet.airframe.Design
-import wvlet.airframe.http.Http
+import wvlet.airframe.http.{Http, RPC}
 import wvlet.airframe.http.client.SyncClient
 import wvlet.airframe.http.router.RxRouter
 import wvlet.airspec.AirSpec
 
 class NettyRxRPCServerTest extends AirSpec {
 
+  @RPC
   class MyRPC {
     def helloNetty(msg: String): String  = s"Hello ${msg}!"
     def helloNetty2(msg: String): String = s"Hello ${msg}2!"
@@ -35,10 +36,14 @@ class NettyRxRPCServerTest extends AirSpec {
   }
 
   test("Start an RPC server using RxRouter") { (client: SyncClient) =>
-    val resp = client.send(Http.POST("/helloNetty").withJson("""{"msg":"Netty"}"""))
+    val resp = client.send(
+      Http.POST("/wvlet.airframe.http.netty.NettyRxRPCServerTest.MyRPC/helloNetty").withJson("""{"msg":"Netty"}""")
+    )
     resp.message.toContentString shouldBe "Hello Netty!"
 
-    val resp2 = client.send(Http.POST("/helloNetty2").withJson("""{"msg":"Netty"}"""))
+    val resp2 = client.send(
+      Http.POST("/wvlet.airframe.http.netty.NettyRxRPCServerTest.MyRPC/helloNetty2").withJson("""{"msg":"Netty"}""")
+    )
     resp2.message.toContentString shouldBe "Hello Netty2!"
   }
 }

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/Router.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/Router.scala
@@ -13,6 +13,7 @@
  */
 package wvlet.airframe.http
 
+import wvlet.airframe.http.Router.extractEndpointRoutes
 import wvlet.airframe.http.router.Automaton.DFA
 import wvlet.airframe.http.router.RxRouter.{EndpointNode, FilterNode, StemNode}
 import wvlet.airframe.surface._
@@ -141,82 +142,9 @@ case class Router(
             s"Cannot define both of @Endpoint and @RPC annotations: ${controllerSurface}"
           )
         case (_, None) =>
-          val prefixPath = endpointOpt.map(_.path()).getOrElse("")
-          // Add methods annotated with @Endpoint
-          controllerMethodSurfaces
-            .map { m =>
-              (m, m.findAnnotationOf[Endpoint])
-            }
-            .collect { case (m: MethodSurface, Some(endPoint)) =>
-              val endpointInterfaceCls =
-                controllerSurface
-                  .findAnnotationOwnerOf[Endpoint]
-                  .getOrElse(controllerSurface.rawType)
-
-              val rpcMethod = RPCMethod(
-                path = prefixPath + endPoint.path(),
-                rpcInterfaceName = TypeName.sanitizeTypeName(endpointInterfaceCls.getName),
-                methodName = m.name,
-                requestSurface = Surface.of[Array[Byte]],
-                responseSurface = m.returnType
-              )
-              ControllerRoute(
-                rpcMethod,
-                controllerSurface,
-                endPoint.method(),
-                m,
-                isRPC = false
-              )
-            }
+          extractEndpointRoutes(controllerSurface, controllerMethodSurfaces)
         case (None, Some(rpc)) =>
-          val rpcInterfaceCls = Router.findRPCInterfaceCls(controllerSurface)
-
-          def sanitize(s: String): String = {
-            s.replaceAll("\\$anon\\$", "").replaceAll("\\$", ".")
-          }
-          val prefixPath = if (rpc.path().isEmpty) {
-            s"/${sanitize(rpcInterfaceCls.getName)}"
-          } else {
-            s"${rpc.path()}/${sanitize(rpcInterfaceCls.getSimpleName)}"
-          }
-          val routes = controllerMethodSurfaces
-            .filter(_.isPublic)
-            .map { m =>
-              (m, m.findAnnotationOf[RPC])
-            }
-            .collect { case (m: MethodSurface, rpcAnnot) =>
-              val rpcMethod = rpcAnnot match {
-                case Some(rpc) =>
-                  val methodPath =
-                    if (rpc.path().nonEmpty) rpc.path()
-                    else s"/${m.name}"
-                  RPCMethod(
-                    path = prefixPath + methodPath,
-                    rpcInterfaceName = TypeName.sanitizeTypeName(rpcInterfaceCls.getName),
-                    methodName = m.name,
-                    // No need to bind requestSurface in the server side
-                    requestSurface = Surface.of[Array[Byte]],
-                    responseSurface = m.returnType
-                  )
-                case None =>
-                  RPCMethod(
-                    path = s"${prefixPath}/${m.name}",
-                    rpcInterfaceName = TypeName.sanitizeTypeName(rpcInterfaceCls.getName),
-                    methodName = m.name,
-                    // No need to bind requestSurface in the server side
-                    requestSurface = Surface.of[Array[Byte]],
-                    responseSurface = m.returnType
-                  )
-              }
-              ControllerRoute(
-                rpcMethod,
-                controllerSurface,
-                HttpMethod.POST,
-                m,
-                isRPC = true
-              )
-            }
-          routes
+          Router.extractRPCRoutes(controllerSurface, controllerMethodSurfaces)
       }
     }
 
@@ -326,17 +254,67 @@ object Router extends router.RouterObjectBase with LogSupport {
     rpcInterfaceCls
   }
 
+  private def sanitizePath(s: String): String = {
+    s.replaceAll("\\$anon\\$", "").replaceAll("\\$", ".")
+  }
+
+  // Import ReflectSurface to find method annotations (RPC or Endpoint)
+  import wvlet.airframe.surface.reflect._
+
+  private def extractEndpointRoutes(
+      controllerSurface: Surface,
+      controllerMethodSurfaces: Seq[MethodSurface]
+  ): Seq[ControllerRoute] = {
+    val endpointOpt = controllerSurface.findAnnotationOf[Endpoint]
+
+    val prefixPath = endpointOpt.map(_.path()).getOrElse("")
+    // Add methods annotated with @Endpoint
+    controllerMethodSurfaces
+      .map { m =>
+        (m, m.findAnnotationOf[Endpoint])
+      }
+      .collect { case (m: MethodSurface, Some(endPoint)) =>
+        val endpointInterfaceCls =
+          controllerSurface
+            .findAnnotationOwnerOf[Endpoint]
+            .getOrElse(controllerSurface.rawType)
+
+        val rpcMethod = RPCMethod(
+          path = prefixPath + endPoint.path(),
+          rpcInterfaceName = TypeName.sanitizeTypeName(endpointInterfaceCls.getName),
+          methodName = m.name,
+          requestSurface = Surface.of[Array[Byte]],
+          responseSurface = m.returnType
+        )
+        ControllerRoute(
+          rpcMethod,
+          controllerSurface,
+          endPoint.method(),
+          m,
+          isRPC = false
+        )
+      }
+  }
+
   private def extractRPCRoutes(
       controllerSurface: Surface,
-      controllerMethodSurfaces: Seq[MethodSurface],
-      pathPrefix: String = ""
-  ): Seq[Route] = {
+      controllerMethodSurfaces: Seq[MethodSurface]
+  ): Seq[ControllerRoute] = {
     val rpcInterfaceCls = controllerSurface.rawType
-    val routes: Seq[Route] =
+    val rpcOpt          = controllerSurface.findAnnotationOf[RPC]
+
+    val prefixPath = rpcOpt match {
+      case Some(rpc) if rpc.path().nonEmpty =>
+        s"${rpc.path()}/${sanitizePath(rpcInterfaceCls.getSimpleName)}"
+      case _ =>
+        s"/${sanitizePath(rpcInterfaceCls.getName)}"
+    }
+
+    val routes: Seq[ControllerRoute] =
       controllerMethodSurfaces.sortBy(_.name).map { (m: MethodSurface) =>
         val methodPath = s"/${m.name}"
         val rpcMethod = RPCMethod(
-          path = pathPrefix + methodPath,
+          path = prefixPath + methodPath,
           rpcInterfaceName = TypeName.sanitizeTypeName(rpcInterfaceCls.getName),
           methodName = m.name,
           // No need to bind requestSurface in the server side
@@ -358,10 +336,24 @@ object Router extends router.RouterObjectBase with LogSupport {
   def fromRxRouter(router: RxRouter): Router = {
     val newRouter = router match {
       case e: EndpointNode =>
-        val routes = extractRPCRoutes(
-          e.controllerSurface,
-          e.methodSurfaces
-        )
+        val endpointOpt = e.controllerSurface.findAnnotationOf[Endpoint]
+        val rpcOpt      = e.controllerSurface.findAnnotationOf[RPC]
+        val routes = (endpointOpt, rpcOpt) match {
+          case (Some(_), Some(_)) =>
+            throw new IllegalArgumentException(
+              s"Both @Endpoint and @RPC are defined in ${e.controllerSurface.fullName}"
+            )
+          case (_, None) =>
+            extractEndpointRoutes(
+              e.controllerSurface,
+              e.methodSurfaces
+            )
+          case (None, Some(_)) =>
+            extractRPCRoutes(
+              e.controllerSurface,
+              e.methodSurfaces
+            )
+        }
         Router(surface = Some(e.controllerSurface), localRoutes = routes)
       case s: StemNode =>
         s.filter match {
@@ -392,6 +384,8 @@ object Router extends router.RouterObjectBase with LogSupport {
             wrapWithFilter(f.parent, leafRouter)
         }
     }
+    // Check whether the route is valid or not
+    newRouter.verifyRoutes
     newRouter
   }
 }

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/router/RPCCustomPathTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/router/RPCCustomPathTest.scala
@@ -18,7 +18,7 @@ import wvlet.airspec.AirSpec
 
 /**
   */
-object RPCTest extends AirSpec {
+object RPCCustomPathTest extends AirSpec {
 
   case class BookRequest(id: String)
   case class Book(id: String, name: String)
@@ -54,7 +54,7 @@ object RPCTest extends AirSpec {
   test("Create RPC interface without any path") {
     val r = Router.add[MyRPCService2]
     debug(r)
-    val m = r.routes.find(_.path == "/wvlet.airframe.http.router.RPCTest.MyRPCService2/hello")
+    val m = r.routes.find(_.path == "/wvlet.airframe.http.router.RPCCustomPathTest.MyRPCService2/hello")
     m shouldBe defined
 
     m.get.httpMethod shouldBe HttpMethod.POST

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/router/RxRouterConverterTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/router/RxRouterConverterTest.scala
@@ -14,12 +14,13 @@
 package wvlet.airframe.http.router
 
 import wvlet.airframe.http.HttpMessage.Request
-import wvlet.airframe.http.{HttpMethod, Router, RxEndpoint, RxFilter}
+import wvlet.airframe.http.{HttpMethod, RPC, Router, RxEndpoint, RxFilter}
 import wvlet.airframe.surface.Surface
 import wvlet.airspec.AirSpec
 
 class RxRouterConverterTest extends AirSpec {
 
+  @RPC
   trait MyApi {
     def hello: String = "hello"
   }
@@ -39,6 +40,7 @@ class RxRouterConverterTest extends AirSpec {
     }
   }
 
+  @RPC
   trait MyApi2 {
     def hello2: String = "hello2"
   }
@@ -47,7 +49,7 @@ class RxRouterConverterTest extends AirSpec {
     val r = Router.fromRxRouter(MyApi.router)
     r.routes.size shouldBe 1
     val r0 = r.routes(0)
-    r0.path shouldBe "/hello"
+    r0.path shouldBe "/wvlet.airframe.http.router.RxRouterConverterTest.MyApi/hello"
     r0.httpMethod shouldBe HttpMethod.POST
     r0.controllerSurface shouldBe Surface.of[MyApi]
   }
@@ -60,7 +62,7 @@ class RxRouterConverterTest extends AirSpec {
     r.filterSurface shouldBe Some(Surface.of[AuthFilter])
 
     val r0 = r.routes(0)
-    r0.path shouldBe "/hello"
+    r0.path shouldBe "/wvlet.airframe.http.router.RxRouterConverterTest.MyApi/hello"
     r0.httpMethod shouldBe HttpMethod.POST
     r0.controllerSurface shouldBe Surface.of[MyApi]
   }
@@ -83,7 +85,7 @@ class RxRouterConverterTest extends AirSpec {
     val rc1 = rc0.children(0)
     rc1.localRoutes.size shouldBe 1
     val l0 = rc1.localRoutes(0)
-    l0.path shouldBe "/hello"
+    l0.path shouldBe "/wvlet.airframe.http.router.RxRouterConverterTest.MyApi/hello"
     l0.httpMethod shouldBe HttpMethod.POST
     l0.controllerSurface shouldBe Surface.of[MyApi]
   }
@@ -97,10 +99,10 @@ class RxRouterConverterTest extends AirSpec {
     val r = Router.fromRxRouter(rxRouter)
     r.routes.size shouldBe 2
     val r0 = r.routes(0)
-    r0.path shouldBe "/hello"
+    r0.path shouldBe "/wvlet.airframe.http.router.RxRouterConverterTest.MyApi/hello"
     r0.controllerSurface shouldBe Surface.of[MyApi]
     val r1 = r.routes(1)
-    r1.path shouldBe "/hello2"
+    r1.path shouldBe "/wvlet.airframe.http.router.RxRouterConverterTest.MyApi2/hello2"
     r1.controllerSurface shouldBe Surface.of[MyApi2]
   }
 
@@ -115,10 +117,10 @@ class RxRouterConverterTest extends AirSpec {
     r.filterSurface shouldBe Some(Surface.of[AuthFilter])
     r.routes.size shouldBe 2
     val r0 = r.routes(0)
-    r0.path shouldBe "/hello"
+    r0.path shouldBe "/wvlet.airframe.http.router.RxRouterConverterTest.MyApi/hello"
     r0.controllerSurface shouldBe Surface.of[MyApi]
     val r1 = r.routes(1)
-    r1.path shouldBe "/hello2"
+    r1.path shouldBe "/wvlet.airframe.http.router.RxRouterConverterTest.MyApi2/hello2"
     r1.controllerSurface shouldBe Surface.of[MyApi2]
   }
 
@@ -135,10 +137,10 @@ class RxRouterConverterTest extends AirSpec {
     r.filterSurface shouldBe Some(Surface.of[AuthFilter])
     r.routes.size shouldBe 2
     val r0 = r.routes(0)
-    r0.path shouldBe "/hello"
+    r0.path shouldBe "/wvlet.airframe.http.router.RxRouterConverterTest.MyApi/hello"
     r0.controllerSurface shouldBe Surface.of[MyApi]
     val r1 = r.routes(1)
-    r1.path shouldBe "/hello2"
+    r1.path shouldBe "/wvlet.airframe.http.router.RxRouterConverterTest.MyApi2/hello2"
     r1.controllerSurface shouldBe Surface.of[MyApi2]
 
     r.children.size shouldBe 2


### PR DESCRIPTION
- Add REST Endpoint support in RxRouter 
- Support scanning RxRouterProvider definitions in the classpath