### PR TITLE
sbt-airframe: Regenerate RPC clients upon API change without reload

### DIFF
--- a/airframe-http-codegen/src/main/scala/wvlet/airframe/http/codegen/HttpCodeGenerator.scala
+++ b/airframe-http-codegen/src/main/scala/wvlet/airframe/http/codegen/HttpCodeGenerator.scala
@@ -187,7 +187,7 @@ class HttpCodeGenerator(
   }
 
   private def buildRouter(apiPackageNames: Seq[String], classLoader: URLClassLoader): Router = {
-    info(s"Target API packages: ${apiPackageNames.mkString(", ")}")
+    debug(s"Target API packages: ${apiPackageNames.mkString(", ")}")
     val rxRouter = RouteScanner.buildRxRouter(apiPackageNames, classLoader)
     if (rxRouter.routes.isEmpty) {
       warn(s"Scanning classes implementing @RPC or @Endpoint from the classpath...")
@@ -202,7 +202,7 @@ class HttpCodeGenerator(
       @argument(description = "HttpCodeGeneratorOption in JSON file")
       jsonFilePath: String
   ): Unit = {
-    info(s"Reading JSON option file: ${jsonFilePath}")
+    debug(s"Reading JSON option file: ${jsonFilePath}")
     val option = MessageCodec.of[HttpCodeGeneratorOption].fromJson(IOUtil.readAsString(jsonFilePath))
     generate(option)
   }
@@ -231,7 +231,7 @@ class HttpCodeGenerator(
           touch(routerHashFile)
           writeFile(outputFile, code)
         } else {
-          info(s"${outputFile} is up-to-date")
+          info(s"${path} is up-to-date")
         }
         outputFile
       }

--- a/airframe-http-codegen/src/main/scala/wvlet/airframe/http/codegen/HttpCodeGenerator.scala
+++ b/airframe-http-codegen/src/main/scala/wvlet/airframe/http/codegen/HttpCodeGenerator.scala
@@ -231,7 +231,7 @@ class HttpCodeGenerator(
           touch(routerHashFile)
           writeFile(outputFile, code)
         } else {
-          info(s"${path} is up-to-date")
+          debug(s"${path} is up-to-date")
         }
         outputFile
       }

