### PR TITLE
fix(grpc) #2883: Scala 3 grpc support works with the latest airframe

### DIFF
--- a/sbt-airframe/src/sbt-test/sbt-airframe/grpc/build.sbt
+++ b/sbt-airframe/src/sbt-test/sbt-airframe/grpc/build.sbt
@@ -1,6 +1,6 @@
 import wvlet.airframe.sbt.http.AirframeHttpPlugin
 
-val AIRSPEC_VERSION = "22.12.1"
+val AIRSPEC_VERSION = "23.5.6"
 
 val buildSettings: Seq[Def.Setting[_]] = Seq(
   testFrameworks += new TestFramework("wvlet.airspec.Framework"),
@@ -8,7 +8,7 @@ val buildSettings: Seq[Def.Setting[_]] = Seq(
 )
 ThisBuild / resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 // TODO: To use Scala 3, https://github.com/wvlet/airframe/issues/2883 needs to be fixed
-ThisBuild / scalaVersion := "2.12.17"
+ThisBuild / scalaVersion := "3.3.0"
 // ThisBuild / crossScalaVersions := Seq("2.13.10", "3.2.2")
 
 lazy val root =


### PR DESCRIPTION
Scala 3 + grpc issue was fixed in https://github.com/wvlet/airframe/releases/tag/v23.5.5