### PR TITLE
Support sslmode parameter in PostgreSQL

### DIFF
--- a/airframe-jdbc/src/main/scala/wvlet/airframe/jdbc/DbConfig.scala
+++ b/airframe-jdbc/src/main/scala/wvlet/airframe/jdbc/DbConfig.scala
@@ -125,7 +125,7 @@ case class PostgreSQLConfig(
     // SSL configuration for using RDS
     useSSL: Boolean = true,
     sslFactory: String = "org.postgresql.ssl.NonValidatingFactory",
-    sslmode: String = "verify-full"
+    sslmode: String = "prefer"
 )
 
 case class ConnectionPoolConfig(

--- a/airframe-jdbc/src/main/scala/wvlet/airframe/jdbc/DbConfig.scala
+++ b/airframe-jdbc/src/main/scala/wvlet/airframe/jdbc/DbConfig.scala
@@ -124,7 +124,8 @@ case class DbConfig(
 case class PostgreSQLConfig(
     // SSL configuration for using RDS
     useSSL: Boolean = true,
-    sslFactory: String = "org.postgresql.ssl.NonValidatingFactory"
+    sslFactory: String = "org.postgresql.ssl.NonValidatingFactory",
+    sslmode: String = "verify-full"
 )
 
 case class ConnectionPoolConfig(

--- a/airframe-jdbc/src/main/scala/wvlet/airframe/jdbc/GenericConnectionPool.scala
+++ b/airframe-jdbc/src/main/scala/wvlet/airframe/jdbc/GenericConnectionPool.scala
@@ -36,6 +36,7 @@ class GenericConnectionPool(val config: DbConfig) extends ConnectionPool {
         if (config.postgres.useSSL) {
           connectionPoolConfig.addDataSourceProperty("ssl", "true")
           connectionPoolConfig.addDataSourceProperty("sslfactory", config.postgres.sslFactory)
+          connectionPoolConfig.addDataSourceProperty("sslmode", config.postgres.sslmode)
         }
     }
 

--- a/airframe-jdbc/src/test/scala/wvlet/airframe/jdbc/DbConfigTest.scala
+++ b/airframe-jdbc/src/test/scala/wvlet/airframe/jdbc/DbConfigTest.scala
@@ -64,6 +64,7 @@ class DbConfigTest extends AirSpec {
       .withPassword("xxx")
     p.jdbcPort shouldBe 5432
     p.jdbcDriverName shouldBe "org.postgresql.Driver"
+    p.jdbcUrl shouldBe "jdbc:postgresql://localhost/public"
 
     val presto =
       c.withType("presto")


### PR DESCRIPTION
## Overview

- Support `sslmode` parameter in PostgreSQL


## Background

- For relax verification when connecting to a DB using a CNAME record.
- When using a RDS host, a RDS is set up with a SSL certificate managed by AWS. But, a hostname is generated with randomly. It's not convenient. So, some of the users use DNS to set up an arbitrary name and use it to connect to the DB.
- At that case, the default sslmode gets cause of the error since a proper SSL certification isn't used.
- For the `psql` command,  it uses `prefer` when connecting to a DB with ssl. And, it works as expected.

<!--
- `pgJDBC` and `psql`, which is a default CLI commnd, use different sslmode by default.
  `psql` use `prefer` but `pgJDBC` use `verify-full` when connecting to a DB with ssl.
-->