### PR TITLE
rx-html (fix): Properly call onMount hook when internal Rx is updated

### DIFF
--- a/airframe-rx-html/.js/src/main/scala/wvlet/airframe/rx/html/DOMRenderer.scala
+++ b/airframe-rx-html/.js/src/main/scala/wvlet/airframe/rx/html/DOMRenderer.scala
@@ -171,7 +171,6 @@ object DOMRenderer extends LogSupport {
           val elem = node.lastChild
           val c2   = rx.traverseModifiers(m => renderToInternal(localContext, elem, m))
           node.mountHere(elem, anchor)
-          trace(s"add onRenderHook for ${rx}")
           localContext.addOnRenderHook(() => rx.onMount)
           Cancelable.merge(Cancelable(() => rx.beforeUnmount), Cancelable.merge(c1, c2))
         case s: String =>

--- a/airframe-rx-html/.js/src/test/scala/wvlet/airframe/http/rx/html/RxRenderingTest.scala
+++ b/airframe-rx-html/.js/src/test/scala/wvlet/airframe/http/rx/html/RxRenderingTest.scala
@@ -314,7 +314,7 @@ object RxRenderingTest extends AirSpec {
     var foundElement             = false
 
     object infoPage extends RxElement {
-      override def onMount {
+      override def onMount: Unit = {
         nestedOnMountCallCount += 1
         Option(org.scalajs.dom.document.getElementById("id001")).collect { case e: HTMLElement =>
           foundElement = true

--- a/airframe-rx-html/.js/src/test/scala/wvlet/airframe/http/rx/html/RxRenderingTest.scala
+++ b/airframe-rx-html/.js/src/test/scala/wvlet/airframe/http/rx/html/RxRenderingTest.scala
@@ -313,7 +313,7 @@ object RxRenderingTest extends AirSpec {
     var nestedOnMountCallCount   = 0
     var foundElement             = false
 
-    val infoPage = new RxElement() {
+    object infoPage extends RxElement {
       override def onMount {
         nestedOnMountCallCount += 1
         Option(org.scalajs.dom.document.getElementById("id001")).collect { case e: HTMLElement =>
@@ -323,7 +323,7 @@ object RxRenderingTest extends AirSpec {
       override def render: RxElement = div(id -> "id001", "render: info")
     }
 
-    val nested = new RxElement() {
+    object nestedPage extends RxElement() {
       override def onMount: Unit = {
         topLevelOnMountCallCount += 1
       }
@@ -336,7 +336,7 @@ object RxRenderingTest extends AirSpec {
       }
     }
 
-    val c = nested.renderTo("main")
+    val c = nestedPage.renderTo("main")
     page := "info"
     org.scalajs.dom.document.getElementById("id001") shouldMatch { case e: HTMLElement =>
       e.innerHTML shouldContain "render: info"

--- a/airframe-rx-html/src/main/scala/wvlet/airframe/rx/html/RxElement.scala
+++ b/airframe-rx-html/src/main/scala/wvlet/airframe/rx/html/RxElement.scala
@@ -47,6 +47,9 @@ abstract class RxElement(val modifiers: List[Seq[HtmlNode]] = List.empty) extend
     */
   def beforeUnmount: Unit = {}
 
+  /**
+    * Add child elements or attributes to this element and return this element
+    */
   def apply(xs: HtmlNode*): RxElement = {
     if (xs.isEmpty) {
       this
@@ -55,13 +58,13 @@ abstract class RxElement(val modifiers: List[Seq[HtmlNode]] = List.empty) extend
     }
   }
 
+  def addModifier(xs: HtmlNode*): RxElement = add(xs: _*)
+
   def add(xs: HtmlNode*): RxElement = {
     new RxElement(xs :: modifiers) {
       override def render = self.render
     }
   }
-
-  def addModifier(xs: HtmlNode*): RxElement = add(xs: _*)
 
   private[html] def traverseModifiers(f: HtmlNode => Cancelable): Cancelable = {
     val cancelables = for (g <- modifiers.reverse; m <- g) yield {


### PR DESCRIPTION
- Reproduce and fixes #3118
- rx-html: Call onMount when Rx is updated
