### PR TITLE
rpc (fix): Use lazy val for generated RPCMethod to avoid xxxInternals$.<clinit> is too large error

### DIFF
--- a/airframe-http-codegen/src/main/scala/wvlet/airframe/http/codegen/client/RPCClientGenerator.scala
+++ b/airframe-http-codegen/src/main/scala/wvlet/airframe/http/codegen/client/RPCClientGenerator.scala
@@ -70,7 +70,7 @@ object RPCClientGenerator extends HttpClientGenerator {
     def rpcMethodDefs(svc: ClientServiceDef): String = {
       svc.methods
         .map { m =>
-          s"""val __m_${m.name} = RPCMethod("${m.path}", "${svc.interfaceName}", "${m.name}", Surface.of[${m.requestModelClassType}], Surface.of[${m.returnType.fullTypeName}])"""
+          s"""lazy val __m_${m.name} = RPCMethod("${m.path}", "${svc.interfaceName}", "${m.name}", Surface.of[${m.requestModelClassType}], Surface.of[${m.returnType.fullTypeName}])"""
         }.mkString("\n")
     }
 


### PR DESCRIPTION
This error happened in Scala 3 when compiling a RPC client for a large API 