### PR TITLE
airframe-rx-html: Support implicit convertion to RxElement with import wvlet.airframe.rx.html.all.*

### DIFF
--- a/airframe-rx-html/.js/src/main/scala/wvlet/airframe/rx/html/compat.scala
+++ b/airframe-rx-html/.js/src/main/scala/wvlet/airframe/rx/html/compat.scala
@@ -18,7 +18,7 @@ import org.scalajs.dom
   */
 object compat {
   trait PlatformEmbeddableNode {
-    @inline implicit def embedHtmlElement[A <: dom.Element]: EmbeddableNode[A] = null
+    @inline implicit def embedHtmlElement[A <: dom.Element]: RxEmbedding.EmbeddableNode[A] = null
   }
   type UIEvent    = dom.UIEvent
   type MouseEvent = dom.MouseEvent

--- a/airframe-rx-html/.js/src/test/scala/wvlet/airframe/http/rx/html/HtmlRenderingTest.scala
+++ b/airframe-rx-html/.js/src/test/scala/wvlet/airframe/http/rx/html/HtmlRenderingTest.scala
@@ -15,7 +15,6 @@ package wvlet.airframe.rx.html
 
 import org.scalajs.dom
 import wvlet.airframe.rx.Rx
-import wvlet.airframe.rx.html._
 import wvlet.airframe.rx.html.all._
 import wvlet.airspec._
 

--- a/airframe-rx-html/src/main/scala/wvlet/airframe/rx/html/HtmlNode.scala
+++ b/airframe-rx-html/src/main/scala/wvlet/airframe/rx/html/HtmlNode.scala
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.rx.html
+import wvlet.airframe.rx.html.RxEmbedding._
+
+trait HtmlNode {
+  def when(cond: => Boolean): HtmlNode = {
+    if (cond) this else HtmlNode.empty
+  }
+
+  def unless(cond: => Boolean): HtmlNode = {
+    if (cond) HtmlNode.empty else this
+  }
+}
+
+// HtmlNode -> Element -> HtmlElement
+//          -> HtmlAttribute
+object HtmlNode {
+  object empty extends HtmlNode
+}
+
+case class HtmlAttribute(name: String, v: Any, ns: Namespace = Namespace.xhtml, append: Boolean = false)
+    extends HtmlNode
+
+class HtmlAttributeOf(name: String, namespace: Namespace = Namespace.xhtml) {
+  def apply[V: EmbeddableAttribute](v: V): HtmlNode = HtmlAttribute(name, v, namespace)
+  def ->[V: EmbeddableAttribute](v: V): HtmlNode    = apply(v)
+  def add[V: EmbeddableAttribute](v: V): HtmlNode   = HtmlAttribute(name, v, namespace, append = true)
+  def +=[V: EmbeddableAttribute](v: V): HtmlNode    = add(v)
+  def noValue: HtmlNode                             = HtmlAttribute(name, true, namespace)
+}
+
+class HtmlEventHandlerOf[E](name: String, namespace: Namespace = Namespace.xhtml) {
+  def apply[U](v: E => U): HtmlNode  = HtmlAttribute(name, v, namespace)
+  def ->[U](v: E => U): HtmlNode     = apply(v)
+  def apply[U](v: () => U): HtmlNode = HtmlAttribute(name, v, namespace)
+  def ->[U](v: () => U): HtmlNode    = apply(v)
+  def noValue: HtmlNode              = HtmlAttribute(name, false, namespace)
+}
+
+case class EntityRef(ref: String) extends HtmlNode
+
+// Used for properly embedding namespaces to DOM. For example, for rendering SVG elements,
+// Namespace.svg must be set to DOM elements. If not, the SVG elements will not be rendered in the web browsers.
+case class Namespace(uri: String)
+
+object Namespace {
+  val xhtml: Namespace = Namespace("http://www.w3.org/1999/xhtml")
+  val svg: Namespace   = Namespace("http://www.w3.org/2000/svg")
+  val svgXLink         = Namespace("http://www.w3.org/1999/xlink")
+}

--- a/airframe-rx-html/src/main/scala/wvlet/airframe/rx/html/RxElement.scala
+++ b/airframe-rx-html/src/main/scala/wvlet/airframe/rx/html/RxElement.scala
@@ -15,6 +15,7 @@ package wvlet.airframe.rx.html
 
 import wvlet.airframe.rx.{Cancelable, Rx}
 import wvlet.log.LogSupport
+import wvlet.airframe.rx.html.RxEmbedding._
 
 /**
   */

--- a/airframe-rx-html/src/main/scala/wvlet/airframe/rx/html/RxEmbedding.scala
+++ b/airframe-rx-html/src/main/scala/wvlet/airframe/rx/html/RxEmbedding.scala
@@ -14,18 +14,21 @@
 package wvlet.airframe.rx.html
 
 import wvlet.airframe.rx.{Rx, RxOption}
-import wvlet.airframe.rx.html.compat
-import wvlet.log.LogSupport
 
 import scala.annotation.implicitNotFound
 import scala.language.higherKinds
 import scala.language.implicitConversions
 
-trait RxEmbeddingSupport {
-  @implicitNotFound(msg = "Unsupported type as an attribute value")
-  trait EmbeddableAttribute[X]
+trait RxEmbedding {
+  import RxEmbedding._
+  implicit def embedAsNode[A: EmbeddableNode](v: A): RxElement = Embedded(v)
+}
 
-  object EmbeddableAttribute {
+object RxEmbedding {
+  @implicitNotFound(msg = "Unsupported type as an attribute value")
+  private[html] trait EmbeddableAttribute[X]
+
+  private[html] object EmbeddableAttribute {
     type EA[A] = EmbeddableAttribute[A]
     @inline implicit def embedNone: EA[None.type]                            = null
     @inline implicit def embedBoolean: EA[Boolean]                           = null
@@ -43,9 +46,9 @@ trait RxEmbeddingSupport {
   }
 
   @implicitNotFound(msg = "Unsupported type as an HtmlNode")
-  trait EmbeddableNode[A]
+  private[html] trait EmbeddableNode[A]
 
-  object EmbeddableNode extends compat.PlatformEmbeddableNode {
+  private[html] object EmbeddableNode extends compat.PlatformEmbeddableNode {
     type EN[A] = EmbeddableNode[A]
     @inline implicit def embedNil: EN[Nil.type]                              = null
     @inline implicit def embedNone: EN[None.type]                            = null
@@ -65,17 +68,4 @@ trait RxEmbeddingSupport {
     @inline implicit def embedOption[C[x] <: Option[x], A: EN]: EN[C[A]]     = null
   }
 
-  /**
-    * Holder for embedding various types as tag contents
-    *
-    * @param v
-    */
-  case class Embedded(v: Any) extends RxElement with LogSupport {
-    override def render: RxElement = {
-      warn(s"render is called for ${v}")
-      ???
-    }
-  }
-
-  implicit def embedAsNode[A: EmbeddableNode](v: A): RxElement = Embedded(v)
 }

--- a/airframe-rx-html/src/main/scala/wvlet/airframe/rx/html/RxEmbeddingSupport.scala
+++ b/airframe-rx-html/src/main/scala/wvlet/airframe/rx/html/RxEmbeddingSupport.scala
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.rx.html
+
+import wvlet.airframe.rx.{Rx, RxOption}
+import wvlet.airframe.rx.html.compat
+import wvlet.log.LogSupport
+
+import scala.annotation.implicitNotFound
+import scala.language.higherKinds
+import scala.language.implicitConversions
+
+trait RxEmbeddingSupport {
+  @implicitNotFound(msg = "Unsupported type as an attribute value")
+  trait EmbeddableAttribute[X]
+
+  object EmbeddableAttribute {
+    type EA[A] = EmbeddableAttribute[A]
+    @inline implicit def embedNone: EA[None.type]                            = null
+    @inline implicit def embedBoolean: EA[Boolean]                           = null
+    @inline implicit def embedInt: EA[Int]                                   = null
+    @inline implicit def embedLong: EA[Long]                                 = null
+    @inline implicit def embedString: EA[String]                             = null
+    @inline implicit def embedFloat: EA[Float]                               = null
+    @inline implicit def embedDouble: EA[Double]                             = null
+    @inline implicit def embedF0[U]: EA[() => U]                             = null
+    @inline implicit def embedF1[I, U]: EA[I => U]                           = null
+    @inline implicit def embedOption[C[x] <: Option[x], A: EA]: EA[C[A]]     = null
+    @inline implicit def embedRx[C[x] <: Rx[x], A: EA]: EA[C[A]]             = null
+    @inline implicit def embedRxOption[C[x] <: RxOption[x], A: EA]: EA[C[A]] = null
+    @inline implicit def embedSeq[C[x] <: Iterable[x], A: EA]: EA[C[A]]      = null
+  }
+
+  @implicitNotFound(msg = "Unsupported type as an HtmlNode")
+  trait EmbeddableNode[A]
+
+  object EmbeddableNode extends compat.PlatformEmbeddableNode {
+    type EN[A] = EmbeddableNode[A]
+    @inline implicit def embedNil: EN[Nil.type]                              = null
+    @inline implicit def embedNone: EN[None.type]                            = null
+    @inline implicit def embedBoolean: EN[Boolean]                           = null
+    @inline implicit def embedInt: EN[Int]                                   = null
+    @inline implicit def embedChar: EN[Char]                                 = null
+    @inline implicit def embedShort: EN[Short]                               = null
+    @inline implicit def embedByte: EN[Byte]                                 = null
+    @inline implicit def embedLong: EN[Long]                                 = null
+    @inline implicit def embedFloat: EN[Float]                               = null
+    @inline implicit def embedDouble: EN[Double]                             = null
+    @inline implicit def embedString: EN[String]                             = null
+    @inline implicit def embedHtmlNode[A <: HtmlNode]: EN[A]                 = null
+    @inline implicit def embedRx[C[x] <: Rx[x], A: EN]: EN[C[A]]             = null
+    @inline implicit def embedRxOption[C[x] <: RxOption[x], A: EN]: EN[C[A]] = null
+    @inline implicit def embedSeq[C[x] <: Iterable[x], A: EN]: EN[C[A]]      = null
+    @inline implicit def embedOption[C[x] <: Option[x], A: EN]: EN[C[A]]     = null
+  }
+
+  /**
+    * Holder for embedding various types as tag contents
+    *
+    * @param v
+    */
+  case class Embedded(v: Any) extends RxElement with LogSupport {
+    override def render: RxElement = {
+      warn(s"render is called for ${v}")
+      ???
+    }
+  }
+
+  implicit def embedAsNode[A: EmbeddableNode](v: A): RxElement = Embedded(v)
+}

--- a/airframe-rx-html/src/main/scala/wvlet/airframe/rx/html/SvgTags.scala
+++ b/airframe-rx-html/src/main/scala/wvlet/airframe/rx/html/SvgTags.scala
@@ -18,7 +18,7 @@ package wvlet.airframe.rx.html
   */
 trait SvgTags {
 
-  private def tag(name: String) = tagOf(name, namespace = Namespace.svg)
+  private def tag(name: String) = svgTag(name)
 
   /**
     * The altGlyph element allows sophisticated selection of the glyphs used to render its child character data.
@@ -579,6 +579,13 @@ trait SvgTags {
     * MDN
     */
   lazy val tref = tag("tref")
+
+  /**
+    * The title element provides an accessible, short-text description of any SVG container element or graphics element.
+    *
+    * MDN
+    */
+  lazy val title = tag("title")
 
   /**
     * Within a text element, text and font properties and the current text position can be adjusted with absolute or

--- a/airframe-rx-html/src/main/scala/wvlet/airframe/rx/html/package.scala
+++ b/airframe-rx-html/src/main/scala/wvlet/airframe/rx/html/package.scala
@@ -12,21 +12,16 @@
  * limitations under the License.
  */
 package wvlet.airframe.rx
-import wvlet.log.LogSupport
-
-import scala.annotation.implicitNotFound
-import scala.language.higherKinds
-import scala.language.implicitConversions
 
 /**
   */
-package object html extends HtmlCompat {
+package object html extends HtmlCompat with RxEmbeddingSupport {
 
   object tags       extends Tags
   object tags_extra extends TagsExtra
   object attrs      extends Attrs
 
-  object all extends Tags with Attrs
+  object all extends Tags with Attrs with RxEmbeddingSupport
 
   object svgTags  extends SvgTags
   object svgAttrs extends SvgAttrs
@@ -77,67 +72,17 @@ package object html extends HtmlCompat {
     val svgXLink         = Namespace("http://www.w3.org/1999/xlink")
   }
 
-  def tag(name: String): HtmlElement                                        = new HtmlElement(name)
-  def tagOf(name: String, namespace: Namespace)                             = new HtmlElement(name, namespace)
-  def attr(name: String): HtmlAttributeOf                                   = new HtmlAttributeOf(name)
-  def attr(name: String, namespace: Namespace): HtmlAttributeOf             = new HtmlAttributeOf(name, namespace)
-  def attributeOf(name: String): HtmlAttributeOf                            = attr(name)
+  def tag(name: String): HtmlElement            = new HtmlElement(name)
+  def tagOf(name: String, namespace: Namespace) = new HtmlElement(name, namespace)
+
+  def attr(name: String): HtmlAttributeOf                       = new HtmlAttributeOf(name)
+  def attr(name: String, namespace: Namespace): HtmlAttributeOf = new HtmlAttributeOf(name, namespace)
+  def attributeOf(name: String): HtmlAttributeOf                = attr(name)
+
+  def svgTag(name: String) = new HtmlElement(name, Namespace.svg)
+
   def handler[T](name: String): HtmlEventHandlerOf[T]                       = new HtmlEventHandlerOf[T](name)
   def handler[T](name: String, namespace: Namespace): HtmlEventHandlerOf[T] = new HtmlEventHandlerOf[T](name, namespace)
-
-  @implicitNotFound(msg = "Unsupported type as an attribute value")
-  trait EmbeddableAttribute[X]
-  object EmbeddableAttribute {
-    type EA[A] = EmbeddableAttribute[A]
-    @inline implicit def embedNone: EA[None.type]                            = null
-    @inline implicit def embedBoolean: EA[Boolean]                           = null
-    @inline implicit def embedInt: EA[Int]                                   = null
-    @inline implicit def embedLong: EA[Long]                                 = null
-    @inline implicit def embedString: EA[String]                             = null
-    @inline implicit def embedFloat: EA[Float]                               = null
-    @inline implicit def embedDouble: EA[Double]                             = null
-    @inline implicit def embedF0[U]: EA[() => U]                             = null
-    @inline implicit def embedF1[I, U]: EA[I => U]                           = null
-    @inline implicit def embedOption[C[x] <: Option[x], A: EA]: EA[C[A]]     = null
-    @inline implicit def embedRx[C[x] <: Rx[x], A: EA]: EA[C[A]]             = null
-    @inline implicit def embedRxOption[C[x] <: RxOption[x], A: EA]: EA[C[A]] = null
-    @inline implicit def embedSeq[C[x] <: Iterable[x], A: EA]: EA[C[A]]      = null
-  }
-
-  @implicitNotFound(msg = "Unsupported type as an HtmlNode")
-  trait EmbeddableNode[A]
-  object EmbeddableNode extends compat.PlatformEmbeddableNode {
-    type EN[A] = EmbeddableNode[A]
-    @inline implicit def embedNil: EN[Nil.type]                              = null
-    @inline implicit def embedNone: EN[None.type]                            = null
-    @inline implicit def embedBoolean: EN[Boolean]                           = null
-    @inline implicit def embedInt: EN[Int]                                   = null
-    @inline implicit def embedChar: EN[Char]                                 = null
-    @inline implicit def embedShort: EN[Short]                               = null
-    @inline implicit def embedByte: EN[Byte]                                 = null
-    @inline implicit def embedLong: EN[Long]                                 = null
-    @inline implicit def embedFloat: EN[Float]                               = null
-    @inline implicit def embedDouble: EN[Double]                             = null
-    @inline implicit def embedString: EN[String]                             = null
-    @inline implicit def embedHtmlNode[A <: HtmlNode]: EN[A]                 = null
-    @inline implicit def embedRx[C[x] <: Rx[x], A: EN]: EN[C[A]]             = null
-    @inline implicit def embedRxOption[C[x] <: RxOption[x], A: EN]: EN[C[A]] = null
-    @inline implicit def embedSeq[C[x] <: Iterable[x], A: EN]: EN[C[A]]      = null
-    @inline implicit def embedOption[C[x] <: Option[x], A: EN]: EN[C[A]]     = null
-  }
-
-  /**
-    * Holder for embedding various types as tag contents
-    * @param v
-    */
-  case class Embedded(v: Any) extends RxElement with LogSupport {
-    override def render: RxElement = {
-      warn(s"render is called for ${v}")
-      ???
-    }
-  }
-
-  implicit def embedAsNode[A: EmbeddableNode](v: A): RxElement = Embedded(v)
 
   private[rx] case class RxCode(rxElements: Seq[RxElement], sourceCode: String)
 

--- a/airframe-rx-html/src/main/scala/wvlet/airframe/rx/html/package.scala
+++ b/airframe-rx-html/src/main/scala/wvlet/airframe/rx/html/package.scala
@@ -13,64 +13,21 @@
  */
 package wvlet.airframe.rx
 
+import wvlet.airframe.rx.html.{HtmlAttributeOf, HtmlElement, HtmlEventHandlerOf, Namespace}
+import wvlet.log.LogSupport
+
 /**
   */
-package object html extends HtmlCompat with RxEmbeddingSupport {
+package object html extends HtmlCompat with RxEmbedding {
 
   object tags       extends Tags
   object tags_extra extends TagsExtra
   object attrs      extends Attrs
 
-  object all extends Tags with Attrs with RxEmbeddingSupport
+  object all extends Tags with Attrs with RxEmbedding
 
   object svgTags  extends SvgTags
   object svgAttrs extends SvgAttrs
-
-  trait HtmlNode {
-    def when(cond: => Boolean): HtmlNode = {
-      if (cond) this else HtmlNode.empty
-    }
-    def unless(cond: => Boolean): HtmlNode = {
-      if (cond) HtmlNode.empty else this
-    }
-  }
-
-  // HtmlNode -> Element -> HtmlElement
-  //          -> HtmlAttribute
-
-  object HtmlNode {
-    object empty extends HtmlNode
-  }
-
-  case class HtmlAttribute(name: String, v: Any, ns: Namespace = Namespace.xhtml, append: Boolean = false)
-      extends HtmlNode
-
-  class HtmlAttributeOf(name: String, namespace: Namespace = Namespace.xhtml) {
-    def apply[V: EmbeddableAttribute](v: V): HtmlNode = HtmlAttribute(name, v, namespace)
-    def ->[V: EmbeddableAttribute](v: V): HtmlNode    = apply(v)
-    def add[V: EmbeddableAttribute](v: V): HtmlNode   = HtmlAttribute(name, v, namespace, append = true)
-    def +=[V: EmbeddableAttribute](v: V): HtmlNode    = add(v)
-    def noValue: HtmlNode                             = HtmlAttribute(name, true, namespace)
-  }
-
-  class HtmlEventHandlerOf[E](name: String, namespace: Namespace = Namespace.xhtml) {
-    def apply[U](v: E => U): HtmlNode  = HtmlAttribute(name, v, namespace)
-    def ->[U](v: E => U): HtmlNode     = apply(v)
-    def apply[U](v: () => U): HtmlNode = HtmlAttribute(name, v, namespace)
-    def ->[U](v: () => U): HtmlNode    = apply(v)
-    def noValue: HtmlNode              = HtmlAttribute(name, false, namespace)
-  }
-
-  case class EntityRef(ref: String) extends HtmlNode
-
-  // TODO embed namespace properly to DOM
-  case class Namespace(uri: String)
-
-  object Namespace {
-    val xhtml: Namespace = Namespace("http://www.w3.org/1999/xhtml")
-    val svg: Namespace   = Namespace("http://www.w3.org/2000/svg")
-    val svgXLink         = Namespace("http://www.w3.org/1999/xlink")
-  }
 
   def tag(name: String): HtmlElement            = new HtmlElement(name)
   def tagOf(name: String, namespace: Namespace) = new HtmlElement(name, namespace)
@@ -86,4 +43,15 @@ package object html extends HtmlCompat with RxEmbeddingSupport {
 
   private[rx] case class RxCode(rxElements: Seq[RxElement], sourceCode: String)
 
+  /**
+    * Holder for embedding various types as tag contents
+    *
+    * @param v
+    */
+  private[html] case class Embedded(v: Any) extends RxElement with LogSupport {
+    override def render: RxElement = {
+      warn(s"render is called for ${v}")
+      ???
+    }
+  }
 }

--- a/airframe-rx-html/src/test/scala/wvlet/airframe/rx/html/HtmlTest.scala
+++ b/airframe-rx-html/src/test/scala/wvlet/airframe/rx/html/HtmlTest.scala
@@ -195,7 +195,8 @@ class HtmlTest extends AirSpec {
     import svgAttrs._
     svg(
       circle(
-        color -> ""
+        color -> "",
+        svgTags.title("circle description")
       )
     )
   }


### PR DESCRIPTION
And also closes #2994: Adding svg.title tag