### PR TITLE
internal: Add http response builder benchmark

### DIFF
--- a/airframe-benchmark/README.md
+++ b/airframe-benchmark/README.md
@@ -27,9 +27,6 @@ $ ./bin/airframe-benchmark bench msgpack
 # Run JSON benchmark
 $ ./bin/airframe-benchmark bench json
 
-# Run Airframe HTTP benchmark
-$ ./bin/airframe-benchmark bench http_request
-
 # Run Airframe RPC benchmark
 $ ./bin/airframe-benchmark bench rpc_netty
 $ ./bin/airframe-benchmark bench rpc_finagle
@@ -37,6 +34,9 @@ $ ./bin/airframe-benchmark bench rpc_grpc
 
 # Pure grpc-java performance
 $ ./bin/airframe-benchmark bench grpc_java
+
+# Run Airframe RPC request builder benchmark
+$ ./bin/airframe-benchmark bench rpc_request
 
 
 # Run MessagePack benchmaark and write the results to a json file

--- a/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/rpc_finagle/AirframeFinagle.scala
+++ b/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/rpc_finagle/AirframeFinagle.scala
@@ -13,84 +13,84 @@
  */
 package wvlet.airframe.benchmark.rpc_finagle
 
-import com.twitter.finagle.http.{Request, Response}
-import com.twitter.util.Future
-import org.openjdk.jmh.annotations._
-import org.openjdk.jmh.infra.Blackhole
-import wvlet.airframe.Session
-import wvlet.airframe.benchmark.http.HttpBenchmark.asyncIteration
-import wvlet.airframe.benchmark.http.{Greeter, NewServiceSyncClient, ServiceClient, ServiceSyncClient}
-import wvlet.airframe.http.Http
-import wvlet.airframe.http.client.SyncClient
-import wvlet.airframe.http.finagle.{Finagle, FinagleClient, FinagleServer, FinagleSyncClient}
-import wvlet.log.LogSupport
-
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicInteger
-
-/**
-  */
-@State(Scope.Benchmark)
-@BenchmarkMode(Array(Mode.Throughput))
-@OutputTimeUnit(TimeUnit.SECONDS)
-class AirframeFinagle extends LogSupport {
-
-  private val design =
-    Finagle.server
-      .withRouter(Greeter.router)
-      .noLoggingFilter
-      .designWithSyncClient
-      .bind[FinagleClient].toProvider { (server: FinagleServer) =>
-        Finagle.client.newClient(server.localAddress)
-      }
-      .bind[SyncClient].toProvider { (server: FinagleServer) =>
-        Http.client.noLogging.noClientFilter.newSyncClient(server.localAddress)
-      }
-      .withProductionMode
-  private var session: Option[Session]                              = None
-  private var client: ServiceSyncClient[Request, Response]          = null
-  private var syncClient: NewServiceSyncClient                      = null
-  private var asyncClient: ServiceClient[Future, Request, Response] = null
-
-  @Setup
-  def setup: Unit = {
-    val s = design.newSession
-    s.start
-    session = Some(s)
-    client = new ServiceSyncClient(s.build[FinagleSyncClient])
-    syncClient = new NewServiceSyncClient(s.build[SyncClient])
-    asyncClient = new ServiceClient(s.build[FinagleClient])
-  }
-
-  @TearDown
-  def teardown: Unit = {
-    session.foreach(_.shutdown)
-    client.close()
-    syncClient.close()
-    asyncClient.close()
-  }
-
-  @Benchmark
-  def rpcSyncFinagleClient(blackhole: Blackhole): Unit = {
-    blackhole.consume(client.Greeter.hello("RPC"))
-  }
-
-  @Benchmark
-  def rpcSyncDefaultClient(blackhole: Blackhole): Unit = {
-    blackhole.consume(syncClient.Greeter.hello("RPC"))
-  }
-
-  @Benchmark
-  @OperationsPerInvocation(asyncIteration)
-  def rpcAsyncFinagleClient(blackhole: Blackhole): Unit = {
-    val counter = new AtomicInteger(0)
-    val futures = for (i <- 0 until asyncIteration) yield {
-      asyncClient.Greeter.hello("RPC").onSuccess { x =>
-        counter.incrementAndGet()
-      }
-    }
-    while (counter.get() != asyncIteration) {
-      Thread.sleep(0)
-    }
-  }
-}
+//import com.twitter.finagle.http.{Request, Response}
+//import com.twitter.util.Future
+//import org.openjdk.jmh.annotations._
+//import org.openjdk.jmh.infra.Blackhole
+//import wvlet.airframe.Session
+//import wvlet.airframe.benchmark.http.HttpBenchmark.asyncIteration
+//import wvlet.airframe.benchmark.http.{Greeter, NewServiceSyncClient, ServiceClient, ServiceSyncClient}
+//import wvlet.airframe.http.Http
+//import wvlet.airframe.http.client.SyncClient
+//import wvlet.airframe.http.finagle.{Finagle, FinagleClient, FinagleServer, FinagleSyncClient}
+//import wvlet.log.LogSupport
+//
+//import java.util.concurrent.TimeUnit
+//import java.util.concurrent.atomic.AtomicInteger
+//
+///**
+//  */
+//@State(Scope.Benchmark)
+//@BenchmarkMode(Array(Mode.Throughput))
+//@OutputTimeUnit(TimeUnit.SECONDS)
+//class AirframeFinagle extends LogSupport {
+//
+//  private val design =
+//    Finagle.server
+//      .withRouter(Greeter.router)
+//      .noLoggingFilter
+//      .designWithSyncClient
+//      .bind[FinagleClient].toProvider { (server: FinagleServer) =>
+//        Finagle.client.newClient(server.localAddress)
+//      }
+//      .bind[SyncClient].toProvider { (server: FinagleServer) =>
+//        Http.client.noLogging.noClientFilter.newSyncClient(server.localAddress)
+//      }
+//      .withProductionMode
+//  private var session: Option[Session]                              = None
+//  private var client: ServiceSyncClient[Request, Response]          = null
+//  private var syncClient: NewServiceSyncClient                      = null
+//  private var asyncClient: ServiceClient[Future, Request, Response] = null
+//
+//  @Setup
+//  def setup: Unit = {
+//    val s = design.newSession
+//    s.start
+//    session = Some(s)
+//    client = new ServiceSyncClient(s.build[FinagleSyncClient])
+//    syncClient = new NewServiceSyncClient(s.build[SyncClient])
+//    asyncClient = new ServiceClient(s.build[FinagleClient])
+//  }
+//
+//  @TearDown
+//  def teardown: Unit = {
+//    session.foreach(_.shutdown)
+//    client.close()
+//    syncClient.close()
+//    asyncClient.close()
+//  }
+//
+//  @Benchmark
+//  def rpcSyncFinagleClient(blackhole: Blackhole): Unit = {
+//    blackhole.consume(client.Greeter.hello("RPC"))
+//  }
+//
+//  @Benchmark
+//  def rpcSyncDefaultClient(blackhole: Blackhole): Unit = {
+//    blackhole.consume(syncClient.Greeter.hello("RPC"))
+//  }
+//
+//  @Benchmark
+//  @OperationsPerInvocation(asyncIteration)
+//  def rpcAsyncFinagleClient(blackhole: Blackhole): Unit = {
+//    val counter = new AtomicInteger(0)
+//    val futures = for (i <- 0 until asyncIteration) yield {
+//      asyncClient.Greeter.hello("RPC").onSuccess { x =>
+//        counter.incrementAndGet()
+//      }
+//    }
+//    while (counter.get() != asyncIteration) {
+//      Thread.sleep(0)
+//    }
+//  }
+//}

