### PR TITLE
airframe-http: Rename RxFilter/Endpoint to RxHttpFilter/Endpoint

### DIFF
--- a/airframe-http-netty/src/test/scala/wvlet/airframe/http/netty/NettyRxFilterTest.scala
+++ b/airframe-http-netty/src/test/scala/wvlet/airframe/http/netty/NettyRxFilterTest.scala
@@ -14,7 +14,7 @@
 package wvlet.airframe.http.netty
 
 import wvlet.airframe.http.client.SyncClient
-import wvlet.airframe.http.{Http, HttpMessage, RPC, RPCException, RPCStatus, RxEndpoint, RxFilter}
+import wvlet.airframe.http.{Http, HttpMessage, RPC, RPCException, RPCStatus, RxHttpEndpoint, RxHttpFilter}
 import wvlet.airframe.http.router.RxRouter
 import wvlet.airframe.rx.Rx
 import wvlet.airspec.AirSpec
@@ -25,8 +25,8 @@ object NettyRxFilterTest extends AirSpec {
     def hello(msg: String): String = s"Hello ${msg}!"
   }
 
-  class AuthFilter extends RxFilter {
-    override def apply(request: HttpMessage.Request, endpoint: RxEndpoint): Rx[HttpMessage.Response] = {
+  class AuthFilter extends RxHttpFilter {
+    override def apply(request: HttpMessage.Request, endpoint: RxHttpEndpoint): Rx[HttpMessage.Response] = {
       request.authorization match {
         case Some(auth) if auth == "Bearer xxxx" =>
           endpoint(request)
@@ -36,8 +36,8 @@ object NettyRxFilterTest extends AirSpec {
     }
   }
 
-  class ExFilter extends RxFilter {
-    override def apply(request: HttpMessage.Request, endpoint: RxEndpoint): Rx[HttpMessage.Response] = {
+  class ExFilter extends RxHttpFilter {
+    override def apply(request: HttpMessage.Request, endpoint: RxHttpEndpoint): Rx[HttpMessage.Response] = {
       throw RPCStatus.UNAUTHENTICATED_U13.newException("authentication failed")
     }
   }

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/HttpRequestDispatcher.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/HttpRequestDispatcher.scala
@@ -91,9 +91,9 @@ object HttpRequestDispatcher extends LogSupport {
           .filter(_.isDefined)
           .map { filter =>
             filter.get match {
-              case legacyFilter: HttpFilter[Req, Resp, F] =>
+              case legacyFilter: HttpFilter[Req, Resp, F] @unchecked =>
                 legacyFilter
-              case rxFilter: RxFilter =>
+              case rxFilter: RxHttpFilter =>
                 backend.rxFilterAdapter(rxFilter)
               case other =>
                 throw RPCStatus.UNIMPLEMENTED_U8.newException(s"Invalid filter type: ${other.getClass.getName}")

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/Route.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/Route.scala
@@ -109,7 +109,7 @@ case class ControllerRoute(
       codecFactory: MessageCodecFactory
   ): Any = {
     controller match {
-      case endpoint: RxEndpoint =>
+      case endpoint: RxHttpEndpoint =>
         val adapter = implicitly[HttpRequestAdapter[Req]]
         endpoint.apply(adapter.httpRequestOf(request))
       case _ =>

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/router/RxRouterConverterTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/router/RxRouterConverterTest.scala
@@ -14,7 +14,7 @@
 package wvlet.airframe.http.router
 
 import wvlet.airframe.http.HttpMessage.Request
-import wvlet.airframe.http.{HttpMethod, RPC, Router, RxEndpoint, RxFilter}
+import wvlet.airframe.http.{HttpMethod, RPC, Router, RxHttpEndpoint, RxHttpFilter}
 import wvlet.airframe.surface.Surface
 import wvlet.airspec.AirSpec
 
@@ -29,13 +29,13 @@ class RxRouterConverterTest extends AirSpec {
     def router: RxRouter = RxRouter.of[MyApi]
   }
 
-  trait AuthFilter extends RxFilter {
-    def apply(request: Request, endpoint: RxEndpoint) = {
+  trait AuthFilter extends RxHttpFilter {
+    def apply(request: Request, endpoint: RxHttpEndpoint) = {
       endpoint.apply(request)
     }
   }
-  trait LogFilter extends RxFilter {
-    def apply(request: Request, endpoint: RxEndpoint) = {
+  trait LogFilter extends RxHttpFilter {
+    def apply(request: Request, endpoint: RxHttpEndpoint) = {
       endpoint.apply(request)
     }
   }

--- a/airframe-http/src/main/scala-2/wvlet/airframe/http/router/RxRouterBase.scala
+++ b/airframe-http/src/main/scala-2/wvlet/airframe/http/router/RxRouterBase.scala
@@ -13,14 +13,14 @@
  */
 package wvlet.airframe.http.router
 
-import wvlet.airframe.http.RxFilter
+import wvlet.airframe.http.RxHttpFilter
 import scala.language.experimental.macros
 
 trait RxRouterObjectBase {
   def of[Controller]: RxRouter = macro RxRouterMacros.of[Controller]
-  def filter[Filter <: RxFilter]: RxRouter.FilterNode = macro RxRouterMacros.filter[Filter]
+  def filter[Filter <: RxHttpFilter]: RxRouter.FilterNode = macro RxRouterMacros.filter[Filter]
 }
 
 trait RxRouteFilterBase {
-  def andThen[Filter <: RxFilter]: RxRouter.FilterNode = macro RxRouterMacros.andThenFilter[Filter]
+  def andThen[Filter <: RxHttpFilter]: RxRouter.FilterNode = macro RxRouterMacros.andThenFilter[Filter]
 }

--- a/airframe-http/src/main/scala-2/wvlet/airframe/http/router/RxRouterMacros.scala
+++ b/airframe-http/src/main/scala-2/wvlet/airframe/http/router/RxRouterMacros.scala
@@ -34,7 +34,7 @@ private[http] object RxRouterMacros {
     import c.universe._
     val t = implicitly[c.WeakTypeTag[A]].tpe
 
-    if (t <:< c.typeTag[wvlet.airframe.http.RxFilter].tpe) {
+    if (t <:< c.typeTag[wvlet.airframe.http.RxHttpFilter].tpe) {
       q"""
        {
          wvlet.airframe.registerTraitFactory[${t}]
@@ -51,7 +51,7 @@ private[http] object RxRouterMacros {
     import c.universe._
     val t = implicitly[c.WeakTypeTag[A]].tpe
 
-    if (t <:< c.typeTag[wvlet.airframe.http.RxFilter].tpe) {
+    if (t <:< c.typeTag[wvlet.airframe.http.RxHttpFilter].tpe) {
       q"""
      {
        wvlet.airframe.registerTraitFactory[${t}]

--- a/airframe-http/src/main/scala-3/wvlet/airframe/http/router/RxRouterBase.scala
+++ b/airframe-http/src/main/scala-3/wvlet/airframe/http/router/RxRouterBase.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.http.router
 
-import wvlet.airframe.http.RxFilter
+import wvlet.airframe.http.RxHttpFilter
 import wvlet.airframe.http.router.RxRouter
 import wvlet.airframe.surface.Surface
 
@@ -23,14 +23,14 @@ trait RxRouterObjectBase {
     RxRouter.EndpointNode(Surface.of[Controller], Surface.methodsOf[Controller], None)
   }
 
-  inline def filter[Filter <: RxFilter]: RxRouter.FilterNode = {
+  inline def filter[Filter <: RxHttpFilter]: RxRouter.FilterNode = {
     wvlet.airframe.registerTraitFactory[Filter]
     RxRouter.FilterNode(None, Surface.of[Filter])
   }
 }
 
 trait RxRouteFilterBase { self: RxRouter.FilterNode =>
-  inline def andThen[Filter <: RxFilter]: RxRouter.FilterNode = {
+  inline def andThen[Filter <: RxHttpFilter]: RxRouter.FilterNode = {
     wvlet.airframe.registerTraitFactory[Filter]
     val next = RxRouter.FilterNode(None, Surface.of[Filter])
     self.andThen(next)

--- a/airframe-http/src/main/scala/wvlet/airframe/http/HttpBackend.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/HttpBackend.scala
@@ -66,7 +66,7 @@ trait HttpBackend[Req, Resp, F[_]] {
   // Wrap the given filter to a backend-specific filter
   def filterAdapter[M[_]](filter: HttpFilter[_, _, M]): Filter = ???
 
-  def rxFilterAdapter(filter: RxFilter): Filter = ???
+  def rxFilterAdapter(filter: RxHttpFilter): Filter = ???
 
   // Create a new default context that process the given request
   def newContext(body: Req => F[Resp]): Context =

--- a/airframe-http/src/main/scala/wvlet/airframe/http/RxHttpEndpoint.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/RxHttpEndpoint.scala
@@ -17,28 +17,14 @@ import wvlet.airframe.http.HttpMessage.{Request, Response}
 import wvlet.airframe.rx.{Rx, RxStream}
 
 /**
-  * [[RxEndpoint]] is a terminal for processing requests and returns `Rx[Response]`.
+  * [[RxHttpEndpoint]] is a terminal for processing requests and returns `Rx[Response]`.
   */
-trait RxEndpoint extends AutoCloseable {
-  private[http] def backend: RxHttpBackend
+trait RxHttpEndpoint extends AutoCloseable {
 
   /**
     * @param request
     * @return
     */
   def apply(request: Request): Rx[Response]
-
-  /**
-    * Set a thread-local parameter
-    */
-  def setThreadLocal[A](key: String, value: A): Unit = {
-    backend.setThreadLocal(key, value)
-  }
-
-  /**
-    * Get a thread-local parameter
-    */
-  def getThreadLocal[A](key: String): Option[A] = {
-    backend.getThreadLocal(key)
-  }
+  override def close(): Unit = {}
 }

--- a/airframe-http/src/main/scala/wvlet/airframe/http/router/RedirectToRxEndpoint.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/router/RedirectToRxEndpoint.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.http.router
 
-import wvlet.airframe.http.{Endpoint, HttpMessage, RPCContext, RxEndpoint}
+import wvlet.airframe.http.{Endpoint, HttpMessage, RPCContext, RxHttpEndpoint}
 import wvlet.airframe.rx.Rx
 import wvlet.log.LogSupport
 
@@ -21,7 +21,7 @@ import wvlet.log.LogSupport
   * An Http endpoint definition for bypassing the request to the given endpoint
   * @param endpoint
   */
-class RedirectToRxEndpoint(endpoint: RxEndpoint) extends LogSupport {
+class RedirectToRxEndpoint(endpoint: RxHttpEndpoint) extends LogSupport {
   @Endpoint(path = "/*path")
   def process(): Rx[HttpMessage.Response] = {
     val req = RPCContext.current.httpRequest

--- a/airframe-http/src/main/scala/wvlet/airframe/http/router/RxRouter.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/router/RxRouter.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.http.router
 
-import wvlet.airframe.http.RxEndpoint
+import wvlet.airframe.http.RxHttpEndpoint
 import wvlet.airframe.http.router.RxRouter.FilterNode
 import wvlet.airframe.surface.{MethodSurface, Surface}
 
@@ -69,7 +69,7 @@ case class RxRoute(filter: Option[FilterNode], controllerSurface: Surface, metho
 
 object RxRouter extends RxRouterObjectBase {
 
-  def of(endpoint: RxEndpoint): RxRouter = {
+  def of(endpoint: RxHttpEndpoint): RxRouter = {
     EndpointNode(
       controllerSurface = Surface.of[RedirectToRxEndpoint],
       methodSurfaces = Surface.methodsOf[RedirectToRxEndpoint],
@@ -133,7 +133,7 @@ object RxRouter extends RxRouterObjectBase {
       List(RxRoute(None, controllerSurface, methodSurfaces))
   }
 
-  case class RxEndpointNode(endpoint: RxEndpoint) extends RxRouter {
+  case class RxEndpointNode(endpoint: RxHttpEndpoint) extends RxRouter {
     override def name: String               = f"${this.hashCode()}%08x"
     override def filter: Option[FilterNode] = None
     override def children: List[RxRouter]   = Nil

--- a/airframe-http/src/test/scala/wvlet/airframe/http/router/CustomEndpointTest.scala
+++ b/airframe-http/src/test/scala/wvlet/airframe/http/router/CustomEndpointTest.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.http.router
 
-import wvlet.airframe.http.{Http, HttpMessage, RxEndpoint}
+import wvlet.airframe.http.{Http, HttpMessage, RxHttpEndpoint}
 import wvlet.airframe.rx.Rx
 import wvlet.airframe.surface.Surface
 import wvlet.airspec.AirSpec
@@ -21,9 +21,7 @@ import wvlet.airspec.AirSpec
 class CustomEndpointTest extends AirSpec {
 
   test("build route with custom endpoint") {
-    val endpoint = new RxEndpoint {
-      override private[http] def backend = ???
-      override def close(): Unit         = {}
+    val endpoint = new RxHttpEndpoint {
       override def apply(request: HttpMessage.Request): Rx[HttpMessage.Response] = {
         Rx.single(Http.response())
       }

--- a/airframe-http/src/test/scala/wvlet/airframe/http/router/RxRouterTest.scala
+++ b/airframe-http/src/test/scala/wvlet/airframe/http/router/RxRouterTest.scala
@@ -14,7 +14,7 @@
 package wvlet.airframe.http.router
 
 import wvlet.airframe.http.router.RxRouter.StemNode
-import wvlet.airframe.http.{HttpMessage, RxEndpoint, RxFilter}
+import wvlet.airframe.http.{HttpMessage, RxHttpEndpoint, RxHttpFilter}
 import wvlet.airframe.rx.Rx
 import wvlet.airframe.surface.Surface
 import wvlet.airspec.AirSpec
@@ -38,14 +38,14 @@ object RxRouterTest extends AirSpec {
     def router: RxRouter = RxRouter.of[MyApi2]
   }
 
-  trait AuthFilter extends RxFilter {
-    override def apply(request: HttpMessage.Request, endpoint: RxEndpoint): Rx[HttpMessage.Response] = {
+  trait AuthFilter extends RxHttpFilter {
+    override def apply(request: HttpMessage.Request, endpoint: RxHttpEndpoint): Rx[HttpMessage.Response] = {
       endpoint(request.withHeader("X-Airframe-Test", "xxx"))
     }
   }
 
-  trait LogFilter extends RxFilter {
-    override def apply(request: HttpMessage.Request, endpoint: RxEndpoint): Rx[HttpMessage.Response] = {
+  trait LogFilter extends RxHttpFilter {
+    override def apply(request: HttpMessage.Request, endpoint: RxHttpEndpoint): Rx[HttpMessage.Response] = {
       // do some logging
       endpoint.apply(request)
     }


### PR DESCRIPTION
Introducing a breaking change before RxHttpFilter is used seriously in applications