### PR TITLE
airframe-sql: Support cascaded set operations

### DIFF
--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
@@ -778,7 +778,15 @@ object LogicalPlan {
       def collectInputAttributes(rels: Seq[Relation], result: Seq[Seq[Attribute]] = Nil): Seq[Seq[Attribute]] = {
         rels.flatMap {
           case s: SetOperation => collectInputAttributes(s.children, result)
-          case x               => result :+ x.outputAttributes.flatMap(_.inputColumns)
+          case other =>
+            result :+ other.outputAttributes.flatMap {
+              case a: AllColumns => a.inputColumns
+              case other =>
+                other.inputColumns match {
+                  case Seq(i) => Seq(i)
+                  case inputs => Seq(MultiSourceColumn(inputs, None, None, None))
+                }
+            }
         }
       }
 

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
@@ -13,6 +13,7 @@
  */
 package wvlet.airframe.sql.model
 import wvlet.airframe.sql.analyzer.{QuerySignatureConfig}
+import wvlet.airframe.sql.Assertion._
 import wvlet.log.LogSupport
 
 import java.util.UUID
@@ -774,7 +775,21 @@ object LogicalPlan {
     override def outputAttributes: Seq[Attribute] = mergeOutputAttributes
     protected def mergeOutputAttributes: Seq[Attribute] = {
       // Collect all input attributes
-      val outputAttributes: Seq[Seq[Attribute]] = children.map(_.outputAttributes.flatMap(_.inputColumns))
+      def collectInputAttributes(rels: Seq[Relation], result: Seq[Seq[Attribute]] = Nil): Seq[Seq[Attribute]] = {
+        rels.flatMap {
+          case s: SetOperation => collectInputAttributes(s.children, result)
+          case x               => result :+ x.outputAttributes.flatMap(_.inputColumns)
+        }
+      }
+
+      val outputAttributes: Seq[Seq[Attribute]] = collectInputAttributes(children)
+
+      // Verify all relations have the same number of columns
+      require(
+        outputAttributes.map(_.size).distinct.size == 1,
+        "All relations in set operation must have the same number of columns",
+        nodeLocation
+      )
 
       // Transpose a set of relation columns into a list of same columns
       // relations: (Ra(a1, a2, ...), Rb(b1, b2, ...))

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
@@ -775,18 +775,18 @@ object LogicalPlan {
     override def outputAttributes: Seq[Attribute] = mergeOutputAttributes
     protected def mergeOutputAttributes: Seq[Attribute] = {
       // Collect all input attributes
-      def collectInputAttributes(rels: Seq[Relation], result: Seq[Seq[Attribute]] = Nil): Seq[Seq[Attribute]] = {
+      def collectInputAttributes(rels: Seq[Relation]): Seq[Seq[Attribute]] = {
         rels.flatMap {
-          case s: SetOperation => collectInputAttributes(s.children, result)
+          case s: SetOperation => collectInputAttributes(s.children)
           case other =>
-            result :+ other.outputAttributes.flatMap {
+            Seq(other.outputAttributes.flatMap {
               case a: AllColumns => a.inputColumns
               case other =>
                 other.inputColumns match {
-                  case Seq(i) => Seq(i)
-                  case inputs => Seq(MultiSourceColumn(inputs, None, None, None))
+                  case x if x.length <= 1 => x
+                  case inputs             => Seq(MultiSourceColumn(inputs, None, None, None))
                 }
-            }
+            })
         }
       }
 

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
@@ -305,6 +305,25 @@ class TypeResolverTest extends AirSpec with ResolverTestHelper {
       p2.outputAttributes shouldBe List(
         MultiSourceColumn(List(ra1, rb1, rc1, ra1), None, None, None)
       )
+
+      val p3 =
+        analyze(
+          "select id from (select id from (select id, name from A) union all select id from B) union all select id from C"
+        )
+      p3.inputAttributes shouldBe List(MultiSourceColumn(List(ra1, rb1), None, None, None), rc1, rc2)
+      p3.outputAttributes shouldBe List(
+        MultiSourceColumn(List(MultiSourceColumn(List(ra1, rb1), None, None, None), rc1), None, None, None)
+      )
+    }
+
+    test("resolve union with literal value") {
+      val p = analyze("select 1 union all select id from A")
+      p.inputAttributes shouldBe List(ra1, ra2)
+      p.outputAttributes shouldMatch {
+        case List(
+              MultiSourceColumn(List(SingleColumn(LongLiteral(1, _), None, None, _), `ra1`), None, None, None)
+            ) =>
+      }
     }
 
     test("fail to resolve union if columns are inconsistent") {

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
@@ -292,6 +292,35 @@ class TypeResolverTest extends AirSpec with ResolverTestHelper {
       }
     }
 
+    test("resolve cascaded unions") {
+      val p1 = analyze("select id from A union all select id from B union all select id from C")
+      p1.inputAttributes shouldBe List(ra1, ra2, rb1, rb2, rc1, rc2)
+      p1.outputAttributes shouldBe List(
+        MultiSourceColumn(List(ra1, rb1, rc1), None, None, None)
+      )
+
+      val p2 =
+        analyze("select id from A union all select id from B union all select id from C union all select id from A")
+      p2.inputAttributes shouldBe List(ra1, ra2, rb1, rb2, rc1, rc2, ra1, ra2)
+      p2.outputAttributes shouldBe List(
+        MultiSourceColumn(List(ra1, rb1, rc1, ra1), None, None, None)
+      )
+    }
+
+    test("fail to resolve union if columns are inconsistent") {
+      val e1 = intercept[SQLError] {
+        analyze("select id, name from A union all select id from B")
+      }
+      e1.errorCode shouldBe SQLErrorCode.RequirementFailed
+      e1.getMessage shouldContain "All relations in set operation must have the same number of columns"
+
+      val e2 = intercept[SQLError] {
+        analyze("select id, name from A union all select id, name from B union all select id from C")
+      }
+      e2.errorCode shouldBe SQLErrorCode.RequirementFailed
+      e2.getMessage shouldContain "All relations in set operation must have the same number of columns"
+    }
+
     test("resolve intersect") {
       val p = analyze("select id from A intersect select id from B") // => Distinct(Intersect(...))
       p shouldMatch { case Distinct(i @ Intersect(_, _), _) =>


### PR DESCRIPTION
Currently, `TypeResolver` fails to resolve cascaded set operations like:
```sql
select id from A union all select id from B union all select id from C
```
due to the following error:
> java.lang.IllegalArgumentException: transpose requires all collections have the same size