### PR TITLE
surface (fix): Reduce bytecode size for Scala 3

### DIFF
--- a/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
+++ b/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
@@ -803,9 +803,8 @@ private[surface] class CompileTimeSurfaceFactory[Q <: Quotes](using quotes: Q) {
 
   private def clsCast(term: Term, t: TypeRepr): Term = {
     if(clsOfToVar.contains(t)) {
-      // TODO Use Class.cast
+      // __cl0.cast(term)
       Select.unique(Ref(clsOfToVar(t)), "cast").appliedToArgs(List(term))
-      //Select.unique(term, "asInstanceOf").appliedToType(t)
     }
     else {
       Select.unique(term, "asInstanceOf").appliedToType(t)

--- a/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
+++ b/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
@@ -723,7 +723,7 @@ private[surface] class CompileTimeSurfaceFactory[Q <: Quotes](using quotes: Q) {
       methodsOfInternal(t).asTerm
     ).asExprOf[Seq[MethodSurface]]
 
-    //println(s"===  methodOf: ${t.typeSymbol.fullName} => \n${expr.show}")
+    println(s"===  methodOf: ${t.typeSymbol.fullName} => \n${expr.show}")
     expr
   }
 

--- a/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
+++ b/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
@@ -691,7 +691,10 @@ private[surface] class CompileTimeSurfaceFactory[Q <: Quotes](using quotes: Q) {
 
     var count = 0
     // Bind the observed surfaces to local variables __s0, __s1, ...
-    seen.foreach { s =>
+    seen
+      // Skip primitive types
+      .filterNot(primitiveTypeFactory.isDefinedAt)
+      .foreach { s =>
       // Update the cache so that the next call of surfaceOf method will use the local varaible reference
       surfaceToVar += s -> Symbol.newVal(
         Symbol.spliceOwner,
@@ -720,7 +723,7 @@ private[surface] class CompileTimeSurfaceFactory[Q <: Quotes](using quotes: Q) {
       methodsOfInternal(t).asTerm
     ).asExprOf[Seq[MethodSurface]]
 
-    // println(s"===  methodOf: ${t.typeSymbol.fullName} => \n${expr.show}")
+    //println(s"===  methodOf: ${t.typeSymbol.fullName} => \n${expr.show}")
     expr
   }
 


### PR DESCRIPTION
- surface (fix): Reduce methodOf code size for PrimitiveSurface
- debug
- Extract method ref
- Extract classOf expr
- Apply class cast
- Use class.cast
