### PR TITLE
airframe-http (internal): Fix flaky JS http client tests

### DIFF
--- a/airframe-http/.js/src/main/scala/wvlet/airframe/http/client/JSHttpClientChannel.scala
+++ b/airframe-http/.js/src/main/scala/wvlet/airframe/http/client/JSHttpClientChannel.scala
@@ -31,12 +31,6 @@ class JSHttpClientChannel(serverAddress: ServerAddress, private[client] val conf
 
   private[client] implicit val executionContext: ExecutionContext = config.newExecutionContext
 
-  /**
-    * Provide the underlying ExecutionContext. This is only for internal-use
-    * @return
-    */
-  private[http] def getExecutionContext: ExecutionContext = executionContext
-
   override def close(): Unit = {
     // nothing to do
   }

--- a/airframe-http/.js/src/test/scala/wvlet/airframe/http/client/JSRPCClientTest.scala
+++ b/airframe-http/.js/src/test/scala/wvlet/airframe/http/client/JSRPCClientTest.scala
@@ -13,34 +13,31 @@
  */
 package wvlet.airframe.http.client
 
-import wvlet.airframe.http.HttpHeader.MediaType
 import wvlet.airframe.http.{Http, HttpClientConfig, RPCMethod}
 import wvlet.airframe.surface.Surface
 import wvlet.airspec.AirSpec
 
 object JSRPCClientTest extends AirSpec {
   case class Person(id: Int, name: String)
-  private val p     = Person(1, "leo")
-  private val pJson = """{"id":1,"name":"leo"}"""
+  private val p = Person(1, "leo")
 
   // Use a public REST test server
-  private val PUBLIC_REST_SERVICE = "https://httpbin.org/"
-  case class TestRequest(id: Int, name: String)
-  case class TestResponse(url: String, headers: Map[String, Any])
+  private val PUBLIC_REST_SERVICE = "https://jsonplaceholder.typicode.com"
+  case class TestRequest(userId: Int, name: String)
+  case class TestResponse(userId: Int, name: String)
 
   test("Create an Async RPCClient") {
     val client = Http.client.newAsyncClient(PUBLIC_REST_SERVICE)
 
     test("rpc") {
       flaky {
-        val m = RPCMethod("/post", "example.Api", "test", Surface.of[TestRequest], Surface.of[TestResponse])
+        val m = RPCMethod("/posts", "example.Api", "test", Surface.of[TestRequest], Surface.of[TestResponse])
         client
           .rpc[TestRequest, TestResponse](m, TestRequest(1, "test"))
           .toRxStream
           .map { response =>
-            info(response)
-            response.headers.get("Content-Type") shouldBe Some(MediaType.ApplicationJson)
-            response
+            debug(response)
+            response shouldBe TestResponse(1, "test")
           }
       }
     }
@@ -48,12 +45,11 @@ object JSRPCClientTest extends AirSpec {
     test("call") {
       flaky {
         client
-          .call[Person, Map[String, Any]](Http.POST("/post"), p)
+          .call[Person, Map[String, Any]](Http.POST("/posts"), p)
           .toRxStream
           .map { m =>
-            info(m)
-            m("data") shouldBe pJson
-            m("json") shouldBe Map("id" -> 1, "name" -> "leo")
+            debug(m)
+            m shouldBe Map("id" -> 101, "name" -> "leo")
           }
       }
     }

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/client/JavaHttpClientBackend.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/client/JavaHttpClientBackend.scala
@@ -16,6 +16,6 @@ import wvlet.airframe.http.{HttpClientConfig, ServerAddress}
 
 object JavaHttpClientBackend extends HttpClientBackend {
   override def newHttpChannel(serverAddress: ServerAddress, config: HttpClientConfig): HttpChannel = {
-    new JavaClientChannel(serverAddress, config)
+    new JavaHttpClientChannel(serverAddress, config)
   }
 }

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/client/JavaHttpClientChannel.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/client/JavaHttpClientChannel.scala
@@ -36,7 +36,8 @@ import scala.jdk.CollectionConverters._
   * @param serverAddress
   * @param config
   */
-class JavaClientChannel(serverAddress: ServerAddress, private[http] val config: HttpClientConfig) extends HttpChannel {
+class JavaHttpClientChannel(serverAddress: ServerAddress, private[http] val config: HttpClientConfig)
+    extends HttpChannel {
   private val javaHttpClient: HttpClient = initClient(config)
 
   private def initClient(config: HttpClientConfig): HttpClient = {

--- a/airframe-http/src/main/scala/wvlet/airframe/http/client/ClientFilter.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/client/ClientFilter.scala
@@ -17,8 +17,6 @@ import wvlet.airframe.http.HttpClientConfig
 import wvlet.airframe.http.HttpMessage.{Request, Response}
 import wvlet.airframe.rx.Rx
 
-import scala.concurrent.Future
-
 /**
   * Http client request and response interceptor interface.
   *


### PR DESCRIPTION
- Switch the public REST endpoint for testing from https://httpbin.org/ to https://jsonplaceholder.typicode.com/