### PR TITLE
airframe-http: Move RxRouter under wvlet.airframe.http

### DIFF
--- a/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/http/Greeter.scala
+++ b/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/http/Greeter.scala
@@ -15,15 +15,15 @@ package wvlet.airframe.benchmark.http
 
 import wvlet.airframe.benchmark.http.Greeter.GreeterResponse
 import wvlet.airframe.http.codegen.{HttpClientGeneratorConfig, HttpCodeGenerator}
-import wvlet.airframe.http.{RPC, Router}
+import wvlet.airframe.http._
 
 @RPC
 class Greeter {
   def hello(name: String) = GreeterResponse(s"Hello ${name}!")
 }
 
-object Greeter {
-  def router = Router.of[Greeter]
+object Greeter extends RxRouterProvider {
+  override def router: RxRouter = RxRouter.of[Greeter]
 
   case class GreeterResponse(message: String)
 

--- a/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/netty/RPCNetty.scala
+++ b/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/netty/RPCNetty.scala
@@ -19,7 +19,7 @@ import org.openjdk.jmh.infra.Blackhole
 import wvlet.airframe.Session
 import wvlet.airframe.benchmark.http.HttpBenchmark.asyncIteration
 import wvlet.airframe.benchmark.http.{Greeter, NewServiceSyncClient, ServiceClient}
-import wvlet.airframe.http.Http
+import wvlet.airframe.http._
 import wvlet.airframe.http.client.{AsyncClient, SyncClient}
 import wvlet.airframe.http.finagle.{Finagle, FinagleClient}
 import wvlet.airframe.http.netty.{Netty, NettyServer}

--- a/airframe-http-codegen/src/main/scala/wvlet/airframe/http/codegen/HttpClientIR.scala
+++ b/airframe-http-codegen/src/main/scala/wvlet/airframe/http/codegen/HttpClientIR.scala
@@ -15,14 +15,14 @@ package wvlet.airframe.http.codegen
 
 import java.util.Locale
 import wvlet.airframe.http.Router.unwrapFuture
-import wvlet.airframe.http.{HttpMethod, Router}
+import wvlet.airframe.http.{HttpMethod, Router, RxRouter}
 import wvlet.airframe.http.codegen.RouteAnalyzer.RouteAnalysisResult
 import wvlet.airframe.http.codegen.client.HttpClientGenerator
 import wvlet.airframe.http.codegen.client.HttpClientGenerator.fullTypeNameOf
 import wvlet.airframe.rx.{Rx, RxStream}
 import wvlet.airframe.surface.{GenericSurface, HigherKindedTypeSurface, MethodParameter, Parameter, Surface, TypeName}
 import wvlet.log.LogSupport
-import wvlet.airframe.http.router.{HttpRequestMapper, Route, RxRouter}
+import wvlet.airframe.http.router.{HttpRequestMapper, Route}
 
 /**
   * Generate an intermediate representation (IR) of Scala HTTP client code from a given airframe-http interface

--- a/airframe-http-codegen/src/main/scala/wvlet/airframe/http/codegen/HttpCodeGenerator.scala
+++ b/airframe-http-codegen/src/main/scala/wvlet/airframe/http/codegen/HttpCodeGenerator.scala
@@ -17,10 +17,9 @@ import java.io.{File, FileWriter}
 import java.net.URLClassLoader
 import wvlet.airframe.codec.MessageCodec
 import wvlet.airframe.control.Control
-import wvlet.airframe.http.Router
+import wvlet.airframe.http.{Router, RxRouter}
 import wvlet.airframe.http.codegen.client.{AsyncClientGenerator, HttpClientGenerator}
 import wvlet.airframe.http.openapi.{OpenAPI, OpenAPIGeneratorConfig}
-import wvlet.airframe.http.router.RxRouter
 import wvlet.airframe.launcher.Launcher
 import wvlet.log.io.IOUtil
 import wvlet.log.{LogLevel, LogSupport, Logger}

--- a/airframe-http-codegen/src/main/scala/wvlet/airframe/http/codegen/RouteScanner.scala
+++ b/airframe-http-codegen/src/main/scala/wvlet/airframe/http/codegen/RouteScanner.scala
@@ -12,8 +12,7 @@
  * limitations under the License.
  */
 package wvlet.airframe.http.codegen
-import wvlet.airframe.http.router.{RxRouter, RxRouterProvider}
-import wvlet.airframe.http.{Endpoint, RPC, Router}
+import wvlet.airframe.http.{Endpoint, RPC, Router, RxRouter, RxRouterProvider}
 import wvlet.airframe.surface.{Surface, TypeName}
 import wvlet.airframe.surface.reflect.ReflectTypeUtil
 import wvlet.log.LogSupport

--- a/airframe-http-codegen/src/test/scala/example/nested/v1/MyApi.scala
+++ b/airframe-http-codegen/src/test/scala/example/nested/v1/MyApi.scala
@@ -14,8 +14,7 @@
 package example.nested.v1
 
 import example.nested.v1.MyApi.{HelloRequest, HelloResponse, Message}
-import wvlet.airframe.http.RPC
-import wvlet.airframe.http.router.{RxRouter, RxRouterProvider}
+import wvlet.airframe.http.{RPC, RxRouter, RxRouterProvider}
 
 /**
   */

--- a/airframe-http-codegen/src/test/scala/example/nested/v2/MyApi.scala
+++ b/airframe-http-codegen/src/test/scala/example/nested/v2/MyApi.scala
@@ -14,8 +14,7 @@
 package example.nested.v2
 
 import example.nested.v2.MyApi.{HelloRequest, HelloResponse}
-import wvlet.airframe.http.RPC
-import wvlet.airframe.http.router.{RxRouter, RxRouterProvider}
+import wvlet.airframe.http.{RPC, RxRouter, RxRouterProvider}
 
 /**
   */

--- a/airframe-http-codegen/src/test/scala/example/rpc/RPCTestService.scala
+++ b/airframe-http-codegen/src/test/scala/example/rpc/RPCTestService.scala
@@ -12,8 +12,7 @@
  * limitations under the License.
  */
 package example.rpc
-import wvlet.airframe.http.RPC
-import wvlet.airframe.http.router.{RxRouter, RxRouterProvider}
+import wvlet.airframe.http.{RPC, RxRouter, RxRouterProvider}
 
 /**
   */

--- a/airframe-http-codegen/src/test/scala/wvlet/airframe/http/codegen/RPCClientGeneratorTest.scala
+++ b/airframe-http-codegen/src/test/scala/wvlet/airframe/http/codegen/RPCClientGeneratorTest.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.http.codegen
 
-import wvlet.airframe.http.router.RxRouter
+import wvlet.airframe.http.RxRouter
 import wvlet.airspec.AirSpec
 
 class RPCClientGeneratorTest extends AirSpec {

--- a/airframe-http-codegen/src/test/scala/wvlet/airframe/http/codegen/RxRouterProviderTest.scala
+++ b/airframe-http-codegen/src/test/scala/wvlet/airframe/http/codegen/RxRouterProviderTest.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.http.codegen
 
-import wvlet.airframe.http.router.RxRouter
+import wvlet.airframe.http.RxRouter
 import wvlet.airspec.AirSpec
 
 class RxRouterProviderTest extends AirSpec {

--- a/airframe-http-finagle/src/main/scala/wvlet/airframe/http/finagle/FinagleServer.scala
+++ b/airframe-http-finagle/src/main/scala/wvlet/airframe/http/finagle/FinagleServer.scala
@@ -25,7 +25,16 @@ import wvlet.airframe.codec.MessageCodec
 import wvlet.airframe.control.MultipleExceptions
 import wvlet.airframe.http.finagle.FinagleServer.FinagleService
 import wvlet.airframe.http.finagle.filter.HttpAccessLogFilter
-import wvlet.airframe.http.{HttpBackend, HttpHeader, HttpMessage, HttpServerException, RPCContext, RPCException, Router, RxRouter}
+import wvlet.airframe.http.{
+  HttpBackend,
+  HttpHeader,
+  HttpMessage,
+  HttpServerException,
+  RPCContext,
+  RPCException,
+  Router,
+  RxRouter
+}
 import wvlet.airframe.http.router.{ControllerProvider, HttpRequestDispatcher, ResponseHandler}
 import wvlet.airframe.surface.Surface
 import wvlet.log.LogSupport
@@ -64,9 +73,14 @@ case class FinagleServerConfig(
   def withPort(port: Int): FinagleServerConfig = {
     this.copy(serverPort = Some(port))
   }
+  @deprecated("Use withRouter(RxRouter)", "23.5.0")
   def withRouter(router: Router): FinagleServerConfig = {
     this.copy(router = router)
   }
+  def withRouter(router: RxRouter): FinagleServerConfig = {
+    this.copy(router = Router.fromRxRouter(router))
+  }
+
   def withCustomCodec(p: PartialFunction[Surface, MessageCodec[_]]): FinagleServerConfig = {
     this.copy(customCodec = p)
   }

--- a/airframe-http-finagle/src/main/scala/wvlet/airframe/http/finagle/FinagleServer.scala
+++ b/airframe-http-finagle/src/main/scala/wvlet/airframe/http/finagle/FinagleServer.scala
@@ -25,8 +25,8 @@ import wvlet.airframe.codec.MessageCodec
 import wvlet.airframe.control.MultipleExceptions
 import wvlet.airframe.http.finagle.FinagleServer.FinagleService
 import wvlet.airframe.http.finagle.filter.HttpAccessLogFilter
-import wvlet.airframe.http.{HttpBackend, HttpHeader, HttpMessage, HttpServerException, RPCContext, RPCException, Router}
-import wvlet.airframe.http.router.{ControllerProvider, HttpRequestDispatcher, ResponseHandler, RxRouter}
+import wvlet.airframe.http.{HttpBackend, HttpHeader, HttpMessage, HttpServerException, RPCContext, RPCException, Router, RxRouter}
+import wvlet.airframe.http.router.{ControllerProvider, HttpRequestDispatcher, ResponseHandler}
 import wvlet.airframe.surface.Surface
 import wvlet.log.LogSupport
 import wvlet.log.io.IOUtil

--- a/airframe-http-grpc/src/main/scala/wvlet/airframe/http/grpc/GrpcServer.scala
+++ b/airframe-http-grpc/src/main/scala/wvlet/airframe/http/grpc/GrpcServer.scala
@@ -15,7 +15,7 @@ package wvlet.airframe.http.grpc
 
 import io.grpc._
 import wvlet.airframe.codec.MessageCodecFactory
-import wvlet.airframe.http.Router
+import wvlet.airframe.http.{Router, RxRouter}
 import wvlet.airframe.http.grpc.internal.{GrpcRequestLogger, GrpcServiceBuilder}
 import wvlet.airframe.{Design, Session}
 import wvlet.log.LogSupport
@@ -45,9 +45,12 @@ case class GrpcServerConfig(
 ) extends LogSupport {
   lazy val port = serverPort.getOrElse(IOUtil.unusedPort)
 
-  def withName(name: String): GrpcServerConfig     = this.copy(name = name)
-  def withPort(port: Int): GrpcServerConfig        = this.copy(serverPort = Some(port))
-  def withRouter(router: Router): GrpcServerConfig = this.copy(router = router)
+  def withName(name: String): GrpcServerConfig = this.copy(name = name)
+  def withPort(port: Int): GrpcServerConfig    = this.copy(serverPort = Some(port))
+
+  @deprecated("Use withRouter(RxRouter)", "23.5.0")
+  def withRouter(router: Router): GrpcServerConfig   = this.copy(router = router)
+  def withRouter(router: RxRouter): GrpcServerConfig = this.copy(router = Router.fromRxRouter(router))
 
   /**
     * Use this method to customize gRPC server, e.g., setting tracer, add transport filter, etc.

--- a/airframe-http-netty/src/main/scala/wvlet/airframe/http/netty/NettyServer.scala
+++ b/airframe-http-netty/src/main/scala/wvlet/airframe/http/netty/NettyServer.scala
@@ -26,7 +26,7 @@ import wvlet.airframe.codec.MessageCodecFactory
 import wvlet.airframe.control.ThreadUtil
 import wvlet.airframe.http._
 import wvlet.airframe.http.client.SyncClient
-import wvlet.airframe.http.router.{ControllerProvider, HttpRequestDispatcher, RxRouter}
+import wvlet.airframe.http.router.{ControllerProvider, HttpRequestDispatcher}
 import wvlet.airframe.{Design, Session}
 import wvlet.log.LogSupport
 import wvlet.log.io.IOUtil

--- a/airframe-http-netty/src/main/scala/wvlet/airframe/http/netty/NettyServer.scala
+++ b/airframe-http-netty/src/main/scala/wvlet/airframe/http/netty/NettyServer.scala
@@ -53,10 +53,6 @@ case class NettyServerConfig(
   def withPort(port: Int): NettyServerConfig = {
     this.copy(serverPort = Some(port))
   }
-  @deprecated("Use withRouter(RxRouter) instead", "23.4.3")
-  def withRouter(router: Router): NettyServerConfig = {
-    this.copy(router = router)
-  }
   def withRouter(rxRouter: RxRouter): NettyServerConfig = {
     this.copy(router = Router.fromRxRouter(rxRouter))
   }

--- a/airframe-http-netty/src/test/scala/wvlet/airframe/http/netty/NettyRPCServerTest.scala
+++ b/airframe-http-netty/src/test/scala/wvlet/airframe/http/netty/NettyRPCServerTest.scala
@@ -14,7 +14,7 @@
 package wvlet.airframe.http.netty
 
 import wvlet.airframe.Design
-import wvlet.airframe.http.{Http, RPC, Router}
+import wvlet.airframe.http._
 import wvlet.airframe.http.client.SyncClient
 import wvlet.airframe.rx.Rx
 import wvlet.airspec.AirSpec
@@ -28,7 +28,7 @@ object NettyRPCServerTest extends AirSpec {
     def helloNetty(msg: String): String = s"Hello ${msg}!"
   }
 
-  private def router = Router.of[MyRPC]
+  private def router = RxRouter.of[MyRPC]
 
   override protected def design: Design = {
     Netty.server

--- a/airframe-http-netty/src/test/scala/wvlet/airframe/http/netty/NettyRxFilterTest.scala
+++ b/airframe-http-netty/src/test/scala/wvlet/airframe/http/netty/NettyRxFilterTest.scala
@@ -14,8 +14,7 @@
 package wvlet.airframe.http.netty
 
 import wvlet.airframe.http.client.SyncClient
-import wvlet.airframe.http.{Http, HttpMessage, RPC, RPCException, RPCStatus, RxHttpEndpoint, RxHttpFilter}
-import wvlet.airframe.http.router.RxRouter
+import wvlet.airframe.http.{Http, HttpMessage, RPC, RPCException, RPCStatus, RxHttpEndpoint, RxHttpFilter, RxRouter}
 import wvlet.airframe.rx.Rx
 import wvlet.airspec.AirSpec
 

--- a/airframe-http-netty/src/test/scala/wvlet/airframe/http/netty/NettyRxRPCServerTest.scala
+++ b/airframe-http-netty/src/test/scala/wvlet/airframe/http/netty/NettyRxRPCServerTest.scala
@@ -14,9 +14,8 @@
 package wvlet.airframe.http.netty
 
 import wvlet.airframe.Design
-import wvlet.airframe.http.{Http, RPC}
+import wvlet.airframe.http.{Http, RPC, RxRouter}
 import wvlet.airframe.http.client.SyncClient
-import wvlet.airframe.http.router.RxRouter
 import wvlet.airspec.AirSpec
 
 class NettyRxRPCServerTest extends AirSpec {

--- a/airframe-http-netty/src/test/scala/wvlet/airframe/http/netty/RPCClientBindingTest.scala
+++ b/airframe-http-netty/src/test/scala/wvlet/airframe/http/netty/RPCClientBindingTest.scala
@@ -17,7 +17,6 @@ import wvlet.airframe.http._
 import wvlet.airframe.http.client.SyncClient
 import wvlet.airframe.http.netty.MyRPCClient.RPCSyncClient
 import wvlet.airframe.http.netty.RPCClientBindingTest.MyApi.{HelloRequest, HelloResponse}
-import wvlet.airframe.http.router.RxRouter
 import wvlet.airframe.surface.Surface
 import wvlet.airspec.AirSpec
 

--- a/airframe-http-okhttp/src/test/scala/wvlet/airframe/http/okhttp/OkHttpClientTest.scala
+++ b/airframe-http-okhttp/src/test/scala/wvlet/airframe/http/okhttp/OkHttpClientTest.scala
@@ -5,7 +5,6 @@ import wvlet.airframe.control.Control.withResource
 import wvlet.airframe.http.HttpMessage.{Request, Response}
 import wvlet.airframe.http.client.{AsyncClient, SyncClient}
 import wvlet.airframe.http.netty.{Netty, NettyServer}
-import wvlet.airframe.http.router.RxRouter
 import wvlet.airframe.http._
 import wvlet.airspec.AirSpec
 import wvlet.log.LogSupport

--- a/airframe-http-recorder/src/main/scala/wvlet/airframe/http/recorder/HttpRecorderServer.scala
+++ b/airframe-http-recorder/src/main/scala/wvlet/airframe/http/recorder/HttpRecorderServer.scala
@@ -15,9 +15,8 @@ package wvlet.airframe.http.recorder
 
 import wvlet.airframe.{Design, Session}
 import wvlet.airframe.http.HttpMessage.{Request, Response}
-import wvlet.airframe.http.{RxHttpEndpoint, RxHttpFilter}
+import wvlet.airframe.http.{RxHttpEndpoint, RxHttpFilter, RxRouter}
 import wvlet.airframe.http.netty.{Netty, NettyServer, NettyServerConfig}
-import wvlet.airframe.http.router.RxRouter
 import wvlet.airframe.rx.{Rx, RxStream}
 import wvlet.log.LogSupport
 import wvlet.log.io.IOUtil

--- a/airframe-http/.jvm/src/main/scala-2/wvlet/airframe/http/router/RouterBase.scala
+++ b/airframe-http/.jvm/src/main/scala-2/wvlet/airframe/http/router/RouterBase.scala
@@ -29,6 +29,8 @@ trait RouterBase {
 }
 
 trait RouterObjectBase {
+  @deprecated("Use RxRouter.of[Controller] instead", "23.5.0")
   def of[Controller]: Router = macro RouterMacros.of[Controller]
+  @deprecated("Use RxRouter.of[Controller] instead", "23.5.0")
   def add[Controller]: Router = macro RouterMacros.of[Controller]
 }

--- a/airframe-http/.jvm/src/main/scala-3/wvlet/airframe/http/router/RouterBase.scala
+++ b/airframe-http/.jvm/src/main/scala-3/wvlet/airframe/http/router/RouterBase.scala
@@ -30,8 +30,10 @@ trait RouterBase { self: Router =>
 }
 
 trait RouterObjectBase {
+  @deprecated("Use RxRouter.of[Controller] instead", "23.5.0")
   inline def of[Controller]: Router = ${ RouterObjectMacros.routerOf[Controller] }
 
+  @deprecated("Use RxRouter.of[Controller] instead", "23.5.0")
   inline def add[Controller]: Router = ${ RouterObjectMacros.routerOf[Controller] }
 }
 

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/Router.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/Router.scala
@@ -16,10 +16,10 @@ package wvlet.airframe.http
 import wvlet.airframe.http.HttpMessage.Response
 import wvlet.airframe.http.Router.extractEndpointRoutes
 import wvlet.airframe.http.router.Automaton.DFA
-import wvlet.airframe.http.router.RxRouter.{EndpointNode, FilterNode, RxEndpointNode, StemNode}
+import wvlet.airframe.http.RxRouter.{EndpointNode, FilterNode, RxEndpointNode, StemNode}
 import wvlet.airframe.surface._
 import wvlet.log.LogSupport
-import wvlet.airframe.http.router.{ControllerRoute, RedirectToRxEndpoint, Route, RouteMatch, RouteMatcher, RxRouter}
+import wvlet.airframe.http.router.{ControllerRoute, RedirectToRxEndpoint, Route, RouteMatch, RouteMatcher}
 
 import scala.annotation.tailrec
 import scala.language.experimental.macros

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/router/RxRouterConverterTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/router/RxRouterConverterTest.scala
@@ -14,7 +14,7 @@
 package wvlet.airframe.http.router
 
 import wvlet.airframe.http.HttpMessage.Request
-import wvlet.airframe.http.{HttpMethod, RPC, Router, RxHttpEndpoint, RxHttpFilter}
+import wvlet.airframe.http.{HttpMethod, RPC, Router, RxHttpEndpoint, RxHttpFilter, RxRouter}
 import wvlet.airframe.surface.Surface
 import wvlet.airspec.AirSpec
 

--- a/airframe-http/src/main/scala-2/wvlet/airframe/http/RxRouterMacros.scala
+++ b/airframe-http/src/main/scala-2/wvlet/airframe/http/RxRouterMacros.scala
@@ -11,8 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.airframe.http.router
-
+package wvlet.airframe.http
 import scala.language.experimental.macros
 import scala.reflect.macros.{blackbox => sm}
 
@@ -25,7 +24,7 @@ private[http] object RxRouterMacros {
     q"""
      {
        wvlet.airframe.registerTraitFactory[${t}]
-       wvlet.airframe.http.router.RxRouter.EndpointNode(wvlet.airframe.surface.Surface.of[${t}], wvlet.airframe.surface.Surface.methodsOf[${t}])
+       wvlet.airframe.http.RxRouter.EndpointNode(wvlet.airframe.surface.Surface.of[${t}], wvlet.airframe.surface.Surface.methodsOf[${t}])
      }
    """
   }
@@ -38,7 +37,7 @@ private[http] object RxRouterMacros {
       q"""
        {
          wvlet.airframe.registerTraitFactory[${t}]
-         wvlet.airframe.http.router.RxRouter.FilterNode(None, wvlet.airframe.surface.Surface.of[${t}])
+         wvlet.airframe.http.RxRouter.FilterNode(None, wvlet.airframe.surface.Surface.of[${t}])
        }
      """
     } else {
@@ -55,7 +54,7 @@ private[http] object RxRouterMacros {
       q"""
      {
        wvlet.airframe.registerTraitFactory[${t}]
-       val next = wvlet.airframe.http.router.RxRouter.FilterNode(None, wvlet.airframe.surface.Surface.of[${t}])
+       val next = wvlet.airframe.http.RxRouter.FilterNode(None, wvlet.airframe.surface.Surface.of[${t}])
        ${c.prefix}.andThen(next)
      }
    """

--- a/airframe-http/src/main/scala-2/wvlet/airframe/http/RxRouterObjectBase.scala
+++ b/airframe-http/src/main/scala-2/wvlet/airframe/http/RxRouterObjectBase.scala
@@ -11,23 +11,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.airframe.http.router
+package wvlet.airframe.http
+import scala.language.experimental.macros
 
-/**
-  * An interface used for RPC clients (sbt-airframe) to discover the default router for the RPC endpoint.
-  *
-  * Example usage:
-  * {{{
-  *   trait MyRPC {
-  *     def hello(name:String) : String
-  *   }
-  *
-  *   object MyRPC extends RxRouterProvider {
-  *     // sbt-airframe will generate an RPC client using this router
-  *     override def router: RxRouter = RxRouter.of[MyRPC]
-  *   }
-  * }}}
-  */
-trait RxRouterProvider {
-  def router: RxRouter
+trait RxRouterObjectBase {
+  def of[Controller]: RxRouter = macro RxRouterMacros.of[Controller]
+  def filter[Filter <: RxHttpFilter]: RxRouter.FilterNode = macro RxRouterMacros.filter[Filter]
+}
+
+trait RxRouteFilterBase {
+  def andThen[Filter <: RxHttpFilter]: RxRouter.FilterNode = macro RxRouterMacros.andThenFilter[Filter]
 }

--- a/airframe-http/src/main/scala-3/wvlet/airframe/http/RxRouterBase.scala
+++ b/airframe-http/src/main/scala-3/wvlet/airframe/http/RxRouterBase.scala
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.airframe.http.router
+package wvlet.airframe.http
 
 import wvlet.airframe.http.RxHttpFilter
 import wvlet.airframe.http.RxRouter

--- a/airframe-http/src/main/scala-3/wvlet/airframe/http/RxRouterBase.scala
+++ b/airframe-http/src/main/scala-3/wvlet/airframe/http/RxRouterBase.scala
@@ -14,7 +14,7 @@
 package wvlet.airframe.http.router
 
 import wvlet.airframe.http.RxHttpFilter
-import wvlet.airframe.http.router.RxRouter
+import wvlet.airframe.http.RxRouter
 import wvlet.airframe.surface.Surface
 
 trait RxRouterObjectBase {

--- a/airframe-http/src/main/scala/wvlet/airframe/http/RxRouter.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/RxRouter.scala
@@ -11,21 +11,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.airframe.http.router
+package wvlet.airframe.http
 
-import wvlet.airframe.http.RxHttpEndpoint
-import wvlet.airframe.http.router.RxRouter.FilterNode
+import wvlet.airframe.http.router.{RedirectToRxEndpoint, RxRoute}
 import wvlet.airframe.surface.{MethodSurface, Surface}
 
 trait RxRouter {
   def name: String
-  def filter: Option[FilterNode]
+  def filter: Option[RxRouter.FilterNode]
   def children: List[RxRouter]
   def isLeaf: Boolean
 
   def routes: List[RxRoute]
 
-  def wrapWithFilter(parentFilter: FilterNode): RxRouter
+  def wrapWithFilter(parentFilter: RxRouter.FilterNode): RxRouter
 
   override def toString: String = printNode(0)
 
@@ -47,23 +46,6 @@ trait RxRouter {
       s += c.printNode(indentLevel + 1)
     }
     s.result().mkString("\n")
-  }
-}
-
-case class RxRoute(filter: Option[FilterNode], controllerSurface: Surface, methodSurfaces: Seq[MethodSurface]) {
-  override def toString: String = {
-    val s = Seq.newBuilder[String]
-    for (m <- methodSurfaces) {
-      s += s"${m.name}(${m.args.map(x => s"${x.name}:${x.surface}").mkString(", ")}): ${m.returnType}"
-    }
-    s.result().mkString("\n")
-  }
-
-  def wrapWithFilter(parentFilter: Option[FilterNode]): RxRoute = {
-    this.copy(filter = parentFilter match {
-      case None    => filter
-      case Some(f) => f.andThenOpt(filter)
-    })
   }
 }
 

--- a/airframe-http/src/main/scala/wvlet/airframe/http/RxRouterProvider.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/RxRouterProvider.scala
@@ -11,16 +11,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.airframe.http.router
+package wvlet.airframe.http
 
-import wvlet.airframe.http.RxHttpFilter
-import scala.language.experimental.macros
-
-trait RxRouterObjectBase {
-  def of[Controller]: RxRouter = macro RxRouterMacros.of[Controller]
-  def filter[Filter <: RxHttpFilter]: RxRouter.FilterNode = macro RxRouterMacros.filter[Filter]
-}
-
-trait RxRouteFilterBase {
-  def andThen[Filter <: RxHttpFilter]: RxRouter.FilterNode = macro RxRouterMacros.andThenFilter[Filter]
+/**
+  * An interface used for RPC clients (sbt-airframe) to discover the default router for the RPC endpoint.
+  *
+  * Example usage:
+  * {{{
+  *   trait MyRPC {
+  *     def hello(name:String) : String
+  *   }
+  *
+  *   object MyRPC extends RxRouterProvider {
+  *     // sbt-airframe will generate an RPC client using this router
+  *     override def router: RxRouter = RxRouter.of[MyRPC]
+  *   }
+  * }}}
+  */
+trait RxRouterProvider {
+  def router: RxRouter
 }

--- a/airframe-http/src/main/scala/wvlet/airframe/http/RxRouterProvider.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/RxRouterProvider.scala
@@ -18,6 +18,9 @@ package wvlet.airframe.http
   *
   * Example usage:
   * {{{
+  *   import wvlet.airframe.http._
+  *
+  *   @RPC
   *   trait MyRPC {
   *     def hello(name:String) : String
   *   }

--- a/airframe-http/src/main/scala/wvlet/airframe/http/router/RxRoute.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/router/RxRoute.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.http.router
+
+import wvlet.airframe.http.RxRouter.FilterNode
+import wvlet.airframe.surface.{MethodSurface, Surface}
+
+case class RxRoute(filter: Option[FilterNode], controllerSurface: Surface, methodSurfaces: Seq[MethodSurface]) {
+  override def toString: String = {
+    val s = Seq.newBuilder[String]
+    for (m <- methodSurfaces) {
+      s += s"${m.name}(${m.args.map(x => s"${x.name}:${x.surface}").mkString(", ")}): ${m.returnType}"
+    }
+    s.result().mkString("\n")
+  }
+
+  def wrapWithFilter(parentFilter: Option[FilterNode]): RxRoute = {
+    this.copy(filter = parentFilter match {
+      case None    => filter
+      case Some(f) => f.andThenOpt(filter)
+    })
+  }
+}

--- a/airframe-http/src/test/scala/wvlet/airframe/http/RxRouterTest.scala
+++ b/airframe-http/src/test/scala/wvlet/airframe/http/RxRouterTest.scala
@@ -11,10 +11,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.airframe.http.router
+package wvlet.airframe.http
 
-import wvlet.airframe.http.router.RxRouter.StemNode
-import wvlet.airframe.http.{HttpMessage, RxHttpEndpoint, RxHttpFilter}
+import wvlet.airframe.http.RxRouter.StemNode
+import wvlet.airframe.http.router.RxRoute
 import wvlet.airframe.rx.Rx
 import wvlet.airframe.surface.Surface
 import wvlet.airspec.AirSpec

--- a/airframe-http/src/test/scala/wvlet/airframe/http/router/CustomEndpointTest.scala
+++ b/airframe-http/src/test/scala/wvlet/airframe/http/router/CustomEndpointTest.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.http.router
 
-import wvlet.airframe.http.{Http, HttpMessage, RxHttpEndpoint}
+import wvlet.airframe.http.{Http, HttpMessage, RxHttpEndpoint, RxRouter}
 import wvlet.airframe.rx.Rx
 import wvlet.airframe.surface.Surface
 import wvlet.airspec.AirSpec

--- a/sbt-airframe/src/sbt-test/sbt-airframe/grpc/api/src/main/scala/example/api/GreeterApi.scala
+++ b/sbt-airframe/src/sbt-test/sbt-airframe/grpc/api/src/main/scala/example/api/GreeterApi.scala
@@ -1,7 +1,6 @@
 package example.api
 
-import wvlet.airframe.http.RPC
-import wvlet.airframe.http.router.{RxRouter, RxRouterProvider}
+import wvlet.airframe.http._
 import wvlet.airframe.rx.RxStream
 
 @RPC

--- a/sbt-airframe/src/sbt-test/sbt-airframe/grpc/server/src/test/scala/example/api/GreeterApiTest.scala
+++ b/sbt-airframe/src/sbt-test/sbt-airframe/grpc/server/src/test/scala/example/api/GreeterApiTest.scala
@@ -4,7 +4,6 @@ import wvlet.airspec._
 import wvlet.airframe._
 import wvlet.airframe.rx.{Rx, RxStream}
 import wvlet.airframe.http._
-import wvlet.airframe.http.router.RxRouter
 import wvlet.airframe.http.grpc.gRPC
 import wvlet.airframe.http.grpc.GrpcServer
 import io.grpc.ManagedChannelBuilder

--- a/sbt-airframe/src/sbt-test/sbt-airframe/js-client/spi/src/main/scala/myspp/spi/MyService.scala
+++ b/sbt-airframe/src/sbt-test/sbt-airframe/js-client/spi/src/main/scala/myspp/spi/MyService.scala
@@ -14,7 +14,6 @@
 package myapp.spi
 
 import wvlet.airframe.http._
-import wvlet.airframe.http.router.{RxRouter, RxRouterProvider}
 
 @RPC
 trait MyRPC {

--- a/sbt-airframe/src/sbt-test/sbt-airframe/openapi/src/main/scala/example/api/RPCExample.scala
+++ b/sbt-airframe/src/sbt-test/sbt-airframe/openapi/src/main/scala/example/api/RPCExample.scala
@@ -12,8 +12,8 @@
  * limitations under the License.
  */
 package example.api
-import wvlet.airframe.http.RPC
-import wvlet.airframe.http.router.{RxRouter,RxRouterProvider}
+import wvlet.airframe.http._
+
 /**
   */
 @RPC

--- a/sbt-airframe/src/sbt-test/sbt-airframe/rpc-finagle/api/src/main/scala/example/api/MyRPCApi.scala
+++ b/sbt-airframe/src/sbt-test/sbt-airframe/rpc-finagle/api/src/main/scala/example/api/MyRPCApi.scala
@@ -1,7 +1,6 @@
 package example.api
 
-import wvlet.airframe.http.RPC
-import wvlet.airframe.http.router.{RxRouter,RxRouterProvider}
+import wvlet.airframe.http._
 import wvlet.log.LogSupport
 
 @RPC

--- a/sbt-airframe/src/sbt-test/sbt-airframe/rpc-finagle/server/src/test/scala/example/MyRPCTest.scala
+++ b/sbt-airframe/src/sbt-test/sbt-airframe/rpc-finagle/server/src/test/scala/example/MyRPCTest.scala
@@ -2,7 +2,7 @@ package example
 
 import wvlet.airspec.AirSpec
 import wvlet.airframe._
-import wvlet.airframe.http.{Http, Router}
+import wvlet.airframe.http._
 import wvlet.airframe.http.finagle.{Finagle, FinagleServer}
 import example.api.MyRPCApi
 import example.api.MyRPCApi.{HelloRequest, HelloResponse}
@@ -11,7 +11,7 @@ import example.api.MyRPCClient.RPCSyncClient
 
 class MyRPCTest extends AirSpec {
 
-  private val router = Router.of[MyRPCApi]
+  private val router = RxRouter.of[MyRPCApi]
 
   override protected def design: Design = {
     Finagle.server

--- a/sbt-airframe/src/sbt-test/sbt-airframe/rpc-netty/api/src/main/scala/example/api/MyRPCApi.scala
+++ b/sbt-airframe/src/sbt-test/sbt-airframe/rpc-netty/api/src/main/scala/example/api/MyRPCApi.scala
@@ -1,7 +1,6 @@
 package example.api
 
-import wvlet.airframe.http.RPC
-import wvlet.airframe.http.router.{RxRouter,RxRouterProvider}
+import wvlet.airframe.http._
 import wvlet.log.LogSupport
 
 @RPC

--- a/sbt-airframe/src/test/scala/example/MyService.scala
+++ b/sbt-airframe/src/test/scala/example/MyService.scala
@@ -42,6 +42,10 @@ trait ResourceApi {
   }
 }
 
+object ResourceApi extends RxRouterProvider {
+  override def router: RxRouter = RxRouter.of[ResourceApi]
+}
+
 case class Query(id: String, sql: String)
 case class CreateQueryRequest(request_id: String = UUID.randomUUID().toString, sql: String)
 case class QueryResultResponse(id: String, nextToken: String)
@@ -58,4 +62,8 @@ trait QueryApi {
 
   @Endpoint(method = HttpMethod.POST, path = "/v1/query")
   def newQuery(createQueryRequest: CreateQueryRequest): QueryResultResponse
+}
+
+object QueryApi extends RxRouterProvider {
+  override def router: RxRouter = RxRouter.of[ResourceApi]
 }


### PR DESCRIPTION
With this PR `import wvlet.airframe.http._`  will be sufficient to define a new RPC interface 

- airframe-http: Move RxRouter under wvlet.airframe.http package
- Fix sbt-airframe tests to use the new package
- Add .withRouter(RxRouter)
