### PR TITLE
airframe-http: Support reading REST endpoints with RPC clients

### DIFF
--- a/airframe-http-codegen/src/main/scala/wvlet/airframe/http/codegen/HttpClientIR.scala
+++ b/airframe-http-codegen/src/main/scala/wvlet/airframe/http/codegen/HttpClientIR.scala
@@ -170,7 +170,8 @@ object HttpClientIR extends LogSupport {
       returnType: Surface,
       path: String,
       // A case class definition for wrapping HTTP request parameters
-      requestModelClassDef: Option[ClientRequestModelClassDef] = None
+      requestModelClassDef: Option[ClientRequestModelClassDef] = None,
+      isRPC: Boolean
   ) extends ClientCodeIR {
     def typeArgString =
       typeArgs
@@ -382,7 +383,8 @@ object HttpClientIR extends LogSupport {
         clientCallParameters = clientCallParams.result(),
         path = analysis.pathString,
         returnType = unwrapFuture(route.returnTypeSurface),
-        requestModelClassDef = requestModelClassDef
+        requestModelClassDef = requestModelClassDef,
+        isRPC = route.isRPC
       )
     }
 

--- a/airframe-http-codegen/src/main/scala/wvlet/airframe/http/codegen/client/RPCClientGenerator.scala
+++ b/airframe-http-codegen/src/main/scala/wvlet/airframe/http/codegen/client/RPCClientGenerator.scala
@@ -156,7 +156,7 @@ object RPCClientGenerator extends HttpClientGenerator {
                    |}""".stripMargin
               case _ =>
                 val args = Seq.newBuilder[String]
-                args += s"Http.${m.httpMethod}(${m.path})"
+                args += s"""Http.${m.httpMethod}("${m.path}")"""
                 args += m.path
                 args ++= m.clientCallParameters
                 s"""def ${m.name}(${inputArgs.mkString(", ")}): ${returnType} = {

--- a/airframe-http-codegen/src/main/scala/wvlet/airframe/http/codegen/client/RPCClientGenerator.scala
+++ b/airframe-http-codegen/src/main/scala/wvlet/airframe/http/codegen/client/RPCClientGenerator.scala
@@ -157,7 +157,6 @@ object RPCClientGenerator extends HttpClientGenerator {
               case _ =>
                 val args = Seq.newBuilder[String]
                 args += s"""Http.${m.httpMethod}("${m.path}")"""
-                args += m.path
                 args ++= m.clientCallParameters
                 s"""def ${m.name}(${inputArgs.mkString(", ")}): ${returnType} = {
                    |  client.call[${m.typeArgString}](${args.result().mkString(", ")})

--- a/airframe-http-codegen/src/main/scala/wvlet/airframe/http/codegen/client/RPCClientGenerator.scala
+++ b/airframe-http-codegen/src/main/scala/wvlet/airframe/http/codegen/client/RPCClientGenerator.scala
@@ -152,7 +152,7 @@ object RPCClientGenerator extends HttpClientGenerator {
             m.httpMethod match {
               case HttpMethod.GET =>
                 s"""def ${m.name}(${inputArgs.mkString(", ")}): ${returnType} = {
-                   |  client.readAs[${m.returnType.fullTypeName}](Http.GET(${m.path}))
+                   |  client.readAs[${m.returnType.fullTypeName}](Http.GET("${m.path}"))
                    |}""".stripMargin
               case _ =>
                 val args = Seq.newBuilder[String]

--- a/airframe-http-codegen/src/main/scala/wvlet/airframe/http/codegen/client/RPCClientGenerator.scala
+++ b/airframe-http-codegen/src/main/scala/wvlet/airframe/http/codegen/client/RPCClientGenerator.scala
@@ -152,11 +152,11 @@ object RPCClientGenerator extends HttpClientGenerator {
             m.httpMethod match {
               case HttpMethod.GET =>
                 s"""def ${m.name}(${inputArgs.mkString(", ")}): ${returnType} = {
-                   |  client.readAs[${m.returnType.fullTypeName}](Http.GET("${m.path}"))
+                   |  client.readAs[${m.returnType.fullTypeName}](Http.GET(s"${m.path}"))
                    |}""".stripMargin
               case _ =>
                 val args = Seq.newBuilder[String]
-                args += s"""Http.${m.httpMethod}("${m.path}")"""
+                args += s"""Http.${m.httpMethod}(s"${m.path}")"""
                 args ++= m.clientCallParameters
                 s"""def ${m.name}(${inputArgs.mkString(", ")}): ${returnType} = {
                    |  client.call[${m.typeArgString}](${args.result().mkString(", ")})

--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,7 @@ addCommandAlias(
 // [Development purpose] publish all sbt-airframe related artifacts to local repo
 addCommandAlias(
   "publishSbtDevLocal",
-  s"+ projectJVM/publishLocal; ++ 2.13; projectJS/publishLocal; ++ 3; projectJS/publishLocal"
+  s"++ 2.12 projectJVM/publishLocal; ++ 3; projectJVM/publishLocal; projectJS/publishLocal"
 )
 
 addCommandAlias(

--- a/build.sbt
+++ b/build.sbt
@@ -268,6 +268,7 @@ lazy val projectDotty =
       codec.jvm,
       fluentd,
       http.jvm,
+      netty,
       httpCodeGen,
       httpRecorder,
       okhttp,

--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,7 @@ addCommandAlias(
 // [Development purpose] publish all sbt-airframe related artifacts to local repo
 addCommandAlias(
   "publishSbtDevLocal",
-  s"++ 2.12; projectJVM/publishLocal; ++ 3; projectJVM/publishLocal; projectJS/publishLocal"
+  s"++ 2.12; projectJVM/publishLocal; ++ 3; projectDotty/publishLocal; projectJS/publishLocal"
 )
 
 addCommandAlias(

--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,7 @@ addCommandAlias(
 // [Development purpose] publish all sbt-airframe related artifacts to local repo
 addCommandAlias(
   "publishSbtDevLocal",
-  s"++ 2.12 projectJVM/publishLocal; ++ 3; projectJVM/publishLocal; projectJS/publishLocal"
+  s"++ 2.12; projectJVM/publishLocal; ++ 3; projectJVM/publishLocal; projectJS/publishLocal"
 )
 
 addCommandAlias(

--- a/sbt-airframe/src/sbt-test/sbt-airframe/generate-client/build.sbt
+++ b/sbt-airframe/src/sbt-test/sbt-airframe/generate-client/build.sbt
@@ -5,7 +5,7 @@ ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-parse
 
 ThisBuild / resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 
-ThisBuild / scalaVersion := "2.13.10"
+ThisBuild / scalaVersion := "3.2.2"
 
 lazy val root =
   project.aggregate(spi, server)
@@ -24,11 +24,10 @@ lazy val server =
     .settings(
       airframeHttpGeneratorOption := "-l trace",
       airframeHttpClients := Seq(
-        "myapp.spi",
-        "myapp.spi:sync"
+        "myapp.spi:rpc"
       ),
       libraryDependencies ++= Seq(
-        "org.wvlet.airframe" %% "airframe-http-finagle" % sys.props("airframe.version")
+        "org.wvlet.airframe" %% "airframe-http-netty" % sys.props("airframe.version")
       )
     )
     .dependsOn(spi)

--- a/sbt-airframe/src/sbt-test/sbt-airframe/generate-client/build.sbt
+++ b/sbt-airframe/src/sbt-test/sbt-airframe/generate-client/build.sbt
@@ -5,7 +5,7 @@ ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-parse
 
 ThisBuild / resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 
-ThisBuild / scalaVersion := "3.2.2"
+ThisBuild / scalaVersion := "2.12.17"
 
 lazy val root =
   project.aggregate(spi, server)

--- a/sbt-airframe/src/sbt-test/sbt-airframe/generate-client/server/src/main/scala/myapp/server/MyServer.scala
+++ b/sbt-airframe/src/sbt-test/sbt-airframe/generate-client/server/src/main/scala/myapp/server/MyServer.scala
@@ -35,7 +35,7 @@ object MyServer extends LogSupport {
         .designWithSyncClient
 
     d.build[SyncClient] { httpClient =>
-      val syncClient = myapp.spi.ServiceRPC.newSyncClient(httpClient)
+      val syncClient = myapp.spi.ServiceRPC.newRPCSyncClient(httpClient)
       val ret        = syncClient.MyService.hello(101)
       info(ret)
       assert(ret == "hello 101")

--- a/sbt-airframe/src/sbt-test/sbt-airframe/generate-client/spi/src/main/scala/myapp/spi/MyRPC.scala
+++ b/sbt-airframe/src/sbt-test/sbt-airframe/generate-client/spi/src/main/scala/myapp/spi/MyRPC.scala
@@ -13,7 +13,7 @@ trait MyRPC {
   def createPageWithId(id: Int, createPageRequest: CreatePageRequest): String
 }
 
-object MyRPC extends RxRotuerProvider {
+object MyRPC extends RxRouterProvider {
   override def router: RxRouter = RxRouter.of[MyRPC]
 
   case class World(name: String)

--- a/sbt-airframe/src/sbt-test/sbt-airframe/generate-client/spi/src/main/scala/myapp/spi/MyRPC.scala
+++ b/sbt-airframe/src/sbt-test/sbt-airframe/generate-client/spi/src/main/scala/myapp/spi/MyRPC.scala
@@ -13,7 +13,9 @@ trait MyRPC {
   def createPageWithId(id: Int, createPageRequest: CreatePageRequest): String
 }
 
-object MyRPC {
+object MyRPC extends RxRotuerProvider {
+  override def router: RxRouter = RxRouter.of[MyRPC]
+
   case class World(name: String)
   case class CreatePageRequest(name: String)
 }

--- a/sbt-airframe/src/sbt-test/sbt-airframe/generate-client/spi/src/main/scala/myapp/spi/MyService.scala
+++ b/sbt-airframe/src/sbt-test/sbt-airframe/generate-client/spi/src/main/scala/myapp/spi/MyService.scala
@@ -6,7 +6,7 @@ trait MyService {
   @Endpoint(method = HttpMethod.GET, path = "/v1/hello/:id")
   def hello(id: Int): String
 
-  @Endpoint(method = HttpMethod.GET, path = "/v1/books")
+  @Endpoint(method = HttpMethod.POST, path = "/v1/books")
   def books(limit: Int = 100): String
 }
 

--- a/sbt-airframe/src/sbt-test/sbt-airframe/generate-client/spi/src/main/scala/myapp/spi/MyService.scala
+++ b/sbt-airframe/src/sbt-test/sbt-airframe/generate-client/spi/src/main/scala/myapp/spi/MyService.scala
@@ -9,3 +9,7 @@ trait MyService {
   @Endpoint(method = HttpMethod.GET, path = "/v1/books")
   def books(limit: Int = 100): String
 }
+
+object MyService extends RxRouterProvider {
+  def router: RxRouter = RxRouter.of[MyService]
+}

--- a/sbt-airframe/src/sbt-test/sbt-airframe/grpc/build.sbt
+++ b/sbt-airframe/src/sbt-test/sbt-airframe/grpc/build.sbt
@@ -7,7 +7,7 @@ val buildSettings: Seq[Def.Setting[_]] = Seq(
   libraryDependencies += "org.wvlet.airframe" %% "airspec" % AIRSPEC_VERSION % Test
 )
 ThisBuild / resolvers ++= Resolver.sonatypeOssRepos("snapshots")
-ThisBuild / scalaVersion := "2.13.10"
+ThisBuild / scalaVersion := "3.2.2"
 // ThisBuild / crossScalaVersions := Seq("2.13.10", "3.2.2")
 
 lazy val root =

--- a/sbt-airframe/src/sbt-test/sbt-airframe/grpc/build.sbt
+++ b/sbt-airframe/src/sbt-test/sbt-airframe/grpc/build.sbt
@@ -7,7 +7,8 @@ val buildSettings: Seq[Def.Setting[_]] = Seq(
   libraryDependencies += "org.wvlet.airframe" %% "airspec" % AIRSPEC_VERSION % Test
 )
 ThisBuild / resolvers ++= Resolver.sonatypeOssRepos("snapshots")
-ThisBuild / scalaVersion := "3.2.2"
+// TODO: To use Scala 3, https://github.com/wvlet/airframe/issues/2883 needs to be fixed
+ThisBuild / scalaVersion := "2.12.17"
 // ThisBuild / crossScalaVersions := Seq("2.13.10", "3.2.2")
 
 lazy val root =

--- a/sbt-airframe/src/sbt-test/sbt-airframe/js-client/build.sbt
+++ b/sbt-airframe/src/sbt-test/sbt-airframe/js-client/build.sbt
@@ -1,7 +1,6 @@
 ThisBuild / resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 
-ThisBuild / scalaVersion       := "2.13.10"
-ThisBuild / crossScalaVersions := Seq("2.13.10", "3.2.2")
+ThisBuild / scalaVersion := "3.2.2"
 
 lazy val root =
   project.aggregate(spi.js, client.js)

--- a/sbt-airframe/src/sbt-test/sbt-airframe/js-client/test
+++ b/sbt-airframe/src/sbt-test/sbt-airframe/js-client/test
@@ -1,1 +1,1 @@
-> + clientJS/fastLinkJS
+> clientJS/fastLinkJS

--- a/sbt-airframe/src/sbt-test/sbt-airframe/openapi/build.sbt
+++ b/sbt-airframe/src/sbt-test/sbt-airframe/openapi/build.sbt
@@ -5,8 +5,7 @@ enablePlugins(AirframeHttpPlugin)
 name    := "Open API Test"
 version := "1.0.0"
 
-ThisBuild / scalaVersion       := "2.13.10"
-ThisBuild / crossScalaVersions := Seq("2.13.10", "3.2.2")
+ThisBuild / scalaVersion := "3.2.2"
 
 airframeHttpOpenAPIPackages := Seq("example.api")
 airframeHttpOpts            := "-l debug"

--- a/sbt-airframe/src/sbt-test/sbt-airframe/openapi/test
+++ b/sbt-airframe/src/sbt-test/sbt-airframe/openapi/test
@@ -1,3 +1,3 @@
-> + package
+> package
 $ exists target/openapi.yaml
-> + check
+> check

--- a/sbt-airframe/src/sbt-test/sbt-airframe/rpc-finagle/build.sbt
+++ b/sbt-airframe/src/sbt-test/sbt-airframe/rpc-finagle/build.sbt
@@ -5,7 +5,7 @@ ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-parse
 
 ThisBuild / resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 
-ThisBuild / scalaVersion := "2.13.10"
+ThisBuild / scalaVersion := "2.12.17"
 
 val AIRSPEC_VERSION = "23.4.5"
 

--- a/sbt-airframe/src/sbt-test/sbt-airframe/rpc-netty/build.sbt
+++ b/sbt-airframe/src/sbt-test/sbt-airframe/rpc-netty/build.sbt
@@ -12,8 +12,7 @@ val buildSettings: Seq[Def.Setting[_]] = Seq(
   libraryDependencies += "org.wvlet.airframe" %% "airspec" % AIRSPEC_VERSION % Test
 )
 
-ThisBuild / scalaVersion       := "2.13.10"
-ThisBuild / crossScalaVersions := Seq("2.13.10", "3.2.2")
+ThisBuild / scalaVersion := "3.2.2"
 
 lazy val root =
   project.aggregate(api, server)

--- a/sbt-airframe/src/sbt-test/sbt-airframe/rpc-netty/test
+++ b/sbt-airframe/src/sbt-test/sbt-airframe/rpc-netty/test
@@ -1,1 +1,1 @@
-> + test
+> test


### PR DESCRIPTION
- internal: Reduce sbt-integration test scope only to Scala 2.12 and Scala 3 for reducing the test overhead

