### PR TITLE
airframe-rx: Separte Rx and RxOption interfaces

### DIFF
--- a/airframe-http-codegen/src/main/scala/wvlet/airframe/http/codegen/HttpClientIR.scala
+++ b/airframe-http-codegen/src/main/scala/wvlet/airframe/http/codegen/HttpClientIR.scala
@@ -19,7 +19,7 @@ import wvlet.airframe.http.{HttpMethod, Router, RxRouter}
 import wvlet.airframe.http.codegen.RouteAnalyzer.RouteAnalysisResult
 import wvlet.airframe.http.codegen.client.HttpClientGenerator
 import wvlet.airframe.http.codegen.client.HttpClientGenerator.fullTypeNameOf
-import wvlet.airframe.rx.{Rx, RxStream}
+import wvlet.airframe.rx.Rx
 import wvlet.airframe.surface.{GenericSurface, HigherKindedTypeSurface, MethodParameter, Parameter, Surface, TypeName}
 import wvlet.log.LogSupport
 import wvlet.airframe.http.router.{HttpRequestMapper, Route}

--- a/airframe-http-codegen/src/test/scala/example/grpc/Streaming.scala
+++ b/airframe-http-codegen/src/test/scala/example/grpc/Streaming.scala
@@ -13,19 +13,19 @@
  */
 package example.grpc
 import wvlet.airframe.http.RPC
