### PR TITLE
internal (fix): Collect coverage report xml files properly

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -35,9 +35,9 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           name: airframe-coverage
-          file: ./projectJVM/target/scala-2.13/scoverage-report/scoverage.xml
+          file: ./projectJVM/target/scoverage-report/scoverage.xml
       - name: Archive code coverage results
         uses: actions/upload-artifact@v3
         with:
           name: code-coverage-report
-          path: ./projectJVM/target/scala-2.13/scoverage-report
+          path: ./projectJVM/target/scoverage-report

--- a/build.sbt
+++ b/build.sbt
@@ -257,7 +257,9 @@ lazy val projectJVM =
     .settings(noPublish)
     .settings(
       // Skip importing aggregated projects in IntelliJ IDEA
-      ideSkipProject := true
+      ideSkipProject := true,
+      // Use a stable coverage directory name without containing scala version
+      coverageDataDir := target.value
     )
     .aggregate(jvmProjects: _*)
 


### PR DESCRIPTION
Due to the change in #3137, coverageAggregate now runs on Scala 3 and chooses a different test report folder. This PR removes scala-2.xx or scala-3 version name from the test report path. 