--- a/airframe-http-codegen/src/main/scala/wvlet/airframe/http/codegen/HttpCodeGenerator.scala
+++ b/airframe-http-codegen/src/main/scala/wvlet/airframe/http/codegen/HttpCodeGenerator.scala
@@ -226,7 +226,7 @@ class HttpCodeGenerator(
         val routerHashFile = new File(option.targetDir, f"router-${config.clientType.name}-${routerHash}%07x.update")
         if (!outputFile.exists() || !routerHashFile.exists()) {
           info(f"Router for package ${config.apiPackageName}:\n${routerStr}")
-          info(s"Generating a ${config.clientType.name} client code: ${path}")
+          info(s"Generating ${config.clientType.name} client code: ${path}")
           val code = HttpCodeGenerator.generate(router, config)
           touch(routerHashFile)
           writeFile(outputFile, code)

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/Router.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/Router.scala
@@ -61,19 +61,19 @@ case class Router(
 
   override def toString: String = printNode(0)
 
-  private def routerName: String = {
+  private def getRouterName: Option[String] = {
     surface
       .orElse(filterSurface)
       .orElse(filterInstance.map(_.getClass.getSimpleName))
-      .getOrElse(f"${hashCode()}%x")
-      .toString
+      .map(_.toString)
   }
 
   private def printNode(indentLevel: Int): String = {
     val s = Seq.newBuilder[String]
 
-    val ws = " " * (indentLevel * 2)
-    s += s"${ws}- Router[${routerName}]"
+    val ws   = " " * (indentLevel * 2)
+    val name = getRouterName.map(routerName => s"[${x}]").getOrElse("")
+    s += s"${ws}- Router${name}"
 
     for (r <- localRoutes) {
       s += s"${ws}  + ${r}"

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/Router.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/Router.scala
@@ -72,7 +72,7 @@ case class Router(
     val s = Seq.newBuilder[String]
 
     val ws   = " " * (indentLevel * 2)
-    val name = getRouterName.map(routerName => s"[${x}]").getOrElse("")
+    val name = getRouterName.map(routerName => s"[${routerName}]").getOrElse("")
     s += s"${ws}- Router${name}"
 
     for (r <- localRoutes) {

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/Router.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/Router.scala
@@ -63,7 +63,7 @@ case class Router(
 
   private def getRouterName: Option[String] = {
     surface
-      .orElse(filterSurface)
+      .orElse(filterSurface.map(_.name))
       .orElse(filterInstance.map(_.getClass.getSimpleName))
       .map(_.toString)
   }

--- a/sbt-airframe/build.sbt
+++ b/sbt-airframe/build.sbt
@@ -1,7 +1,7 @@
 // Reload build.sbt on changes
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
-val AIRFRAME_VERSION = sys.env.getOrElse("AIRFRAME_VERSION", "23.1.3")
+val AIRFRAME_VERSION = sys.env.getOrElse("AIRFRAME_VERSION", "23.5.0")
 val AIRSPEC_VERSION  = "23.4.8"
 val SCALA_2_12       = "2.12.17"
 

--- a/sbt-airframe/src/main/scala/wvlet/airframe/sbt/http/AirframeHttpPlugin.scala
+++ b/sbt-airframe/src/main/scala/wvlet/airframe/sbt/http/AirframeHttpPlugin.scala
@@ -195,7 +195,6 @@ object AirframeHttpPlugin extends AutoPlugin with LogSupport {
       airframeHttpGenerateClient := {
         val targetDir = airframeHttpWorkDir.value
         val baseDir   = targetDir.relativeTo(file(".")).getOrElse(targetDir)
-        val cacheFile = baseDir / cacheFileName
         val binDir    = airframeHttpBinaryDir.value
         val opts =
           s"${airframeHttpOpts.value} ${airframeHttpGeneratorOption.value}"
@@ -216,15 +215,9 @@ object AirframeHttpPlugin extends AutoPlugin with LogSupport {
           debug(cmd)
           val json: String = cmd.!!
           debug(s"client generator result: ${json}")
-          IO.write(cacheFile, json)
           // Return generated files
           seqFileCodec.unpackJson(json).getOrElse(Seq.empty)
         }
-        //        else {
-        //          debug(s"Using cached client")
-        //          val json = IO.read(cacheFile)
-        //          seqFileCodec.fromJson(json)
-        //        }
         result
       },
       airframeHttpOpts := "",

--- a/sbt-airframe/src/main/scala/wvlet/airframe/sbt/http/AirframeHttpPlugin.scala
+++ b/sbt-airframe/src/main/scala/wvlet/airframe/sbt/http/AirframeHttpPlugin.scala
@@ -206,7 +206,7 @@ object AirframeHttpPlugin extends AutoPlugin with LogSupport {
           targets = airframeHttpClients.value
         )
 
-        val result: Seq[File] = if (!cacheFile.exists) {
+        val result: Seq[File] = {
           debug(s"airframe-http directory: ${binDir}")
           val commandLineOptsJson = MessageCodec.of[HttpCodeGeneratorOption].toJson(commandLineOpts)
           trace(s"airframe-http code-generator option:\n${commandLineOptsJson}")
@@ -219,11 +219,12 @@ object AirframeHttpPlugin extends AutoPlugin with LogSupport {
           IO.write(cacheFile, json)
           // Return generated files
           seqFileCodec.unpackJson(json).getOrElse(Seq.empty)
-        } else {
-          debug(s"Using cached client")
-          val json = IO.read(cacheFile)
-          seqFileCodec.fromJson(json)
         }
+        //        else {
+        //          debug(s"Using cached client")
+        //          val json = IO.read(cacheFile)
+        //          seqFileCodec.fromJson(json)
+        //        }
         result
       },
       airframeHttpOpts := "",

--- a/sbt-airframe/src/sbt-test/sbt-airframe/generate-client/build.sbt
+++ b/sbt-airframe/src/sbt-test/sbt-airframe/generate-client/build.sbt
@@ -22,7 +22,7 @@ lazy val server =
     .in(file("server"))
     .enablePlugins(AirframeHttpPlugin)
     .settings(
-      airframeHttpGeneratorOption := "-l trace",
+      airframeHttpGeneratorOption := "-l debug",
       airframeHttpClients := Seq(
         "myapp.spi:rpc"
       ),

--- a/sbt-airframe/src/sbt-test/sbt-airframe/generate-client/test
+++ b/sbt-airframe/src/sbt-test/sbt-airframe/generate-client/test
@@ -1,2 +1,4 @@
 > compile
+# cache test
+> compile
 > server/run


### PR DESCRIPTION
- Do not include object hash to router string
- fix
- Fix name
- reduce debug log
- clenaup
- Fix