--- a/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/rpc_request/RPCRequestBenchmark.scala
+++ b/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/rpc_request/RPCRequestBenchmark.scala
@@ -68,6 +68,14 @@ class RPCRequestBenchmark extends LogSupport {
     }
   }
 
+  @Benchmark
+  def rpcNettyResponseBuilderImmutable(blackhole: Blackhole): Unit = {
+    blackhole.consume {
+      val resp = Http.response(HttpStatus.Ok_200).withJson("""{"message":"Hello, RPC"}""")
+      NettyRequestHandler.toNettyResponse(resp)
+    }
+  }
+
   private val rpcMethod = RPCMethod(
     path = "/wvlet.airframe.benchmark.http.Greeter/hello",
     rpcInterfaceName = "Greeter",

--- a/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/rpc_request/RPCRequestBenchmark.scala
+++ b/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/rpc_request/RPCRequestBenchmark.scala
@@ -13,21 +13,19 @@
  */
 package wvlet.airframe.benchmark.rpc_request
 
-import org.openjdk.jmh.annotations.{Benchmark, BenchmarkMode, Mode, OutputTimeUnit, Scope, Setup, State, TearDown}
+import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.Blackhole
-import wvlet.airframe.Session
+import wvlet.airframe.benchmark.http.Greeter
 import wvlet.airframe.benchmark.http.Greeter.GreeterResponse
-import wvlet.airframe.benchmark.http.{Greeter, NewServiceAsyncClient, NewServiceSyncClient}
 import wvlet.airframe.codec.MessageCodec
-import wvlet.airframe.http.{Http, HttpMessage, HttpStatus, RPCMethod, RxHttpFilter}
-import wvlet.airframe.http.client.{AsyncClient, HttpChannel, HttpChannelConfig, HttpClients, SyncClient, SyncClientImpl}
-import wvlet.airframe.http.netty.{Netty, NettyRequestHandler, NettyServer}
+import wvlet.airframe.http.client.{HttpChannel, HttpChannelConfig, HttpClients, SyncClientImpl}
+import wvlet.airframe.http.netty.NettyRequestHandler
+import wvlet.airframe.http._
 import wvlet.airframe.rx.Rx
 import wvlet.airframe.surface.Surface
 import wvlet.log.LogSupport
 
-import java.util.concurrent.{Executors, TimeUnit}
-import scala.concurrent.ExecutionContext
+import java.util.concurrent.TimeUnit
 
 @State(Scope.Benchmark)
 @BenchmarkMode(Array(Mode.Throughput))
@@ -62,13 +60,11 @@ class RPCRequestBenchmark extends LogSupport {
     }
   }
 