-import wvlet.airframe.rx.{Rx, RxStream}
+import wvlet.airframe.rx.Rx
 
 /**
   */
 @RPC
 trait Streaming {
-  def serverStreaming(name: String): RxStream[String] = {
+  def serverStreaming(name: String): Rx[String] = {
     Rx.sequence("Hello", "See You").map(x => s"${x} ${name}!")
   }
-  def clientStreaming(input: RxStream[String]): String = {
+  def clientStreaming(input: Rx[String]): String = {
     input.toSeq.mkString(", ")
   }
-  def bidiStreaming(input: RxStream[String]): RxStream[String] = {
+  def bidiStreaming(input: Rx[String]): Rx[String] = {
     input.map(x => s"Hello ${x}!")
   }
 }

--- a/airframe-http-finagle/src/main/scala/wvlet/airframe/http/finagle/package.scala
+++ b/airframe-http-finagle/src/main/scala/wvlet/airframe/http/finagle/package.scala
@@ -21,7 +21,7 @@ import com.twitter.util.{Future, Return, Throw}
 import wvlet.airframe.http.HttpMessage.{ByteArrayMessage, StringMessage}
 import wvlet.airframe.{Design, Session}
 import wvlet.airframe.http.finagle.FinagleServer.FinagleService
-import wvlet.airframe.rx.{Rx, RxStream}
+import wvlet.airframe.rx.Rx
 import wvlet.log.io.IOUtil
 
 import scala.util.{Failure, Success}
@@ -217,7 +217,7 @@ package object finagle {
     * @tparam A
     * @return
     */
-  def convertToRx[A](twitterFuture: Future[A]): RxStream[A] = {
+  def convertToRx[A](twitterFuture: Future[A]): Rx[A] = {
     val v = Rx.variable[Option[A]](None)
     twitterFuture.respond {
       case Return(x) =>

--- a/airframe-http-grpc/src/main/scala/wvlet/airframe/http/grpc/GrpcClientCalls.scala
+++ b/airframe-http-grpc/src/main/scala/wvlet/airframe/http/grpc/GrpcClientCalls.scala
@@ -16,7 +16,7 @@ import io.grpc.stub.{MetadataUtils, StreamObserver}
 import wvlet.airframe.codec.MessageCodec
 import wvlet.airframe.http.RPCEncoding
 import wvlet.airframe.msgpack.spi.MsgPack
-import wvlet.airframe.rx.{Cancelable, OnCompletion, OnError, OnNext, Rx, RxBlockingQueue, RxRunner, RxStream}
+import wvlet.airframe.rx.{Cancelable, OnCompletion, OnError, OnNext, Rx, RxBlockingQueue, RxRunner}
 import wvlet.log.LogSupport
 
 import scala.util.{Failure, Success, Try}
@@ -27,7 +27,7 @@ import scala.util.{Failure, Success, Try}
 object GrpcClientCalls extends LogSupport {
 
   trait BlockingStreamObserver[A] extends StreamObserver[Any] {
-    def toRx: RxStream[A]
+    def toRx: Rx[A]
   }
 
   def blockingResponseObserver[A]: BlockingStreamObserver[A] =

--- a/airframe-http-grpc/src/test/scala/wvlet/airframe/http/grpc/GrpcErrorLogTest.scala
+++ b/airframe-http-grpc/src/test/scala/wvlet/airframe/http/grpc/GrpcErrorLogTest.scala
@@ -19,7 +19,7 @@ import wvlet.airframe.http.grpc.internal.GrpcRequestLogger
 import wvlet.airframe.http.Router
 import wvlet.airframe.http.HttpAccessLogWriter
 import wvlet.airspec.AirSpec
-import wvlet.airframe.rx.{Rx, RxStream}
+import wvlet.airframe.rx.Rx
 import wvlet.log.Logger
 
 import scala.util.{Failure, Try}
@@ -35,11 +35,11 @@ object GrpcErrorLogTest extends AirSpec {
       throw new IllegalArgumentException(s"invalid message: ${name}")
     }
 
-    override def helloClientStreaming(input: RxStream[String]): String = {
+    override def helloClientStreaming(input: Rx[String]): String = {
       throw new UnsupportedOperationException(s"N/A")
     }
 
-    override def helloBidiStreaming(input: RxStream[String]): RxStream[String] = {
+    override def helloBidiStreaming(input: Rx[String]): Rx[String] = {
       throw new UnsupportedOperationException(s"N/A")
     }
   }

--- a/airframe-http-grpc/src/test/scala/wvlet/airframe/http/grpc/GrpcRequestLoggerTest.scala
+++ b/airframe-http-grpc/src/test/scala/wvlet/airframe/http/grpc/GrpcRequestLoggerTest.scala
@@ -18,7 +18,7 @@ import wvlet.airframe.http.HttpAccessLogWriter
 import wvlet.airframe.http.grpc.example.DemoApi
 import wvlet.airframe.http.grpc.example.DemoApi.DemoApiClient
 import wvlet.airframe.http.grpc.internal.GrpcRequestLogger
-import wvlet.airframe.rx.{Rx, RxStream}
+import wvlet.airframe.rx.Rx
 import wvlet.airspec.AirSpec
 
 import scala.util.{Failure, Try}

--- a/airframe-http-grpc/src/test/scala/wvlet/airframe/http/grpc/example/DemoApi.scala
+++ b/airframe-http-grpc/src/test/scala/wvlet/airframe/http/grpc/example/DemoApi.scala
@@ -31,7 +31,7 @@ import wvlet.airframe.http.grpc.internal.{GrpcServiceBuilder, WrappedServerCallL
 import wvlet.airframe.http.grpc._
 import wvlet.airframe.http.{Http, HttpStatus, RPC, RPCContext, RPCEncoding, RPCStatus, Router}
 import wvlet.airframe.msgpack.spi.MsgPack
-import wvlet.airframe.rx.{Rx, RxStream}
+import wvlet.airframe.rx.Rx
 import wvlet.log.LogSupport
 import wvlet.airframe.http.router.Route
 
@@ -61,15 +61,15 @@ trait DemoApi extends LogSupport {
     s"Hello ${name}! (id:${id})"
   }
 
-  def helloStreaming(name: String): RxStream[String] = {
+  def helloStreaming(name: String): Rx[String] = {
     Rx.sequence("Hello", "Bye").map(x => s"${x} ${name}!")
   }
 
-  def helloClientStreaming(input: RxStream[String]): String = {
+  def helloClientStreaming(input: Rx[String]): String = {
     input.toSeq.mkString(", ")
   }
 
-  def helloBidiStreaming(input: RxStream[String]): RxStream[String] = {
+  def helloBidiStreaming(input: Rx[String]): Rx[String] = {
     input.map(x => s"Hello ${x}!")
   }
 

--- a/airframe-http-grpc/src/test/scala/wvlet/airframe/http/grpc/example/DemoApiV2.scala
+++ b/airframe-http-grpc/src/test/scala/wvlet/airframe/http/grpc/example/DemoApiV2.scala
@@ -21,7 +21,7 @@ import wvlet.airframe.http.grpc.example.DemoApiV2.{DemoMessage, DemoResponse}
 import wvlet.airframe.http.grpc.internal.GrpcServiceBuilder
 import wvlet.airframe.http.grpc.{GrpcClient, GrpcClientConfig, GrpcClientInterceptor, gRPC}
 import wvlet.airframe.http.{RPC, RPCEncoding, RPCStatus, Router}
-import wvlet.airframe.rx.{Rx, RxStream}
+import wvlet.airframe.rx.Rx
 import wvlet.airframe.surface.Surface
 import wvlet.log.LogSupport
 import wvlet.airframe.http.router.Route
@@ -49,7 +49,7 @@ trait DemoApiV2 extends LogSupport {
     }
   }
 
-  def clientStreaming(input: RxStream[DemoMessage]): String = {
+  def clientStreaming(input: Rx[DemoMessage]): String = {
     val x = input.toSeq
     x.map(_.name).map {
         case "XXX" =>
@@ -60,7 +60,7 @@ trait DemoApiV2 extends LogSupport {
       .mkString(", ")
   }
 
-  def bidiStreaming(input: RxStream[DemoMessage]): RxStream[DemoResponse] = {
+  def bidiStreaming(input: Rx[DemoMessage]): Rx[DemoResponse] = {
     input.map(x =>
       x.name match {
         case "XXX" =>
@@ -138,7 +138,7 @@ object DemoApiV2 {
       client.asyncUnaryCall(helloMethod, Map("name" -> name), observer)
     }
 
-    def serverStreaming(name: String): RxStream[String] = {
+    def serverStreaming(name: String): Rx[String] = {
       client.serverStreamingCall(serverStreamingMethod, Map("name" -> name))
     }
 
@@ -146,7 +146,7 @@ object DemoApiV2 {
       client.asyncServerStreamingCall(serverStreamingMethod, Map("name" -> name), observer)
     }
 
-    def clientStreaming(input: RxStream[DemoMessage]): String = {
+    def clientStreaming(input: Rx[DemoMessage]): String = {
       client.clientStreamingCall(clientStreamingMethod, input)
     }
 
@@ -154,7 +154,7 @@ object DemoApiV2 {
       client.asyncClientStreamingCall(clientStreamingMethod, observer)
     }
 
-    def bidiStreaming(input: RxStream[DemoMessage]): RxStream[DemoResponse] = {
+    def bidiStreaming(input: Rx[DemoMessage]): Rx[DemoResponse] = {
       client.bidiStreamingCall(bidiStreamingMethod, input)
     }
 

--- a/airframe-http-netty/src/main/scala/wvlet/airframe/http/netty/NettyBackend.scala
+++ b/airframe-http-netty/src/main/scala/wvlet/airframe/http/netty/NettyBackend.scala
@@ -15,7 +15,7 @@ package wvlet.airframe.http.netty
 
 import wvlet.airframe.http.HttpMessage.{Request, Response}
 import wvlet.airframe.http._
-import wvlet.airframe.rx.{Rx, RxStream}
+import wvlet.airframe.rx.Rx
 import wvlet.log.LogSupport
 
 import scala.collection.mutable
@@ -43,7 +43,7 @@ object NettyBackend extends HttpBackend[Request, Response, Rx] with LogSupport {
 
   override def toScalaFuture[A](a: Rx[A]): Future[A] = {
     val promise: Promise[A] = Promise()
-    a.toRxStream
+    a.toRx
       .map { x =>
         promise.success(x)
       }
@@ -88,7 +88,7 @@ object NettyBackend extends HttpBackend[Request, Response, Rx] with LogSupport {
   }
 
   override def mapF[A, B](f: Rx[A], body: A => B): Rx[B] = {
-    f.toRxStream.map(body)
+    f.toRx.map(body)
   }
 
   private lazy val tls =

--- a/airframe-http-netty/src/main/scala/wvlet/airframe/http/netty/NettyServer.scala
+++ b/airframe-http-netty/src/main/scala/wvlet/airframe/http/netty/NettyServer.scala
@@ -136,7 +136,7 @@ class NettyServer(config: NettyServerConfig, session: Session) extends AutoClose
     override def apply(request: HttpMessage.Request, next: RxHttpEndpoint): Rx[Response] = {
       val context = new NettyRPCContext(request)
       wvlet.airframe.http.Compat.attachRPCContext(context)
-      next(request).toRxStream
+      next(request).toRx
         // TODO use transformTry
         .transformRx { v =>
           wvlet.airframe.http.Compat.detachRPCContext(context)

--- a/airframe-http-okhttp/src/test/scala/wvlet/airframe/http/okhttp/OkHttpClientTest.scala
+++ b/airframe-http-okhttp/src/test/scala/wvlet/airframe/http/okhttp/OkHttpClientTest.scala
@@ -115,13 +115,13 @@ class OkHttpClientTest extends AirSpec {
 
   test("create async client") { (client: AsyncClient) =>
     test("readAs") {
-      client.readAs[String](Http.GET("/")).toRxStream.map { v =>
+      client.readAs[String](Http.GET("/")).toRx.map { v =>
         v shouldBe "Ok"
       }
     }
 
     test("call") {
-      client.call[UserRequest, User](Http.GET("/user/info"), UserRequest(2, "kai")).toRxStream.map { v =>
+      client.call[UserRequest, User](Http.GET("/user/info"), UserRequest(2, "kai")).toRx.map { v =>
         v shouldBe User(2, "kai", "N/A")
       }
     }

--- a/airframe-http-recorder/src/main/scala/wvlet/airframe/http/recorder/HttpRecorder.scala
+++ b/airframe-http-recorder/src/main/scala/wvlet/airframe/http/recorder/HttpRecorder.scala
@@ -17,7 +17,7 @@ import wvlet.airframe.http.HttpMessage.EmptyMessage
 import wvlet.airframe.http.{Http, HttpHeader, HttpMessage, HttpStatus, RxHttpEndpoint, ServerAddress}
 import wvlet.airframe.http.client.SyncClient
 import wvlet.airframe.http.netty.{NettyBackend, NettyServer}
-import wvlet.airframe.rx.{Rx, RxStream}
+import wvlet.airframe.rx.Rx
 import wvlet.log.LogSupport
 
 import java.util.Locale

--- a/airframe-http-recorder/src/main/scala/wvlet/airframe/http/recorder/HttpRecorderServer.scala
+++ b/airframe-http-recorder/src/main/scala/wvlet/airframe/http/recorder/HttpRecorderServer.scala
@@ -17,7 +17,7 @@ import wvlet.airframe.{Design, Session}
 import wvlet.airframe.http.HttpMessage.{Request, Response}
 import wvlet.airframe.http.{RxHttpEndpoint, RxHttpFilter, RxRouter}
 import wvlet.airframe.http.netty.{Netty, NettyServer, NettyServerConfig}
-import wvlet.airframe.rx.{Rx, RxStream}
+import wvlet.airframe.rx.Rx
 import wvlet.log.LogSupport
 import wvlet.log.io.IOUtil
 
@@ -107,7 +107,7 @@ object HttpRecorderServer {
     override def apply(request: Request, next: RxHttpEndpoint): Rx[Response] = {
       // Rewrite the target host for proxying
       val newRequest = request.noHost
-      next(newRequest).toRxStream.map { response =>
+      next(newRequest).toRx.map { response =>
         trace(s"Recording the response for ${request}")
         // Record the result
         recordStore.record(request, response)

--- a/airframe-http/.js/src/test/scala/wvlet/airframe/http/client/JSHttpAsyncClientTest.scala
+++ b/airframe-http/.js/src/test/scala/wvlet/airframe/http/client/JSHttpAsyncClientTest.scala
@@ -43,7 +43,6 @@ class JSHttpAsyncClientTest extends AirSpec {
       flaky {
         client
           .send(Http.GET("/posts/1"))
-          .toRx
           .map { resp =>
             resp.status shouldBe HttpStatus.Ok_200
             resp.isContentTypeJson shouldBe true
@@ -60,7 +59,6 @@ class JSHttpAsyncClientTest extends AirSpec {
         val data = """{"id":1,"name":"leo"}"""
         client
           .send(Http.POST("/posts").withContent(data))
-          .toRx
           .map { resp =>
             resp.status shouldBe HttpStatus.Created_201
             resp.isContentTypeJson shouldBe true
@@ -75,7 +73,6 @@ class JSHttpAsyncClientTest extends AirSpec {
       flaky {
         client
           .sendSafe(Http.GET("/status/404"))
-          .toRx
           .transform {
             case Success(resp) =>
               resp.status shouldBe HttpStatus.NotFound_404
@@ -89,7 +86,6 @@ class JSHttpAsyncClientTest extends AirSpec {
       flaky {
         client
           .send(Http.GET("/status/404"))
-          .toRx
           .transform {
             case Failure(e: HttpClientException) =>
               e.status shouldBe HttpStatus.NotFound_404
@@ -112,7 +108,6 @@ class JSHttpAsyncClientTest extends AirSpec {
             }
           })
           .send(Http.GET("/status/500"))
-          .toRx
           .transform {
             case Failure(e: HttpClientMaxRetryException) =>
               e.status.isServerError shouldBe true
@@ -134,7 +129,6 @@ class JSHttpAsyncClientTest extends AirSpec {
           }
         })
         .send(Http.GET("/status/500"))
-        .toRx
         .transform {
           case Failure(e) =>
             e.getCause match {

--- a/airframe-http/.js/src/test/scala/wvlet/airframe/http/client/JSHttpAsyncClientTest.scala
+++ b/airframe-http/.js/src/test/scala/wvlet/airframe/http/client/JSHttpAsyncClientTest.scala
@@ -43,7 +43,7 @@ class JSHttpAsyncClientTest extends AirSpec {
       flaky {
         client
           .send(Http.GET("/posts/1"))
-          .toRxStream
+          .toRx
           .map { resp =>
             resp.status shouldBe HttpStatus.Ok_200
             resp.isContentTypeJson shouldBe true
@@ -60,7 +60,7 @@ class JSHttpAsyncClientTest extends AirSpec {
         val data = """{"id":1,"name":"leo"}"""
         client
           .send(Http.POST("/posts").withContent(data))
-          .toRxStream
+          .toRx
           .map { resp =>
             resp.status shouldBe HttpStatus.Created_201
             resp.isContentTypeJson shouldBe true
@@ -75,7 +75,7 @@ class JSHttpAsyncClientTest extends AirSpec {
       flaky {
         client
           .sendSafe(Http.GET("/status/404"))
-          .toRxStream
+          .toRx
           .transform {
             case Success(resp) =>
               resp.status shouldBe HttpStatus.NotFound_404
@@ -89,7 +89,7 @@ class JSHttpAsyncClientTest extends AirSpec {
       flaky {
         client
           .send(Http.GET("/status/404"))
-          .toRxStream
+          .toRx
           .transform {
             case Failure(e: HttpClientException) =>
               e.status shouldBe HttpStatus.NotFound_404
@@ -112,7 +112,7 @@ class JSHttpAsyncClientTest extends AirSpec {
             }
           })
           .send(Http.GET("/status/500"))
-          .toRxStream
+          .toRx
           .transform {
             case Failure(e: HttpClientMaxRetryException) =>
               e.status.isServerError shouldBe true
@@ -134,7 +134,7 @@ class JSHttpAsyncClientTest extends AirSpec {
           }
         })
         .send(Http.GET("/status/500"))
-        .toRxStream
+        .toRx
         .transform {
           case Failure(e) =>
             e.getCause match {

--- a/airframe-http/.js/src/test/scala/wvlet/airframe/http/client/JSRPCClientTest.scala
+++ b/airframe-http/.js/src/test/scala/wvlet/airframe/http/client/JSRPCClientTest.scala
@@ -34,7 +34,7 @@ object JSRPCClientTest extends AirSpec {
         val m = RPCMethod("/posts", "example.Api", "test", Surface.of[TestRequest], Surface.of[TestResponse])
         client
           .rpc[TestRequest, TestResponse](m, TestRequest(1, "test"))
-          .toRxStream
+          .toRx
           .map { response =>
             debug(response)
             response shouldBe TestResponse(1, "test")
@@ -46,7 +46,7 @@ object JSRPCClientTest extends AirSpec {
       flaky {
         client
           .call[Person, Map[String, Any]](Http.POST("/posts"), p)
-          .toRxStream
+          .toRx
           .map { m =>
             debug(m)
             m shouldBe Map("id" -> 101, "name" -> "leo")

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/client/JavaAsyncClientTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/client/JavaAsyncClientTest.scala
@@ -46,7 +46,7 @@ object JavaAsyncClientTest extends AirSpec {
     test("GET") {
       client
         .send(Http.GET("/get?id=1&name=leo"))
-        .toRxStream
+        .toRx
         .map { resp =>
           resp.status shouldBe HttpStatus.Ok_200
           resp.isContentTypeJson shouldBe true
@@ -60,7 +60,7 @@ object JavaAsyncClientTest extends AirSpec {
       // .
       client
         .call[Person, Map[String, Any]](Http.GET("/get"), p)
-        .toRxStream
+        .toRx
         .map { m =>
           m("args") shouldBe Map("id" -> "1", "name" -> "leo")
         }
@@ -70,7 +70,7 @@ object JavaAsyncClientTest extends AirSpec {
       // .
       client
         .call[Person, Map[String, Any]](Http.GET("/get"), p)
-        .toRxStream
+        .toRx
         .map { m =>
           m("args") shouldBe Map("id" -> "1", "name" -> "leo")
         }
@@ -80,7 +80,7 @@ object JavaAsyncClientTest extends AirSpec {
       val data = """{"id":1,"name":"leo"}"""
       client
         .send(Http.POST("/post").withContent(data))
-        .toRxStream
+        .toRx
         .map { resp =>
           resp.status shouldBe HttpStatus.Ok_200
           resp.isContentTypeJson shouldBe true
@@ -94,7 +94,7 @@ object JavaAsyncClientTest extends AirSpec {
     test("call with POST") {
       client
         .call[Person, Map[String, Any]](Http.POST("/post"), p)
-        .toRxStream
+        .toRx
         .map { m =>
           m("data") shouldBe pJson
           m("json") shouldBe Map("id" -> 1, "name" -> "leo")
@@ -104,7 +104,7 @@ object JavaAsyncClientTest extends AirSpec {
     test("404") {
       client
         .sendSafe(Http.GET("/status/404"))
-        .toRxStream
+        .toRx
         .transform {
           case Success(resp) =>
             resp.status shouldBe HttpStatus.NotFound_404
@@ -116,7 +116,7 @@ object JavaAsyncClientTest extends AirSpec {
     test("404 with HttpClientException") {
       client
         .send(Http.GET("/status/404"))
-        .toRxStream
+        .toRx
         .transform {
           case Failure(e: HttpClientException) =>
             e.status shouldBe HttpStatus.NotFound_404
@@ -132,7 +132,7 @@ object JavaAsyncClientTest extends AirSpec {
       client
         .withRetryContext(_.withMaxRetry(1))
         .send(Http.GET("/status/500"))
-        .toRxStream
+        .toRx
         .transform {
           case Failure(e: HttpClientMaxRetryException) =>
             e.status.isServerError shouldBe true

--- a/airframe-http/src/main/scala/wvlet/airframe/http/RxHttpEndpoint.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/RxHttpEndpoint.scala
@@ -14,7 +14,7 @@
 package wvlet.airframe.http
 
 import wvlet.airframe.http.HttpMessage.{Request, Response}
-import wvlet.airframe.rx.{Rx, RxStream}
+import wvlet.airframe.rx.Rx
 
 /**
   * [[RxHttpEndpoint]] is a terminal for processing requests and returns `Rx[Response]`.

--- a/airframe-http/src/main/scala/wvlet/airframe/http/RxHttpFilter.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/RxHttpFilter.scala
@@ -14,7 +14,7 @@
 package wvlet.airframe.http
 
 import wvlet.airframe.http.HttpMessage.{Request, Response}
-import wvlet.airframe.rx.{OnNext, Rx, RxStream}
+import wvlet.airframe.rx.{OnNext, Rx}
 import wvlet.log.LogSupport
 
 import scala.util.control.NonFatal

--- a/airframe-http/src/main/scala/wvlet/airframe/http/client/HttpClients.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/client/HttpClients.scala
@@ -83,7 +83,6 @@ trait SyncClient extends SyncClientCompat with HttpClientFactory[SyncClient] wit
           .apply(context)
           .andThen(req => Rx.single(channel.send(req, config)))
           .apply(request)
-          .toRx
           .run { resp =>
             lastResponse = Some(resp)
           }

--- a/airframe-http/src/main/scala/wvlet/airframe/http/client/HttpClients.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/client/HttpClients.scala
@@ -192,7 +192,6 @@ trait AsyncClient extends AsyncClientCompat with HttpClientFactory[AsyncClient] 
           .apply(context)
           .andThen(req => channel.sendAsync(req, config))
           .apply(request)
-          .toRx
           .map { resp =>
             // Remember the last response for error reporting purpose
             lastResponse = Some(resp)

--- a/airframe-http/src/main/scala/wvlet/airframe/http/client/HttpClients.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/client/HttpClients.scala
@@ -83,7 +83,7 @@ trait SyncClient extends SyncClientCompat with HttpClientFactory[SyncClient] wit
           .apply(context)
           .andThen(req => Rx.single(channel.send(req, config)))
           .apply(request)
-          .toRxStream
+          .toRx
           .run { resp =>
             lastResponse = Some(resp)
           }
@@ -193,7 +193,7 @@ trait AsyncClient extends AsyncClientCompat with HttpClientFactory[AsyncClient] 
           .apply(context)
           .andThen(req => channel.sendAsync(req, config))
           .apply(request)
-          .toRxStream
+          .toRx
           .map { resp =>
             // Remember the last response for error reporting purpose
             lastResponse = Some(resp)
@@ -212,7 +212,7 @@ trait AsyncClient extends AsyncClientCompat with HttpClientFactory[AsyncClient] 
     * @return
     */
   def sendSafe(req: Request, context: HttpClientContext = HttpClientContext.empty): Rx[Response] = {
-    send(req, context).toRxStream.recover { case e: HttpClientException =>
+    send(req, context).toRx.recover { case e: HttpClientException =>
       e.response.toHttpResponse
     }
   }
@@ -221,7 +221,7 @@ trait AsyncClient extends AsyncClientCompat with HttpClientFactory[AsyncClient] 
       req: Request,
       responseSurface: Surface
   ): Rx[Resp] = {
-    send(req).toRxStream.map { resp =>
+    send(req).toRx.map { resp =>
       HttpClients.parseResponse[Resp](config, responseSurface, resp)
     }
   }
@@ -235,7 +235,7 @@ trait AsyncClient extends AsyncClientCompat with HttpClientFactory[AsyncClient] 
     Rx
       .const(HttpClients.prepareRequest(config, req, requestSurface, requestContent))
       .flatMap { (newRequest: Request) =>
-        send(newRequest, HttpClientContext(config.name)).toRxStream.map { resp =>
+        send(newRequest, HttpClientContext(config.name)).toRx.map { resp =>
           HttpClients.parseResponse[Resp](config, responseSurface, resp)
         }
       }
@@ -253,7 +253,7 @@ trait AsyncClient extends AsyncClientCompat with HttpClientFactory[AsyncClient] 
           rpcMethod = Some(method),
           rpcInput = Some(requestContent)
         )
-        sendSafe(request, context).toRxStream
+        sendSafe(request, context).toRx
           .map { (response: Response) =>
             if (response.status.isSuccessful) {
               val ret = HttpClients.parseRPCResponse(config, response, method.responseSurface)

--- a/airframe-http/src/main/scala/wvlet/airframe/http/internal/HttpLogs.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/internal/HttpLogs.scala
@@ -66,7 +66,7 @@ object HttpLogs {
 
     next
       .apply(request)
-      .toRxStream
+      .toRx
       .map { resp =>
         m ++= durationLogs(baseTime, start)
         rpcCallLogs()

--- a/airframe-rx-html/.js/src/main/scala/wvlet/airframe/rx/html/DOMRenderer.scala
+++ b/airframe-rx-html/.js/src/main/scala/wvlet/airframe/rx/html/DOMRenderer.scala
@@ -13,11 +13,10 @@
  */
 package wvlet.airframe.rx.html
 import org.scalajs.dom
-import wvlet.airframe.rx.{Cancelable, Rx}
+import wvlet.airframe.rx.{Cancelable, Rx, RxOps}
 import wvlet.log.LogSupport
 
 import scala.scalajs.js
-import scala.util.Try
 
 /**
   * Convert HtmlNodes into DOM elements for Scala.js.
@@ -84,7 +83,7 @@ object DOMRenderer extends LogSupport {
           val c    = e.traverseModifiers(m => renderTo(elem, m))
           node.mountHere(elem, anchor)
           c
-        case rx: Rx[_] =>
+        case rx: RxOps[_] =>
           val (start, end) = node.createMountSection()
           var c1           = Cancelable.empty
           val c2 = rx.subscribe { value =>
@@ -181,7 +180,7 @@ object DOMRenderer extends LogSupport {
           Cancelable.empty
         case Some(x) =>
           traverse(x)
-        case rx: Rx[_] =>
+        case rx: RxOps[_] =>
           var c1 = Cancelable.empty
           val c2 = rx.run { value =>
             // Cancel the previous binding
@@ -237,7 +236,7 @@ object DOMRenderer extends LogSupport {
       */
     private def eval(v: Any): Cancelable = {
       v match {
-        case rx: Rx[_] =>
+        case rx: RxOps[_] =>
           rx.run { _ => }
         case Some(v) =>
           eval(v)

--- a/airframe-rx-html/.js/src/main/scala/wvlet/airframe/rx/html/DOMRenderer.scala
+++ b/airframe-rx-html/.js/src/main/scala/wvlet/airframe/rx/html/DOMRenderer.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.rx.html
 import org.scalajs.dom
-import wvlet.airframe.rx.{Cancelable, Rx, RxStream}
+import wvlet.airframe.rx.{Cancelable, Rx}
 import wvlet.log.LogSupport
 
 import scala.scalajs.js

--- a/airframe-rx-html/.js/src/test/scala/wvlet/airframe/http/rx/html/RxRenderingTest.scala
+++ b/airframe-rx-html/.js/src/test/scala/wvlet/airframe/http/rx/html/RxRenderingTest.scala
@@ -14,7 +14,7 @@
 package wvlet.airframe.http.rx.html
 
 import org.scalajs.dom.HTMLElement
-import wvlet.airframe.rx.{Cancelable, Rx, RxStream}
+import wvlet.airframe.rx.{Cancelable, Rx}
 import wvlet.airframe.rx.html.{DOMRenderer, Embedded, RxElement}
 import wvlet.airspec.AirSpec
 import wvlet.airframe.rx.html._
@@ -26,7 +26,7 @@ object RxRenderingTest extends AirSpec {
 
   private def render(v: Any): (HTMLElement, Cancelable) = {
     val (n, c) = v match {
-      case rx: RxStream[RxElement] @unchecked =>
+      case rx: Rx[RxElement] @unchecked =>
         DOMRenderer.render(div(rx))
       case other: RxElement =>
         DOMRenderer.render(other)

--- a/airframe-rx-html/src/test/scala/wvlet/airframe/rx/html/RxElementTest.scala
+++ b/airframe-rx-html/src/test/scala/wvlet/airframe/rx/html/RxElementTest.scala
@@ -68,10 +68,10 @@ class RxElementTest extends AirSpec {
 
     new RxElement() {
       // Specifying map target type as .map[RxElement] is necessary to avoid
-      // type resolution to RxStream[Object]
+      // type resolution to Rx[Object]
       override def render: RxElement = v.map[RxElement] {
         case true =>
-          w.map { i => span(i) } // RxStream[RxElement] is embeddable as RxElement
+          w.map { i => span(i) } // Rx[RxElement] is embeddable as RxElement
         case false =>
           span("N/A") // RxElement
       }

--- a/airframe-rx/src/main/scala/wvlet/airframe/rx/Rx.scala
+++ b/airframe-rx/src/main/scala/wvlet/airframe/rx/Rx.scala
@@ -21,7 +21,7 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.language.higherKinds
 import scala.util.{Failure, Success, Try}
 
-trait RxOps[+A] {
+trait RxOps[+A] { self =>
   def parents: Seq[Rx[_]]
 
   def toRx: Rx[A]
@@ -45,7 +45,7 @@ trait RxOps[+A] {
     * @return
     */
   def run[U](effect: A => U): Cancelable = {
-    RxRunner.runOps(this) {
+    RxRunner.run(self) {
       case OnNext(v) =>
         effect(v.asInstanceOf[A])
       case OnError(e) =>
@@ -59,7 +59,7 @@ trait RxOps[+A] {
     * Keep evaluating Rx[A] even if OnError(e) or OnCompletion is reported. This is useful for keep processing streams.
     */
   def runContinuously[U](effect: A => U): Cancelable = {
-    RxRunner.runOpsContinuously(this) {
+    RxRunner.runContinuously(this) {
       case OnNext(v) =>
         effect(v.asInstanceOf[A])
       case OnError(e) =>

--- a/airframe-rx/src/main/scala/wvlet/airframe/rx/RxRunner.scala
+++ b/airframe-rx/src/main/scala/wvlet/airframe/rx/RxRunner.scala
@@ -43,7 +43,7 @@ object RxRunner extends LogSupport {
   // This runner will not report OnCompleiton event
   private val continuousRunner = new RxRunner(continuous = true)
 
-  def runOps[A, U](rx: RxOps[A])(effect: RxEvent => U): Cancelable =
+  def run[A, U](rx: RxOps[A])(effect: RxEvent => U): Cancelable = {
     defaultRunner.run(rx) { ev =>
       ev match {
         case v @ OnNext(_) =>
@@ -54,10 +54,9 @@ object RxRunner extends LogSupport {
           RxResult.Stop
       }
     }
+  }
 
-  def run[A, U](rx: Rx[A])(effect: RxEvent => U): Cancelable = runOps(rx)(effect)
-
-  def runOpsContinuously[A, U](rx: RxOps[A])(effect: RxEvent => U): Cancelable =
+  def runContinuously[A, U](rx: RxOps[A])(effect: RxEvent => U): Cancelable = {
     continuousRunner.run(rx) { ev =>
       ev match {
         case v @ OnNext(_) =>
@@ -68,11 +67,7 @@ object RxRunner extends LogSupport {
           RxResult.Stop
       }
     }
-
-  def runContinuously[A, U](rx: Rx[A])(effect: RxEvent => U): Cancelable = {
-    runOpsContinuously(rx)(effect)
   }
-
 }
 
 class RxRunner(

--- a/airframe-rx/src/main/scala/wvlet/airframe/rx/RxRunner.scala
+++ b/airframe-rx/src/main/scala/wvlet/airframe/rx/RxRunner.scala
@@ -43,7 +43,7 @@ object RxRunner extends LogSupport {
   // This runner will not report OnCompleiton event
   private val continuousRunner = new RxRunner(continuous = true)
 
-  def run[A, U](rx: Rx[A])(effect: RxEvent => U): Cancelable =
+  def runOps[A, U](rx: RxOps[A])(effect: RxEvent => U): Cancelable =
     defaultRunner.run(rx) { ev =>
       ev match {
         case v @ OnNext(_) =>
@@ -55,7 +55,9 @@ object RxRunner extends LogSupport {
       }
     }
 
-  def runContinuously[A, U](rx: Rx[A])(effect: RxEvent => U): Cancelable =
+  def run[A, U](rx: Rx[A])(effect: RxEvent => U): Cancelable = runOps(rx)(effect)
+
+  def runOpsContinuously[A, U](rx: RxOps[A])(effect: RxEvent => U): Cancelable =
     continuousRunner.run(rx) { ev =>
       ev match {
         case v @ OnNext(_) =>
@@ -66,6 +68,11 @@ object RxRunner extends LogSupport {
           RxResult.Stop
       }
     }
+
+  def runContinuously[A, U](rx: Rx[A])(effect: RxEvent => U): Cancelable = {
+    runOpsContinuously(rx)(effect)
+  }
+
 }
 
 class RxRunner(
@@ -84,7 +91,7 @@ class RxRunner(
     *   this must return [[RxResult.Stop]].
     * @tparam A
     */
-  def run[A](rx: Rx[A])(effect: RxEvent => RxResult): Cancelable = {
+  def run[A](rx: RxOps[A])(effect: RxEvent => RxResult): Cancelable = {
     rx match {
       case MapOp(in, f) =>
         run(in) {

--- a/airframe-rx/src/main/scala/wvlet/airframe/rx/RxSource.scala
+++ b/airframe-rx/src/main/scala/wvlet/airframe/rx/RxSource.scala
@@ -16,7 +16,7 @@ package wvlet.airframe.rx
 /**
   * Rx implementation where the data is provided from an external process.
   */
-trait RxSource[A] extends RxStream[A] {
+trait RxSource[A] extends Rx[A] {
   def add(ev: RxEvent): Unit
   def next: RxEvent
 }

--- a/airframe-rx/src/main/scala/wvlet/airframe/rx/RxVar.scala
+++ b/airframe-rx/src/main/scala/wvlet/airframe/rx/RxVar.scala
@@ -20,7 +20,7 @@ import scala.util.Try
 /**
   * A reactive variable supporting update and propagation of the updated value to the chained operators
   */
-class RxVar[A](private var currentValue: A) extends RxStream[A] with RxVarOps[A] {
+class RxVar[A](private var currentValue: A) extends Rx[A] with RxVarOps[A] {
   override def toString: String                        = s"RxVar(${currentValue})"
   override def parents: Seq[Rx[_]]                     = Seq.empty
   private val subscribers: ArrayBuffer[RxEvent => Any] = ArrayBuffer.empty

--- a/airframe-rx/src/test/scala/wvlet/airframe/rx/RxCacheTest.scala
+++ b/airframe-rx/src/test/scala/wvlet/airframe/rx/RxCacheTest.scala
@@ -20,7 +20,7 @@ import java.util.concurrent.TimeUnit
 class RxCacheTest extends AirSpec {
   private def evalStream(rx: RxOps[_]): Seq[RxEvent] = {
     val events = Seq.newBuilder[RxEvent]
-    val c      = RxRunner.runOpsContinuously(rx)(events += _)
+    val c      = RxRunner.runContinuously(rx)(events += _)
     c.cancel
     events.result()
   }

--- a/airframe-rx/src/test/scala/wvlet/airframe/rx/RxCacheTest.scala
+++ b/airframe-rx/src/test/scala/wvlet/airframe/rx/RxCacheTest.scala
@@ -18,16 +18,16 @@ import wvlet.airspec.AirSpec
 import java.util.concurrent.TimeUnit
 
 class RxCacheTest extends AirSpec {
-  private def evalStream(rx: Rx[_]): Seq[RxEvent] = {
+  private def evalStream(rx: RxOps[_]): Seq[RxEvent] = {
     val events = Seq.newBuilder[RxEvent]
-    val c      = RxRunner.runContinuously(rx)(events += _)
+    val c      = RxRunner.runOpsContinuously(rx)(events += _)
     c.cancel
     events.result()
   }
 
   test("cache") {
-    val v                      = Rx.variable(1)
-    val rx: RxStreamCache[Int] = v.map(x => x * 10).cache
+    val v                = Rx.variable(1)
+    val rx: RxCache[Int] = v.map(x => x * 10).cache
     rx.getCurrent shouldBe empty
     evalStream(rx) shouldBe Seq(OnNext(10))
 

--- a/airframe-rx/src/test/scala/wvlet/airframe/rx/RxRunnerTest.scala
+++ b/airframe-rx/src/test/scala/wvlet/airframe/rx/RxRunnerTest.scala
@@ -22,7 +22,7 @@ object RxRunnerTest extends AirSpec {
     test("last") {
       val rx            = Rx.sequence(1, 2).lastOption.map[Int] { x => throw ex }
       var c: Cancelable = Cancelable.empty
-      RxRunner.run(rx) {
+      RxRunner.runOps(rx) {
         case OnError(e) =>
           e shouldBeTheSameInstanceAs ex
         case OnCompletion =>

--- a/airframe-rx/src/test/scala/wvlet/airframe/rx/RxRunnerTest.scala
+++ b/airframe-rx/src/test/scala/wvlet/airframe/rx/RxRunnerTest.scala
@@ -22,7 +22,7 @@ object RxRunnerTest extends AirSpec {
     test("last") {
       val rx            = Rx.sequence(1, 2).lastOption.map[Int] { x => throw ex }
       var c: Cancelable = Cancelable.empty
-      RxRunner.runOps(rx) {
+      RxRunner.run(rx) {
         case OnError(e) =>
           e shouldBeTheSameInstanceAs ex
         case OnCompletion =>

--- a/airframe-rx/src/test/scala/wvlet/airframe/rx/RxTest.scala
+++ b/airframe-rx/src/test/scala/wvlet/airframe/rx/RxTest.scala
@@ -476,7 +476,7 @@ object RxTest extends AirSpec {
     }
 
     // (test name, input, expected value on success)
-    def newTests(rx: RxStream[Int]): Seq[(String, Rx[Any], Any)] =
+    def newTests(rx: Rx[Int]): Seq[(String, Rx[Any], Any)] =
       Seq(
         ("single", rx, Seq(1)),
         ("map", rx.map(x => x * 2), Seq(2)),

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ val targetScalaVersions = SCALA_3 :: uptoScala2
 // Add this for using snapshot versions
 ThisBuild / resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 
-val AIRSPEC_VERSION                 = sys.env.getOrElse("AIRSPEC_VERSION", "23.4.8-14-32555d5f-SNAPSHOT")
+val AIRSPEC_VERSION                 = sys.env.getOrElse("AIRSPEC_VERSION", "23.4.8-15-992164d0-SNAPSHOT")
 val SCALACHECK_VERSION              = "1.17.0"
 val MSGPACK_VERSION                 = "0.9.3"
 val SCALA_PARSER_COMBINATOR_VERSION = "2.3.0"

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ val targetScalaVersions = SCALA_3 :: uptoScala2
 // Add this for using snapshot versions
 // ThisBuild / resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 
-val AIRSPEC_VERSION                 = "23.4.8"
+val AIRSPEC_VERSION                 = sys.env.getOrElse("AIRSPEC_VERION", "23.4.8")
 val SCALACHECK_VERSION              = "1.17.0"
 val MSGPACK_VERSION                 = "0.9.3"
 val SCALA_PARSER_COMBINATOR_VERSION = "2.3.0"

--- a/build.sbt
+++ b/build.sbt
@@ -7,9 +7,9 @@ val uptoScala2          = SCALA_2_13 :: SCALA_2_12 :: Nil
 val targetScalaVersions = SCALA_3 :: uptoScala2
 
 // Add this for using snapshot versions
-// ThisBuild / resolvers ++= Resolver.sonatypeOssRepos("snapshots")
+ThisBuild / resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 
-val AIRSPEC_VERSION                 = sys.env.getOrElse("AIRSPEC_VERION", "23.4.8")
+val AIRSPEC_VERSION                 = sys.env.getOrElse("AIRSPEC_VERSION", "23.4.8-14-32555d5f-SNAPSHOT")
 val SCALACHECK_VERSION              = "1.17.0"
 val MSGPACK_VERSION                 = "0.9.3"
 val SCALA_PARSER_COMBINATOR_VERSION = "2.3.0"

--- a/examples/rpc-examples/rpc-scalajs/ui/src/main/scala/example/ui/ExampleUI.scala
+++ b/examples/rpc-examples/rpc-scalajs/ui/src/main/scala/example/ui/ExampleUI.scala
@@ -57,7 +57,7 @@ class MainUI extends RxElement with LogSupport {
           debug(s"Sending an RPC request")
           rpcClient.HelloApi
             .hello(s"RPC ${counter}")
-            .toRxStream
+            .toRx
             .map { resp =>
               message := resp
             }

--- a/sbt-airframe/src/sbt-test/sbt-airframe/grpc/api/src/main/scala/example/api/GreeterApi.scala
+++ b/sbt-airframe/src/sbt-test/sbt-airframe/grpc/api/src/main/scala/example/api/GreeterApi.scala
@@ -1,14 +1,14 @@
 package example.api
 
 import wvlet.airframe.http._
-import wvlet.airframe.rx.RxStream
+import wvlet.airframe.rx.Rx
 
 @RPC
 trait GreeterApi {
   def sayHello(message: String): String
-  def serverStreaming(message: String): RxStream[String]
-  def clientStreaming(message: RxStream[String]): String
-  def bidiStreaming(message: RxStream[String]): RxStream[String]
+  def serverStreaming(message: String): Rx[String]
+  def clientStreaming(message: Rx[String]): String
+  def bidiStreaming(message: Rx[String]): Rx[String]
 }
 
 object GreeterApi extends RxRouterProvider {

--- a/sbt-airframe/src/sbt-test/sbt-airframe/grpc/server/src/test/scala/example/api/GreeterApiTest.scala
+++ b/sbt-airframe/src/sbt-test/sbt-airframe/grpc/server/src/test/scala/example/api/GreeterApiTest.scala
@@ -2,7 +2,7 @@ package example.api
 
 import wvlet.airspec._
 import wvlet.airframe._
-import wvlet.airframe.rx.{Rx, RxStream}
+import wvlet.airframe.rx.{Rx, Rx}
 import wvlet.airframe.http._
 import wvlet.airframe.http.grpc.gRPC
 import wvlet.airframe.http.grpc.GrpcServer
@@ -13,13 +13,13 @@ import io.grpc.stub.StreamObserver
 object GreeterApiTest extends AirSpec {
   class GreeterApiImpl extends GreeterApi {
     def sayHello(message: String): String = s"Hello ${message}!"
-    def serverStreaming(message: String): RxStream[String] = {
+    def serverStreaming(message: String): Rx[String] = {
       Rx.sequence("Hello", "See you").map { x => s"${x} ${message}!" }
     }
-    def clientStreaming(message: RxStream[String]): String = {
+    def clientStreaming(message: Rx[String]): String = {
       message.map { x => s"Hello ${x}!" }.toSeq.mkString(", ")
     }
-    def bidiStreaming(message: RxStream[String]): RxStream[String] = {
+    def bidiStreaming(message: Rx[String]): Rx[String] = {
       message.map { x => s"Hello ${x}!" }
     }
   }

--- a/sbt-airframe/src/sbt-test/sbt-airframe/grpc/server/src/test/scala/example/api/GreeterApiTest.scala
+++ b/sbt-airframe/src/sbt-test/sbt-airframe/grpc/server/src/test/scala/example/api/GreeterApiTest.scala
@@ -2,7 +2,7 @@ package example.api
 
 import wvlet.airspec._
 import wvlet.airframe._
-import wvlet.airframe.rx.{Rx, Rx}
+import wvlet.airframe.rx.Rx
 import wvlet.airframe.http._
 import wvlet.airframe.http.grpc.gRPC
 import wvlet.airframe.http.grpc.GrpcServer

--- a/sbt-airframe/src/sbt-test/sbt-airframe/rpc-finagle/build.sbt
+++ b/sbt-airframe/src/sbt-test/sbt-airframe/rpc-finagle/build.sbt
@@ -7,7 +7,7 @@ ThisBuild / resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 
 ThisBuild / scalaVersion := "2.12.17"
 
-val AIRSPEC_VERSION = "23.4.5"
+val AIRSPEC_VERSION = sys.env.getOrElse("AIRSPEC_VERSION", "23.4.8-15-992164d0-SNAPSHOT")
 
 val buildSettings: Seq[Def.Setting[_]] = Seq(
   testFrameworks += new TestFramework("wvlet.airspec.Framework"),

--- a/sbt-airframe/src/sbt-test/sbt-airframe/rpc-netty/build.sbt
+++ b/sbt-airframe/src/sbt-test/sbt-airframe/rpc-netty/build.sbt
@@ -5,7 +5,7 @@ ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-parse
 
 ThisBuild / resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 
-val AIRSPEC_VERSION = "23.4.5"
+val AIRSPEC_VERSION = sys.env.getOrElse("AIRSPEC_VERSION", "23.4.8-15-992164d0-SNAPSHOT")
 
 val buildSettings: Seq[Def.Setting[_]] = Seq(
   testFrameworks += new TestFramework("wvlet.airspec.Framework"),


### PR DESCRIPTION
Closes #2917 

- Merged RxStream[A] to Rx[A] 
- RxOption[A] becomes a separate interface from Rx[A] 
- RxOps[A] is now a common parent between Rx[A] and RxOption[A]

Because this is an incompatible binary change, the build uses a snapshot version of Airframe, which has airframe-rx in the dependency. 
