### PR TITLE
breaking: Drop JDK8 Support and build for JDK11 or later

### DIFF
--- a/airspec/build.sbt
+++ b/airspec/build.sbt
@@ -71,7 +71,7 @@ val buildSettings = Seq[Setting[_]](
   crossScalaVersions := targetScalaVersions,
   crossPaths         := true,
   publishMavenStyle  := true,
-  javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
+  javacOptions ++= Seq("-source", "11", "-target", "11"),
   scalacOptions ++= Seq(
     "-feature",
     "-deprecation"

--- a/build.sbt
+++ b/build.sbt
@@ -105,7 +105,7 @@ val buildSettings = Seq[Setting[_]](
       ProblemFilters.exclude[MissingClassProblem]("wvlet.airframe.http.internal.*")
     )
   },
-  javacOptions ++= Seq("-source", "8", "-target", "8"),
+  javacOptions ++= Seq("-source", "11", "-target", "11"),
   scalacOptions ++= Seq(
     "-feature",
     "-deprecation"

--- a/sbt-airframe/build.sbt
+++ b/sbt-airframe/build.sbt
@@ -29,7 +29,7 @@ val buildSettings = Seq[Setting[_]](
   crossPaths          := true,
   publishMavenStyle   := true,
   publishTo           := sonatypePublishToBundle.value,
-  javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
+  javacOptions ++= Seq("-source", "11", "-target", "11"),
   scalacOptions ++= Seq(
     "-feature",
     "-deprecation"


### PR DESCRIPTION
I am not sure how long we need to support JDK8 as all known blockers have been resolved #3191, but at the same time, no urgent need exists to drop jdk8 support for a while. We can wait for merging this fix during 2023. 