### PR TITLE
control (internal): Use Jittering by default in Retry

### DIFF
--- a/airframe-control/src/main/scala/wvlet/airframe/control/Retry.scala
+++ b/airframe-control/src/main/scala/wvlet/airframe/control/Retry.scala
@@ -81,7 +81,7 @@ object Retry extends LogSupport {
       lastError = NOT_STARTED,
       retryCount = 0,
       maxRetry = 3,
-      retryWaitStrategy = new ExponentialBackOff(retryConfig),
+      retryWaitStrategy = new Jitter(retryConfig),
       nextWaitMillis = retryConfig.initialIntervalMillis,
       baseWaitMillis = retryConfig.initialIntervalMillis,
       extraWaitMillis = 0


### PR DESCRIPTION
Adding randomness to the retry wait interval, called Jittering, is a better behavior in distributed systems so as not to create synthetic retry patterns between multiple programs accessing the same API. 

