### PR TITLE
airframe-codec: 3-5x Improvement of the codec lookup performance of MessageCodecFactory 

### DIFF
--- a/airframe-codec/src/main/scala/wvlet/airframe/codec/MessageCodecFactory.scala
+++ b/airframe-codec/src/main/scala/wvlet/airframe/codec/MessageCodecFactory.scala
@@ -8,7 +8,7 @@ import wvlet.log.LogSupport
 case class MessageCodecFactory(codecFinder: MessageCodecFinder = Compat.messageCodecFinder, mapOutput: Boolean = true)
     extends ScalaCompat.MessageCodecFactoryBase
     with LogSupport {
-  private[this] var cache = Map.empty[Surface, MessageCodec[_]]
+  private[this] var cache = Map.empty[String, MessageCodec[_]]
 
   def withCodecs(additionalCodecs: Map[Surface, MessageCodec[_]]): MessageCodecFactory = {
     this.copy(codecFinder = codecFinder orElse MessageCodecFinder.newCodecFinder(additionalCodecs))
@@ -49,8 +49,9 @@ case class MessageCodecFactory(codecFinder: MessageCodecFinder = Compat.messageC
 
   def ofSurface(surface: Surface, seen: Set[Surface] = Set.empty): MessageCodec[_] = {
     // TODO Create a fast object codec with code generation (e.g., Scala macros)
-    if (cache.contains(surface)) {
-      cache(surface)
+    val surfaceName = surface.fullName
+    if (cache.contains(surfaceName)) {
+      cache(surfaceName)
     } else if (seen.contains(surface)) {
       LazyCodec(surface, this)
     } else {
@@ -65,7 +66,7 @@ case class MessageCodecFactory(codecFinder: MessageCodecFinder = Compat.messageC
           }
           .apply(surface)
 
-      cache += surface -> codec
+      cache += surfaceName -> codec
       codec
     }
   }


### PR DESCRIPTION
MessageCodecFactory used Surface case class as a cache key, which had a significant overhead. Improved the performance by using Surface.fullName as a cache key:

Before
```
[info] Benchmark                                     Mode  Cnt          Score          Error  Units
[info] RPCRequestBenchmark.rpcBodyOnly              thrpt   10  143043471.699 ± 72497486.069  ops/s
[info] RPCRequestBenchmark.rpcRequestNoCodec        thrpt   10      89063.233 ±      624.039  ops/s
[info] RPCRequestBenchmark.rpcRequestWithJsonSer    thrpt   10      74278.516 ±     1438.154  ops/s
[info] RPCRequestBenchmark.rpcRequestWithRPCMethod  thrpt   10      58004.750 ±      984.233  ops/s
```

After
```
[info] Benchmark                                     Mode  Cnt          Score        Error  Units
[info] RPCRequestBenchmark.rpcBodyOnly              thrpt   10  186913889.715 ± 966841.794  ops/s
[info] RPCRequestBenchmark.rpcRequestNoCodec        thrpt   10     346416.119 ±   4292.134  ops/s
[info] RPCRequestBenchmark.rpcRequestWithJsonSer    thrpt   10     204541.213 ±   3527.284  ops/s
[info] RPCRequestBenchmark.rpcRequestWithRPCMethod  thrpt   10     299616.662 ±   1119.058  ops/s
```