### PR TITLE
airspec: Add flaky { ... } block to skip flaky tests

### DIFF
--- a/airspec/src/test/scala/examples/FlakyBlockTest.scala
+++ b/airspec/src/test/scala/examples/FlakyBlockTest.scala
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package examples
+
+import wvlet.airspec.AirSpec
+
+class FlakyBlockTest extends AirSpec {
+  test("flaky test") {
+    flaky {
+      if (scala.util.Random.nextInt(3) == 0) {
+        throw new IllegalStateException(s"flaky test failed")
+      }
+    }
+  }
+
+  test("flaky assertion") {
+    flaky {
+      scala.util.Random.nextInt(3) shouldBe 0
+    }
+  }
+}

--- a/docs/airspec.md
+++ b/docs/airspec.md
@@ -269,6 +269,23 @@ class AsyncTest extends AirSpec {
 
 ```
 
+## Flaky Tests
+
+If your test cases are flaky, i.e., failing occasionally, you can wrap the text code with `flaky` block to mark failures inside the block as 'skipped'. You may need to check the skipped test reports to see if they are really flaky or not:
+
+```scala
+import wvlet.airspec._
+
+class MyTest extends AirSpec {
+  test("performance test") {
+    val elaplsed_time = xxx // measure something
+    flaky {
+       elapsed_time < 100 shouldBe true
+    }
+  }
+}
+
+```
 
 ## Dependency Injection with Airframe DI
 


### PR DESCRIPTION
For handling cases like #2869 without changing the test code so much 