### PR TITLE
airframe-http: Check the completion of Promise in JSHttpClientChannel #2893

### DIFF
--- a/airframe-http/.js/src/main/scala/wvlet/airframe/http/client/JSHttpClientChannel.scala
+++ b/airframe-http/.js/src/main/scala/wvlet/airframe/http/client/JSHttpClientChannel.scala
@@ -64,10 +64,14 @@ class JSHttpClientChannel(serverAddress: ServerAddress, private[client] val conf
     val promise = Promise[Response]()
 
     xhr.onerror = { (e: dom.Event) =>
-      promise.failure(new IOException(s"Request failed for unknown reason: ${request}"))
+      if (!promise.isCompleted) {
+        promise.failure(new IOException(s"Request failed for unknown reason: ${request}"))
+      }
     }
     xhr.ontimeout = { (e: dom.Event) =>
-      promise.failure(new TimeoutException(s"Request timed out: ${request}"))
+      if (!promise.isCompleted) {
+        promise.failure(new TimeoutException(s"Request timed out: ${request}"))
+      }
     }
 
     val data: Array[Byte] = request.contentBytes
@@ -109,7 +113,9 @@ class JSHttpClientChannel(serverAddress: ServerAddress, private[client] val conf
           }
         }
         trace(s"Get response: ${resp}")
-        promise.success(resp)
+        if (!promise.isCompleted) {
+          promise.success(resp)
+        }
       }
     }
     Rx.future(promise.future)


### PR DESCRIPTION
The cause of #2893 looks like setting a value to Promise when it's already completed for some unexpected reason. This PR will mitigate the issue so as not to throw IllegalArgumentException at Promise method calls. 


