### PR TITLE
airframe-surface: Resolve Any type properly in Scala 3

### DIFF
--- a/airframe-http-codegen/src/main/scala/wvlet/airframe/http/codegen/client/HttpClientGenerator.scala
+++ b/airframe-http-codegen/src/main/scala/wvlet/airframe/http/codegen/client/HttpClientGenerator.scala
@@ -32,7 +32,7 @@ object HttpClientGenerator extends LogSupport {
     s match {
       case p if p.isPrimitive && !p.isAlias =>
         p.name
-      case a if a.fullName == "scala.Any" =>
+      case a if a.fullName == "scala.Any" || a.fullName == "java.lang.Object" =>
         "Any"
       case p if p.isOption =>
         s"Option[${p.typeArgs.map(fullTypeNameOf(_)).mkString(", ")}]"

--- a/airframe-http-codegen/src/test/scala/wvlet/airframe/http/codegen/RPCClientGeneratorTest.scala
+++ b/airframe-http-codegen/src/test/scala/wvlet/airframe/http/codegen/RPCClientGeneratorTest.scala
@@ -20,7 +20,6 @@ class RPCClientGeneratorTest extends AirSpec {
   private val router: RxRouter = {
     RouteScanner.buildRxRouter(Seq("example.rpc"))
   }
-
   test("generate RPC client") {
     val config = HttpClientGeneratorConfig("example.rpc:rpc")
     val code   = HttpCodeGenerator.generate(router, config)

--- a/airframe-surface/src/main/scala-2/wvlet/airframe/surface/SurfaceMacros.scala
+++ b/airframe-surface/src/main/scala-2/wvlet/airframe/surface/SurfaceMacros.scala
@@ -625,6 +625,8 @@ private[surface] object SurfaceMacros {
     }
 
     private val genericSurfaceFactory: SurfaceFactory = {
+      case t if t =:= typeOf[Any] =>
+        q"wvlet.airframe.surface.Alias(${"Any"}, ${"scala.Any"}, wvlet.airframe.surface.AnyRefSurface)"
       case t @ TypeRef(prefix, symbol, args) if !args.isEmpty =>
         val typeArgs = typeArgsOf(t).map(surfaceOf(_))
         q"new wvlet.airframe.surface.GenericSurface(classOf[$t], typeArgs = IndexedSeq(..$typeArgs))"

--- a/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
+++ b/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
@@ -405,7 +405,7 @@ private[surface] class CompileTimeSurfaceFactory[Q <: Quotes](using quotes: Q) {
   }
 
   private def genericTypeFactory: Factory = {
-    case t if t =:= TypeRepr.of[Any] || t =:= TypeRepr.of[java.lang.Object] =>
+    case t if t =:= TypeRepr.of[Any] =>
       '{ Alias("Any", "scala.Any", AnyRefSurface) }
     case a: AppliedType =>
       val typeArgs = a.args.map(surfaceOf(_))

--- a/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
+++ b/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
@@ -405,6 +405,8 @@ private[surface] class CompileTimeSurfaceFactory[Q <: Quotes](using quotes: Q) {
   }
 
   private def genericTypeFactory: Factory = {
+    case t if t =:= TypeRepr.of[Any] || t =:= TypeRepr.of[java.lang.Object] =>
+      '{ Alias("Any", "scala.Any", AnyRefSurface) }
     case a: AppliedType =>
       val typeArgs = a.args.map(surfaceOf(_))
       '{ new GenericSurface(${ clsOf(a) }, typeArgs = ${ Expr.ofSeq(typeArgs) }.toIndexedSeq) }

--- a/airframe-surface/src/test/scala/wvlet/airframe/surface/MethodSurfaceTest.scala
+++ b/airframe-surface/src/test/scala/wvlet/airframe/surface/MethodSurfaceTest.scala
@@ -46,6 +46,10 @@ object MethodExamples {
   trait E {
     def hello(v: String = "default"): String
   }
+
+  trait F {
+    def mapInput(m: Map[String, Any]): Unit
+  }
 }
 
 import wvlet.airframe.surface.MethodExamples._
@@ -132,6 +136,18 @@ class MethodSurfaceTest extends SurfaceSpec {
       val v = h.getMethodArgDefaultValue(d)
       // Scala.js doesn't support reading default method arguments
       assertEquals(v, Some("yay"))
+    }
+  }
+
+  test("find Any surface from Map[String, Any] method surface") {
+    val ms = Surface.methodsOf[F]
+    ms.find(_.name == "mapInput") match {
+      case Some(m) if m.args.size == 1 =>
+        val arg = m.args(0)
+        val p1  = arg.surface.typeArgs(1)
+        assertEquals(p1.fullName, "scala.Any")
+      case None =>
+        fail("mapInput method not found")
     }
   }
 }

--- a/airframe-surface/src/test/scala/wvlet/airframe/surface/MethodSurfaceTest.scala
+++ b/airframe-surface/src/test/scala/wvlet/airframe/surface/MethodSurfaceTest.scala
@@ -146,8 +146,8 @@ class MethodSurfaceTest extends SurfaceSpec {
         val arg = m.args(0)
         val p1  = arg.surface.typeArgs(1)
         assertEquals(p1.fullName, "scala.Any")
-      case None =>
-        fail("mapInput method not found")
+      case _ =>
+        fail("F.mapInput method not found")
     }
   }
 }

--- a/airframe-surface/src/test/scala/wvlet/airframe/surface/SurfaceTest.scala
+++ b/airframe-surface/src/test/scala/wvlet/airframe/surface/SurfaceTest.scala
@@ -240,4 +240,10 @@ class SurfaceTest extends SurfaceSpec {
     Surface.of[BigInt]
     Surface.of[BigInteger]
   }
+
+  test("Map[String, Any]") {
+    val s   = Surface.of[Map[String, Any]]
+    val any = s.typeArgs(1)
+    assertEquals(any.fullName, "scala.Any")
+  }
 }

--- a/airframe-surface/src/test/scala/wvlet/airframe/surface/SurfaceTest.scala
+++ b/airframe-surface/src/test/scala/wvlet/airframe/surface/SurfaceTest.scala
@@ -241,9 +241,9 @@ class SurfaceTest extends SurfaceSpec {
     Surface.of[BigInteger]
   }
 
-  test("Map[String, Any]") {
-    val s   = Surface.of[Map[String, Any]]
-    val any = s.typeArgs(1)
-    assertEquals(any.fullName, "scala.Any")
+  test("resolve types args of Map[String, Any]") {
+    val s = Surface.of[Map[String, Any]]
+    assertEquals(s.typeArgs(0).fullName, "java.lang.String")
+    assertEquals(s.typeArgs(1).fullName, "scala.Any")
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -415,9 +415,8 @@ lazy val surface =
     .in(file("airframe-surface"))
     .settings(buildSettings)
     .settings(
-      name                                         := "airframe-surface",
-      description                                  := "A library for extracting object structure surface",
-      libraryDependencies -= "org.wvlet.airframe" %%% "airspec" % AIRSPEC_VERSION % Test,
+      name        := "airframe-surface",
+      description := "A library for extracting object structure surface",
       // TODO: This is a temporaly solution. Use AirSpec after Scala 3 support of Surface is completed
       libraryDependencies += "org.scalameta" %%% "munit" % "0.7.29" % Test,
       libraryDependencies ++= surfaceDependencies(scalaVersion.value)

--- a/sbt-airframe/src/sbt-test/sbt-airframe/generate-client/build.sbt
+++ b/sbt-airframe/src/sbt-test/sbt-airframe/generate-client/build.sbt
@@ -5,7 +5,7 @@ ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-parse
 
 ThisBuild / resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 
-ThisBuild / scalaVersion := "2.12.17"
+ThisBuild / scalaVersion := "3.2.2"
 
 lazy val root =
   project.aggregate(spi, server)


### PR DESCRIPTION
With this fix, sbt-airframe code generator produces valid http client code