### PR TITLE
internal: Use Scala 3 by default for sbt and IntelliJ

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -31,7 +31,7 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: Scala 2.13 test with coverage report
-        run: ./sbt "; coverage; projectJVM/test; projectJVM/coverageReport; projectJVM/coverageAggregate"
+        run: ./sbt "++ 2.13; coverage; projectJVM/test; projectJVM/coverageReport; projectJVM/coverageAggregate"
       - uses: codecov/codecov-action@v3
         with:
           name: airframe-coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,10 +28,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: scalafmt
-        run: ./sbt scalafmtCheckAll
+      - name: scalafmt in Scala 2.x
+        run: ./sbt "++ 2.13; scalafmtCheckAll"
       - name: scalafmt in Scala 3
-        run: DOTTY=true ./sbt scalafmtCheckAll
+        run: ./sbt scalafmtCheckAll
       - name: scalafmt airspec
         run: ../sbt scalafmtCheckAll
         working-directory: ./airspec

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 <p><img src="https://github.com/wvlet/airframe/raw/main/logos/airframe-badge-light.png" alt="logo" width="300px"></p>
 
-Airframe https://wvlet.org/airframe is a collection of [lightweight building blocks](https://wvlet.org/airframe/docs/) for Scala.
+Airframe https://wvlet.org/airframe is essential building blocks for developing applications in Scala, including logging, object serialization using JSON or MessagePack, dependency injection, http server/client with RPC support, functional testing with AirSpec, etc. 
 
 ## Resources
 
@@ -38,24 +38,7 @@ Airframe https://wvlet.org/airframe is a collection of [lightweight building blo
 
 ## For Developers
 
-### Dotty (Scala 3)
-
-For developing with Dotty (Scala 3), use DOTTY=true environment variable:
-```
-$ DOTTY=true ./sbt
-> logJVM/test
-```
-
-Or use `++ 3` in the sbt console:
-```
-# Switch to Scala 3
-> ++ 3
-```
-
-For starting a migration of some project to Scala 3, create a PR that removes `.settings(scala2Only)` from build.sbt to use Scala 3 in the project, and add the project to `projectDotty`. After all tests pass, the PR can be merged.
-
-
-Here is the list of milestones for Dotty support: [#1077](https://github.com/wvlet/airframe/issues/1077)
+Airframe uses Scala 3 as the default Scala version. To use Scala 2.x versions, run `++ 2.12` or `++ 2.13` in the sbt console.
 
 ### Releasing
 
@@ -74,7 +57,7 @@ After that, the artifacts will be published to Sonatype (a.k.a. Maven Central). 
 
 Note: Do not create a new tag from GitHub release pages, because it will not trigger the GitHub Actions for the release.
 
-### Binary Compabibility
+### Binary Compatibility
 
 When changing some interfaces, binary compatibility should be checked so as not to break applications using older versions of Airframe. In build.sbt, set AIRFRAME_BINARY_COMPAT_VERSION to the previous version of Airframe as a comparison target. Then run `sbt mimaReportBinaryIssues` to check the binary compatibility.
 

--- a/build.sbt
+++ b/build.sbt
@@ -66,16 +66,8 @@ Global / onChangedBuildSource := ReloadOnSourceChanges
 // Disable the pipelining available since sbt-1.4.0. It caused compilation failure
 ThisBuild / usePipelining := false
 
-// A build configuration switch for working on Dotty migration. This needs to be removed eventually
-val DOTTY = sys.env.isDefinedAt("DOTTY")
-
-// If DOTTY is set, use Scala 3 by default. This is for the convenience of working on Scala 3 projects
-ThisBuild / scalaVersion := {
-  if (DOTTY)
-    SCALA_3
-  else
-    SCALA_2_13
-}
+// Use Scala 3 by default as scala-2 specific source code is relatively small now
+ThisBuild / scalaVersion := SCALA_3
 
 ThisBuild / organization := "org.wvlet.airframe"
 
@@ -253,17 +245,29 @@ lazy val jsProjects: Seq[ProjectReference] = Seq(
 lazy val communityBuild =
   project
     .settings(noPublish)
+    .settings(
+      // Skip importing aggregated projects in IntelliJ IDEA
+      ideSkipProject := true
+    )
     .aggregate(communityBuildProjects: _*)
 
 // For Scala 2.12
 lazy val projectJVM =
   project
     .settings(noPublish)
+    .settings(
+      // Skip importing aggregated projects in IntelliJ IDEA
+      ideSkipProject := true
+    )
     .aggregate(jvmProjects: _*)
 
 lazy val projectJS =
   project
     .settings(noPublish)
+    .settings(
+      // Skip importing aggregated projects in IntelliJ IDEA
+      ideSkipProject := true
+    )
     .aggregate(jsProjects: _*)
 
 // A scoped project only for Dotty (Scala 3).
@@ -271,6 +275,10 @@ lazy val projectJS =
 lazy val projectDotty =
   project
     .settings(noPublish)
+    .settings(
+      // Skip importing aggregated projects in IntelliJ IDEA
+      ideSkipProject := true
+    )
     .aggregate(
       diMacros.jvm,
       di.jvm,

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -2,12 +2,13 @@
 // sbt-scoverage upgraded to scala-xml 2.1.0, but other sbt-plugins and Scala compilier 2.12 uses scala-xml 1.x.x
 ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % "always"
 
-addSbtPlugin("org.xerial.sbt"     % "sbt-sonatype"             % "3.9.21")
-addSbtPlugin("com.github.sbt"     % "sbt-pgp"                  % "2.2.1")
-addSbtPlugin("org.scoverage"      % "sbt-scoverage"            % "2.0.8")
-addSbtPlugin("org.scalameta"      % "sbt-scalafmt"             % "2.5.0")
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")
-addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"            % "0.11.0")
+addSbtPlugin("org.xerial.sbt"      % "sbt-sonatype"             % "3.9.21")
+addSbtPlugin("com.github.sbt"      % "sbt-pgp"                  % "2.2.1")
+addSbtPlugin("org.scoverage"       % "sbt-scoverage"            % "2.0.8")
+addSbtPlugin("org.scalameta"       % "sbt-scalafmt"             % "2.5.0")
+addSbtPlugin("org.portable-scala"  % "sbt-scalajs-crossproject" % "1.3.2")
+addSbtPlugin("com.eed3si9n"        % "sbt-buildinfo"            % "0.11.0")
+addSbtPlugin("org.jetbrains.scala" % "sbt-ide-settings"         % "1.1.1")
 
 // For integration testing
 val SBT_AIRFRAME_VERSION = sys.env.getOrElse("SBT_AIRFRAME_VERSION", "23.6.2")


### PR DESCRIPTION
As the primary development has moved to Scala 3, adding Scala 3 source code (scala-3) to the IntelliJ project is better for daily development. We still need to support Scala 2 for a while, but we don't have so many Scala 2 specific source code (scala-2 folder). This change is to let IntelliJ recognize scala-3 source code folder to enable syntax highlight, etc. 

