### PR TITLE
sbt-airframe (fix): Remove unused import Future from generated RPC clients

### DIFF
--- a/airframe-http-codegen/src/main/scala/wvlet/airframe/http/codegen/client/RPCClientGenerator.scala
+++ b/airframe-http-codegen/src/main/scala/wvlet/airframe/http/codegen/client/RPCClientGenerator.scala
@@ -31,7 +31,6 @@ object RPCClientGenerator extends HttpClientGenerator {
     def code: String =
       s"""${header(src.destPackageName)}
          |
-         |import scala.concurrent.Future
          |import wvlet.airframe.http._
          |import wvlet.airframe.http.client.{HttpClientConfig, SyncClient, AsyncClient}
          |import wvlet.airframe.surface.Surface


### PR DESCRIPTION
Closes #3099