-  private val strSurface = Surface.of[String]
   @Benchmark
   def rpcNettyResponseBuilder(blackhole: Blackhole): Unit = {
     blackhole.consume {
-      val resp          = Http.response(HttpStatus.Ok_200).withJson("""{"message":"Hello, RPC"}""")
-      val nettyResponse = NettyRequestHandler.toNettyResponse(resp)
-      HttpClients.parseRPCResponse(noNetworkRPCClient.config, resp, strSurface)
+      val resp = Http.response(HttpStatus.Ok_200, """{"message":"Hello, RPC"}""")
+      NettyRequestHandler.toNettyResponse(resp)
     }
   }
 

--- a/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/rpc_request/RPCRequestBenchmark.scala
+++ b/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/rpc_request/RPCRequestBenchmark.scala
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.airframe.benchmark.http_request
+package wvlet.airframe.benchmark.rpc_request
 
 import org.openjdk.jmh.annotations.{Benchmark, BenchmarkMode, Mode, OutputTimeUnit, Scope, Setup, State, TearDown}
 import org.openjdk.jmh.infra.Blackhole

--- a/airframe-http-netty/src/main/scala/wvlet/airframe/http/netty/NetthRequestHandler.scala
+++ b/airframe-http-netty/src/main/scala/wvlet/airframe/http/netty/NetthRequestHandler.scala
@@ -33,6 +33,7 @@ import wvlet.log.LogSupport
 
 import java.net.InetSocketAddress
 import scala.jdk.CollectionConverters._
+import NettyRequestHandler._
 
 class NetthRequestHandler(config: NettyServerConfig, dispatcher: NettyBackend.Filter)
     extends SimpleChannelInboundHandler[FullHttpRequest]
@@ -111,7 +112,10 @@ class NetthRequestHandler(config: NettyServerConfig, dispatcher: NettyBackend.Fi
     }
   }
 
-  private def toNettyResponse(response: Response): DefaultHttpResponse = {
+}
+
+object NettyRequestHandler {
+  def toNettyResponse(response: Response): DefaultFullHttpResponse = {
     val r = if (response.message.isEmpty) {
       val res = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.valueOf(response.statusCode))
       // Need to set the content length properly to return the response in Netty
@@ -130,5 +134,4 @@ class NetthRequestHandler(config: NettyServerConfig, dispatcher: NettyBackend.Fi
     }
     r
   }
-
 }

--- a/build.sbt
+++ b/build.sbt
@@ -802,8 +802,9 @@ lazy val benchmark =
     .settings(buildSettings)
     .settings(noPublish)
     .settings(
-      name     := "airframe-benchmark",
-      packMain := Map("airframe-benchmark" -> "wvlet.airframe.benchmark.BenchmarkMain"),
+      crossScalaVersions := targetScalaVersions,
+      name               := "airframe-benchmark",
+      packMain           := Map("airframe-benchmark" -> "wvlet.airframe.benchmark.BenchmarkMain"),
       // Turbo mode didn't work with this error:
       // java.lang.RuntimeException: ERROR: Unable to find the resource: /META-INF/BenchmarkList
       turbo := false,

--- a/build.sbt
+++ b/build.sbt
@@ -801,7 +801,6 @@ lazy val benchmark =
     .enablePlugins(JmhPlugin, PackPlugin)
     .settings(buildSettings)
     .settings(noPublish)
-    .settings(scala2Only)
     .settings(
       name     := "airframe-benchmark",
       packMain := Map("airframe-benchmark" -> "wvlet.airframe.benchmark.BenchmarkMain"),
@@ -836,7 +835,7 @@ lazy val benchmark =
       // publishing .tgz
       // publishPackArchiveTgz
     )
-    .dependsOn(msgpack.jvm, json.jvm, metrics.jvm, launcher, httpCodeGen, finagle, netty, grpc, ulid.jvm)
+    .dependsOn(msgpack.jvm, json.jvm, metrics.jvm, launcher, httpCodeGen, netty, grpc, ulid.jvm)
 
 lazy val fluentd =
   project


### PR DESCRIPTION
Add a benchmark that revealed the overhead of building HTTP request/response object in an immutable manner:

```
[info] Benchmark                                              Mode  Cnt          Score         Error  Units
[info] RPCRequestBenchmark.rpcBodyOnly                       thrpt   10  188079929.691 ± 1265070.205  ops/s
[info] RPCRequestBenchmark.rpcNettyResponseBuilder           thrpt   10   16701854.988 ±  319776.222  ops/s
[info] RPCRequestBenchmark.rpcNettyResponseBuilderImmutable  thrpt   10    8819855.917 ±   49780.216  ops/s
[info] RPCRequestBenchmark.rpcRequestWithRPCMethod           thrpt   10     307929.262 ±    2108.229  ops/s
```

This PR also disables Finagle-based benchmark, which doesn't work in Scala 3