### PR TITLE
internal: Use Scala 3's new wildcard import `*` syntax 

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,6 +1,6 @@
 version = 3.7.14
 project.layout = StandardConvention
-runner.dialect = scala213source3
+runner.dialect = scala3
 maxColumn = 120
 style = defaultWithAlign
 optIn.breaksInsideChains = true
@@ -17,3 +17,9 @@ runner.dialectOverride.allowPostfixStarVarargSplices = false
 runner.dialectOverride.allowSignificantIndentation = false
 // Disable rewrite Type wildcard [_] -> [?]
 runner.dialectOverride.allowQuestionMarkAsTypeWildcard = false
+
+fileOverride {
+  "glob:**/scala-2/**" {
+    runner.dialect = scala213source3
+  }
+}

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -5,3 +5,15 @@ maxColumn = 120
 style = defaultWithAlign
 optIn.breaksInsideChains = true
 docstrings.blankFirstLine = yes
+
+rewrite.scala3.convertToNewSyntax = true
+// Rewrite import _ to *
+runner.dialectOverride.allowStarWildcardImport = true
+// Disable rewrite import => to 'as'
+runner.dialectOverride.allowAsForImportRename = false
+// Disable vararg rewrite to *
+runner.dialectOverride.allowPostfixStarVarargSplices = false
+// Disable rewrite to if ... then, for ... do
+runner.dialectOverride.allowSignificantIndentation = false
+// Disable rewrite Type wildcard [_] -> [?]
+runner.dialectOverride.allowQuestionMarkAsTypeWildcard = false

--- a/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/grpc_java/GrpcJava.scala
+++ b/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/grpc_java/GrpcJava.scala
@@ -17,7 +17,7 @@ import com.google.common.util.concurrent.{FutureCallback, Futures}
 import io.grpc.ManagedChannelBuilder
 import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder
 import io.grpc.stub.StreamObserver
-import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.annotations.*
 import org.openjdk.jmh.infra.Blackhole
 import wvlet.airframe.benchmark.http.HttpBenchmark.asyncIteration
 import wvlet.airframe.benchmark.http.protojava

--- a/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/http/Greeter.scala
+++ b/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/http/Greeter.scala
@@ -15,7 +15,7 @@ package wvlet.airframe.benchmark.http
 
 import wvlet.airframe.benchmark.http.Greeter.GreeterResponse
 import wvlet.airframe.http.codegen.{HttpClientGeneratorConfig, HttpCodeGenerator}
-import wvlet.airframe.http._
+import wvlet.airframe.http.*
 
 @RPC
 class Greeter {

--- a/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/http/ServiceAsyncClient.scala
+++ b/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/http/ServiceAsyncClient.scala
@@ -15,7 +15,7 @@ package wvlet.airframe.benchmark.http
 
 /**
   */
-import wvlet.airframe.http._
+import wvlet.airframe.http.*
 import wvlet.airframe.http.client.AsyncClient
 import wvlet.airframe.rx.Rx
 import wvlet.airframe.surface.Surface

--- a/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/http/ServiceGrpc.scala
+++ b/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/http/ServiceGrpc.scala
@@ -72,7 +72,7 @@ object ServiceGrpc {
       private val descriptors = new GreeterDescriptors(codecFactory)
 
       import io.grpc.stub.ClientCalls
-      import GreeterModels._
+      import GreeterModels.*
 
       def hello(name: String): String = {
         val __m   = Map("name" -> name)
@@ -112,7 +112,7 @@ object ServiceGrpc {
       private val descriptors = new GreeterDescriptors(codecFactory)
 
       import io.grpc.stub.ClientCalls
-      import GreeterModels._
+      import GreeterModels.*
 
       def hello(name: String, responseObserver: io.grpc.stub.StreamObserver[String]): Unit = {
         val __m   = Map("name" -> name)

--- a/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/http/ServiceSyncClient.scala
+++ b/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/http/ServiceSyncClient.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.benchmark.http
 
-import wvlet.airframe.http._
+import wvlet.airframe.http.*
 import wvlet.airframe.http.client.SyncClient
 
 //class ServiceSyncClient[Req, Resp](private val client: HttpSyncClient[Req, Resp]) extends AutoCloseable {

--- a/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/json/JSONBenchmark.scala
+++ b/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/json/JSONBenchmark.scala
@@ -15,7 +15,7 @@ package wvlet.airframe.benchmark.json
 
 import java.util.concurrent.TimeUnit
 
-import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.annotations.*
 import org.openjdk.jmh.infra.Blackhole
 import wvlet.airframe.json.JSON.{JSONArray, JSONString}
 import wvlet.airframe.json.{JSON, JSONSource, JSONTraverser, JSONVisitor, NullJSONContext}

--- a/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/json_stream/JSONToMsgPackBenchmark.scala
+++ b/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/json_stream/JSONToMsgPackBenchmark.scala
@@ -15,7 +15,7 @@ package wvlet.airframe.benchmark.json_stream
 
 import java.util.concurrent.TimeUnit
 
-import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.annotations.*
 import org.openjdk.jmh.infra.Blackhole
 import wvlet.airframe.benchmark.json.JSONBenchmark
 import wvlet.airframe.codec.JSONValueCodec

--- a/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/msgpack/MsgpackBenchmark.scala
+++ b/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/msgpack/MsgpackBenchmark.scala
@@ -16,7 +16,7 @@ package wvlet.airframe.benchmark.msgpack
 import java.util.concurrent.TimeUnit
 
 import org.msgpack.core.MessageUnpacker
-import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.annotations.*
 import org.openjdk.jmh.infra.Blackhole
 import wvlet.airframe.msgpack.spi.{MessagePack, Packer, Unpacker}
 

--- a/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/netty_simple/NettyHttp.scala
+++ b/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/netty_simple/NettyHttp.scala
@@ -148,7 +148,7 @@ object NettyHttp {
 @OutputTimeUnit(TimeUnit.SECONDS)
 class NettyHttp {
 
-  import NettyHttp._
+  import NettyHttp.*
 
   private val port   = IOUtil.unusedPort
   private val server = new Server(port)

--- a/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/rpc_grpc/AirframeGrpc.scala
+++ b/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/rpc_grpc/AirframeGrpc.scala
@@ -15,7 +15,7 @@ package wvlet.airframe.benchmark.rpc_grpc
 
 import io.grpc.Channel
 import io.grpc.stub.StreamObserver
-import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.annotations.*
 import org.openjdk.jmh.infra.Blackhole
 import wvlet.airframe.Session
 import wvlet.airframe.benchmark.http.HttpBenchmark.asyncIteration

--- a/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/rpc_netty/RPCNetty.scala
+++ b/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/rpc_netty/RPCNetty.scala
@@ -13,12 +13,12 @@
  */
 package wvlet.airframe.benchmark.rpc_netty
 
-import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.annotations.*
 import org.openjdk.jmh.infra.Blackhole
 import wvlet.airframe.Session
 import wvlet.airframe.benchmark.http.HttpBenchmark.asyncIteration
 import wvlet.airframe.benchmark.http.{Greeter, NewServiceAsyncClient, NewServiceSyncClient}
-import wvlet.airframe.http._
+import wvlet.airframe.http.*
 import wvlet.airframe.http.client.{AsyncClient, SyncClient}
 import wvlet.airframe.http.netty.{Netty, NettyServer}
 import wvlet.log.LogSupport

--- a/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/rpc_request/RPCRequestBenchmark.scala
+++ b/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/rpc_request/RPCRequestBenchmark.scala
@@ -13,14 +13,14 @@
  */
 package wvlet.airframe.benchmark.rpc_request
 
-import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.annotations.*
 import org.openjdk.jmh.infra.Blackhole
 import wvlet.airframe.benchmark.http.Greeter
 import wvlet.airframe.benchmark.http.Greeter.GreeterResponse
 import wvlet.airframe.codec.MessageCodec
 import wvlet.airframe.http.client.{HttpChannel, HttpChannelConfig, HttpClients, SyncClientImpl}
 import wvlet.airframe.http.netty.NettyRequestHandler
-import wvlet.airframe.http._
+import wvlet.airframe.http.*
 import wvlet.airframe.rx.Rx
 import wvlet.airframe.surface.Surface
 import wvlet.log.LogSupport

--- a/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/ulid/ULIDBenchmark.scala
+++ b/airframe-benchmark/src/main/scala/wvlet/airframe/benchmark/ulid/ULIDBenchmark.scala
@@ -14,7 +14,7 @@
 package wvlet.airframe.benchmark.ulid
 
 import com.chatwork.scala.ulid.{ULID => ChatworkULID}
-import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.annotations.*
 import org.openjdk.jmh.infra.Blackhole
 import wvlet.airframe.ulid.{ULID => AirframeULID}
 

--- a/airframe-canvas/src/main/scala/wvlet/airframe/canvas/OffHeapMemoryAllocator.scala
+++ b/airframe-canvas/src/main/scala/wvlet/airframe/canvas/OffHeapMemoryAllocator.scala
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.AtomicLong
 
 import wvlet.log.LogSupport
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 private[canvas] case class MemoryRefHolder(ref: MemoryReference, size: Long)
 

--- a/airframe-canvas/src/main/scala/wvlet/airframe/canvas/UnsafeCanvas.scala
+++ b/airframe-canvas/src/main/scala/wvlet/airframe/canvas/UnsafeCanvas.scala
@@ -30,7 +30,7 @@ final class UnsafeCanvas(
     // so that it cannot be released by GC.
     private[canvas] val reference: AnyRef
 ) extends Canvas {
-  import UnsafeUtil._
+  import UnsafeUtil.*
 
   override def readByte(offset: Long): Byte = {
     unsafe.getByte(base, address + offset)

--- a/airframe-codec/.jvm/src/main/scala-2/wvlet/airframe/codec/CompatBase.scala
+++ b/airframe-codec/.jvm/src/main/scala-2/wvlet/airframe/codec/CompatBase.scala
@@ -16,7 +16,7 @@ package wvlet.airframe.codec
 import wvlet.airframe.surface.Surface
 import wvlet.airframe.surface.reflect.ReflectSurfaceFactory
 
-import scala.reflect.runtime.universe._
+import scala.reflect.runtime.universe.*
 
 /**
   */

--- a/airframe-codec/.jvm/src/main/scala-3/wvlet/airframe/codec/CompatBase.scala
+++ b/airframe-codec/.jvm/src/main/scala-3/wvlet/airframe/codec/CompatBase.scala
@@ -20,5 +20,5 @@ trait CompatBase {
     MessageCodecFactory.defaultFactory.of[A]
   }
   // TODO Remove this method usage as runtime-reflection in Scala 3 is unstable and slow
-  def surfaceOfClass(cl: Class[_]): Surface = ReflectSurfaceFactory.ofClass(cl)
+  def surfaceOfClass(cl: Class[?]): Surface = ReflectSurfaceFactory.ofClass(cl)
 }

--- a/airframe-codec/.jvm/src/main/scala/wvlet/airframe/codec/JDBCCodec.scala
+++ b/airframe-codec/.jvm/src/main/scala/wvlet/airframe/codec/JDBCCodec.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.codec
 import java.sql.{ResultSet, Time, Timestamp, Types}
-import wvlet.airframe.codec.PrimitiveCodec._
+import wvlet.airframe.codec.PrimitiveCodec.*
 import wvlet.airframe.msgpack.spi.{MessagePack, Packer, Unpacker, ValueType}
 import wvlet.log.LogSupport
 

--- a/airframe-codec/.jvm/src/main/scala/wvlet/airframe/codec/JavaTimeCodec.scala
+++ b/airframe-codec/.jvm/src/main/scala/wvlet/airframe/codec/JavaTimeCodec.scala
@@ -16,7 +16,7 @@ import java.time.{Instant, ZonedDateTime}
 import java.util.Date
 
 import wvlet.airframe.msgpack.io.ByteArrayBuffer
-import wvlet.airframe.msgpack.spi._
+import wvlet.airframe.msgpack.spi.*
 import wvlet.airframe.surface.Surface
 import wvlet.log.LogSupport
 

--- a/airframe-codec/.jvm/src/test/scala/wvlet/airframe/codec/JDBCCodecTest.scala
+++ b/airframe-codec/.jvm/src/test/scala/wvlet/airframe/codec/JDBCCodecTest.scala
@@ -19,7 +19,7 @@ import java.util
 import wvlet.airframe.msgpack.spi.MessagePack
 import wvlet.airspec.AirSpec
 import wvlet.log.io.IOUtil.withResource
-import wvlet.airframe.codec.JDBCCodec._
+import wvlet.airframe.codec.JDBCCodec.*
 
 /**
   */

--- a/airframe-codec/.jvm/src/test/scala/wvlet/airframe/codec/ValueCodecTest.scala
+++ b/airframe-codec/.jvm/src/test/scala/wvlet/airframe/codec/ValueCodecTest.scala
@@ -26,7 +26,7 @@ object ValueCodecTest {
   case class RawMsgpackTest2(msgpack: MsgPack)
 }
 
-import wvlet.airframe.codec.ValueCodecTest._
+import wvlet.airframe.codec.ValueCodecTest.*
 
 /**
   */

--- a/airframe-codec/src/main/scala-2/wvlet/airrame/codec/CodecMacros.scala
+++ b/airframe-codec/src/main/scala-2/wvlet/airrame/codec/CodecMacros.scala
@@ -19,7 +19,7 @@ import scala.reflect.macros.{blackbox => sm}
   */
 object CodecMacros {
   def codecOf[A: c.WeakTypeTag](c: sm.Context): c.Tree = {
-    import c.universe._
+    import c.universe.*
     val t = implicitly[c.WeakTypeTag[A]].tpe
     q"wvlet.airframe.codec.MessageCodec.ofSurface(wvlet.airframe.surface.Surface.of[${t}]).asInstanceOf[wvlet.airframe.codec.MessageCodec[${t}]]"
   }

--- a/airframe-codec/src/main/scala-2/wvlet/airrame/codec/ScalaCompat.scala
+++ b/airframe-codec/src/main/scala-2/wvlet/airrame/codec/ScalaCompat.scala
@@ -16,7 +16,7 @@ package wvlet.airframe.codec
 import wvlet.airframe.surface.Surface
 
 import scala.language.experimental.macros
-import scala.reflect.runtime.universe._
+import scala.reflect.runtime.universe.*
 
 object ScalaCompat {
 

--- a/airframe-codec/src/main/scala/wvlet/airframe/codec/CollectionCodec.scala
+++ b/airframe-codec/src/main/scala/wvlet/airframe/codec/CollectionCodec.scala
@@ -21,7 +21,7 @@ import wvlet.airframe.surface.{Surface, Zero}
 
 import scala.collection.immutable.ListMap
 import scala.collection.mutable
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.language.higherKinds
 import scala.util.{Failure, Success, Try}
 

--- a/airframe-codec/src/main/scala/wvlet/airframe/codec/JSONCodec.scala
+++ b/airframe-codec/src/main/scala/wvlet/airframe/codec/JSONCodec.scala
@@ -14,8 +14,8 @@
 package wvlet.airframe.codec
 
 import wvlet.airframe.json.{JSON, Json}
-import wvlet.airframe.json.JSON._
-import wvlet.airframe.msgpack.spi._
+import wvlet.airframe.json.JSON.*
+import wvlet.airframe.msgpack.spi.*
 import wvlet.airframe.msgpack.spi.Value.TimestampValue
 
 /**
@@ -38,7 +38,7 @@ object JSONCodec extends MessageCodec[String] {
   }
 
   def packJsonValue(p: Packer, v: JSONValue): Unit = {
-    import wvlet.airframe.json.JSON._
+    import wvlet.airframe.json.JSON.*
     v match {
       case JSONObject(map) =>
         p.packMapHeader(map.size)

--- a/airframe-codec/src/main/scala/wvlet/airframe/codec/MessageContext.scala
+++ b/airframe-codec/src/main/scala/wvlet/airframe/codec/MessageContext.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.codec
 
-import wvlet.airframe.codec.DataType._
+import wvlet.airframe.codec.DataType.*
 
 /**
   * MessageContext is used for passing the parsing configuration and the last value read by codec.

--- a/airframe-codec/src/main/scala/wvlet/airframe/codec/ObjectCodec.scala
+++ b/airframe-codec/src/main/scala/wvlet/airframe/codec/ObjectCodec.scala
@@ -14,7 +14,7 @@
 package wvlet.airframe.codec
 
 import wvlet.airframe.msgpack.spi.{Packer, Unpacker, ValueType}
-import wvlet.airframe.surface._
+import wvlet.airframe.surface.*
 import wvlet.log.LogSupport
 import wvlet.airframe.json.JSONParseException
 import scala.util.{Failure, Success, Try}

--- a/airframe-codec/src/main/scala/wvlet/airframe/codec/PrimitiveCodec.scala
+++ b/airframe-codec/src/main/scala/wvlet/airframe/codec/PrimitiveCodec.scala
@@ -16,7 +16,7 @@ package wvlet.airframe.codec
 import wvlet.airframe.json.JSON.JSONValue
 import wvlet.airframe.json.Json
 import wvlet.airframe.msgpack.spi.Value.ExtensionValue
-import wvlet.airframe.msgpack.spi._
+import wvlet.airframe.msgpack.spi.*
 import wvlet.airframe.surface.{Primitive, Surface}
 import wvlet.airframe.ulid.{PrefixedULID, ULID}
 

--- a/airframe-codec/src/main/scala/wvlet/airframe/codec/TimeCodec.scala
+++ b/airframe-codec/src/main/scala/wvlet/airframe/codec/TimeCodec.scala
@@ -16,7 +16,7 @@ import java.time.Instant
 import java.util.Date
 
 import wvlet.airframe.msgpack.io.ByteArrayBuffer
-import wvlet.airframe.msgpack.spi._
+import wvlet.airframe.msgpack.spi.*
 import wvlet.log.LogSupport
 
 import scala.util.{Failure, Success, Try}

--- a/airframe-codec/src/test/scala/wvlet/airframe/codec/CollectionCodecTest.scala
+++ b/airframe-codec/src/test/scala/wvlet/airframe/codec/CollectionCodecTest.scala
@@ -18,7 +18,7 @@ import wvlet.airframe.msgpack.spi.MessagePack
 import wvlet.airframe.surface.Surface
 
 import scala.collection.immutable.ListMap
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 /**
   */

--- a/airframe-codec/src/test/scala/wvlet/airframe/codec/EnumCodecTest.scala
+++ b/airframe-codec/src/test/scala/wvlet/airframe/codec/EnumCodecTest.scala
@@ -37,7 +37,7 @@ object EnumCodecTest extends AirSpec {
     codec.unpackMsgPack(StringCodec.toMsgPack("Green")) shouldBe empty
   }
 
-  import enumtest._
+  import enumtest.*
 
   test("find unapply(String) from the object") {
     val codec = MessageCodec.of[Status]

--- a/airframe-codec/src/test/scala/wvlet/airframe/codec/JSONCodecTest.scala
+++ b/airframe-codec/src/test/scala/wvlet/airframe/codec/JSONCodecTest.scala
@@ -81,7 +81,7 @@ class JSONCodecTest extends AirSpec {
   }
 
   test("support Instant") {
-    import JSONCodecTest._
+    import JSONCodecTest.*
     val codec        = MessageCodec.of[WithTimestamp]
     val v            = WithTimestamp(Instant.ofEpochMilli(1500000000000L))
     val jsonObj      = codec.toJSONObject(v)

--- a/airframe-codec/src/test/scala/wvlet/airframe/codec/ObjectCodecTest.scala
+++ b/airframe-codec/src/test/scala/wvlet/airframe/codec/ObjectCodecTest.scala
@@ -42,7 +42,7 @@ object ObjectCodecTest {
 /**
   */
 class ObjectCodecTest extends CodecSpec {
-  import wvlet.airframe.codec.ObjectCodecTest._
+  import wvlet.airframe.codec.ObjectCodecTest.*
 
   val codec = MessageCodec.of[A1].asInstanceOf[ObjectMapCodec[A1]]
 

--- a/airframe-codec/src/test/scala/wvlet/airframe/codec/PrimitiveCodecTest.scala
+++ b/airframe-codec/src/test/scala/wvlet/airframe/codec/PrimitiveCodecTest.scala
@@ -30,9 +30,9 @@ import scala.util.Random
   */
 object PrimitiveCodecTest extends CodecSpec with PropertyCheck {
 
-  import org.scalacheck._
+  import org.scalacheck.*
 
-  import scala.jdk.CollectionConverters._
+  import scala.jdk.CollectionConverters.*
 
   protected def roundTripTest[T](surface: Surface, dataType: DataType)(implicit
       a1: Arbitrary[T],

--- a/airframe-codec/src/test/scala/wvlet/airframe/codec/ScalaStandardCodecTest.scala
+++ b/airframe-codec/src/test/scala/wvlet/airframe/codec/ScalaStandardCodecTest.scala
@@ -127,7 +127,7 @@ class ScalaStandardCodecTest extends CodecSpec {
     val et    = Left(new IllegalArgumentException("test exception"))
     val json  = codec.toJson(et)
     debug(json)
-    import wvlet.airframe.json._
+    import wvlet.airframe.json.*
     JSON.parse(json) match {
       case JSONArray(Seq(obj @ JSONObject(v), JSON.JSONNull)) =>
         (obj / "exceptionClass").toStringValue shouldBe "java.lang.IllegalArgumentException"

--- a/airframe-config/src/main/scala/wvlet/airframe/config/Config.scala
+++ b/airframe-config/src/main/scala/wvlet/airframe/config/Config.scala
@@ -82,7 +82,7 @@ case class ConfigChange(tpe: Surface, key: ConfigKey, default: Any, current: Any
   override def toString = s"[${tpe}] ${key} = ${current} (default = ${default})"
 }
 
-import wvlet.airframe.config.Config._
+import wvlet.airframe.config.Config.*
 
 case class Config private[config] (env: ConfigEnv, holder: Map[Surface, ConfigHolder])
     extends ConfigCompat
@@ -91,7 +91,7 @@ case class Config private[config] (env: ConfigEnv, holder: Map[Surface, ConfigHo
     with LogSupport {
   override def toString: String = printConfig
 
-  import wvlet.airframe.surface.reflect._
+  import wvlet.airframe.surface.reflect.*
 
   /**
     * Create a map representation of this config for display purpose. Parameters with @secret annotation will be hidden.

--- a/airframe-config/src/main/scala/wvlet/airframe/config/PropertiesConfig.scala
+++ b/airframe-config/src/main/scala/wvlet/airframe/config/PropertiesConfig.scala
@@ -15,7 +15,7 @@ package wvlet.airframe.config
 
 import java.util.Properties
 
-import wvlet.airframe.surface.CanonicalNameFormatter._
+import wvlet.airframe.surface.CanonicalNameFormatter.*
 import wvlet.airframe.surface.reflect.ObjectBuilder
 import wvlet.airframe.surface.{Surface, TaggedSurface}
 import wvlet.log.LogSupport
@@ -86,7 +86,7 @@ object PropertiesConfig extends LogSupport {
 
   def overrideWithProperties(config: Config, props: Properties, onUnusedProperties: Properties => Unit): Config = {
     val overrides: Seq[ConfigProperty] = {
-      import scala.jdk.CollectionConverters._
+      import scala.jdk.CollectionConverters.*
       val b = Seq.newBuilder[ConfigProperty]
       for ((k, v) <- props.asScala) yield {
         val key = configKeyOf(k)

--- a/airframe-config/src/main/scala/wvlet/airframe/config/YamlReader.scala
+++ b/airframe-config/src/main/scala/wvlet/airframe/config/YamlReader.scala
@@ -20,11 +20,11 @@ import org.yaml.snakeyaml.Yaml
 import wvlet.airframe.codec.MessageCodec
 import wvlet.airframe.msgpack.spi.{MessagePack, Packer}
 import wvlet.log.LogSupport
-import wvlet.log.io.IOUtil._
+import wvlet.log.io.IOUtil.*
 import wvlet.airframe.surface.{Surface, Zero}
 import wvlet.airframe.surface.reflect.ReflectTypeUtil
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.collection.immutable.ListMap
 
 object YamlReader extends YamlReaderCompat with LogSupport {

--- a/airframe-config/src/test/scala/wvlet/airframe/config/AirframeBootstrapTest.scala
+++ b/airframe-config/src/test/scala/wvlet/airframe/config/AirframeBootstrapTest.scala
@@ -14,7 +14,7 @@
 package wvlet.airframe.config
 
 import wvlet.airframe.Design
-import wvlet.airframe.surface._
+import wvlet.airframe.surface.*
 import wvlet.airspec.AirSpec
 
 object AirframeBootstrapTest {
@@ -22,7 +22,7 @@ object AirframeBootstrapTest {
   case class App2Config(name: String)
   case class DBConfig(host: String, private val port: Option[Int] = None)
 
-  import wvlet.airframe._
+  import wvlet.airframe.*
 
   val module1 =
     newDesign
@@ -42,7 +42,7 @@ object AirframeBootstrapTest {
 /**
   */
 class AirframeBootstrapTest extends AirSpec {
-  import AirframeBootstrapTest._
+  import AirframeBootstrapTest.*
 
   test("bind configs") {
     module1.noLifeCycleLogging.showConfig

--- a/airframe-config/src/test/scala/wvlet/airframe/config/ConfigOverrideTest.scala
+++ b/airframe-config/src/test/scala/wvlet/airframe/config/ConfigOverrideTest.scala
@@ -25,7 +25,7 @@ object ConfigOverrideTest {
 /**
   */
 class ConfigOverrideTest extends AirSpec {
-  import ConfigOverrideTest._
+  import ConfigOverrideTest.*
 
   private def newConfig: Config = Config(env = "default").register[MyAppConfig](MyAppConfig())
 

--- a/airframe-config/src/test/scala/wvlet/airframe/config/ConfigPackageTest.scala
+++ b/airframe-config/src/test/scala/wvlet/airframe/config/ConfigPackageTest.scala
@@ -12,8 +12,8 @@
  * limitations under the License.
  */
 package wvlet.airframe.config
-import wvlet.airframe._
-import wvlet.airframe.surface.tag._
+import wvlet.airframe.*
+import wvlet.airframe.surface.tag.*
 import wvlet.airspec.AirSpec
 
 trait AppTag

--- a/airframe-config/src/test/scala/wvlet/airframe/config/ConfigProviderTest.scala
+++ b/airframe-config/src/test/scala/wvlet/airframe/config/ConfigProviderTest.scala
@@ -20,7 +20,7 @@ object ConfigProviderTest {
 //    val configA = bind[ConfigA]
   }
 }
-import ConfigProviderTest._
+import ConfigProviderTest.*
 import wvlet.airspec.AirSpec
 
 /**

--- a/airframe-config/src/test/scala/wvlet/airframe/config/ConfigTest.scala
+++ b/airframe-config/src/test/scala/wvlet/airframe/config/ConfigTest.scala
@@ -18,7 +18,7 @@ import java.util.Properties
 
 import wvlet.airframe.config.PropertiesConfig.{ConfigKey, Prefix}
 import wvlet.log.io.IOUtil
-import wvlet.airframe.surface.tag._
+import wvlet.airframe.surface.tag.*
 import wvlet.airspec.AirSpec
 
 trait AppScope

--- a/airframe-config/src/test/scala/wvlet/airframe/config/NestedConfigTest.scala
+++ b/airframe-config/src/test/scala/wvlet/airframe/config/NestedConfigTest.scala
@@ -18,7 +18,7 @@ import wvlet.airspec.AirSpec
 /**
   */
 class NestedConfigTest extends AirSpec {
-  import NestedConfigTest._
+  import NestedConfigTest.*
   test("support nested case classes") {
     val configPaths = Seq("airframe-config/src/test/resources")
 

--- a/airframe-config/src/test/scala/wvlet/airframe/config/NestedOverrideTest.scala
+++ b/airframe-config/src/test/scala/wvlet/airframe/config/NestedOverrideTest.scala
@@ -25,7 +25,7 @@ object NestedOverrideTest {
 class NestedOverrideTest extends AirSpec {
   private val configPaths = Seq("airframe-config/src/test/resources")
 
-  import NestedOverrideTest._
+  import NestedOverrideTest.*
 
   test("override nested yaml") {
     val config =

--- a/airframe-control/.jvm/src/main/scala/wvlet/airframe/control/Parallel.scala
+++ b/airframe-control/.jvm/src/main/scala/wvlet/airframe/control/Parallel.scala
@@ -14,13 +14,13 @@
 package wvlet.airframe.control
 
 import java.util.UUID
-import java.util.concurrent._
+import java.util.concurrent.*
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicLong, AtomicReference}
 
 import wvlet.log.LogSupport
 
 import scala.reflect.ClassTag
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.util.control.{ControlThrowable, NonFatal}
 
 /**

--- a/airframe-control/.jvm/src/main/scala/wvlet/airframe/control/Shell.scala
+++ b/airframe-control/.jvm/src/main/scala/wvlet/airframe/control/Shell.scala
@@ -19,7 +19,7 @@ import wvlet.log.LogSupport
 
 import scala.collection.mutable.WeakHashMap
 import scala.sys.process.{Process, ProcessLogger}
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.util.Try
 
 /**
@@ -307,7 +307,7 @@ object Shell extends LogSupport {
       val java_home: Option[String] = {
         val e = findJavaHome
 
-        import OSType._
+        import OSType.*
         e match {
           case Some(x) => e
           case None => {

--- a/airframe-control/.jvm/src/test/scala/wvlet/airframe/control/ParallelTest.scala
+++ b/airframe-control/.jvm/src/test/scala/wvlet/airframe/control/ParallelTest.scala
@@ -115,7 +115,7 @@ class ParallelTest extends AirSpec {
   }
 
   test("be run for Seq using syntax sugar") {
-    import wvlet.airframe.control.parallel._
+    import wvlet.airframe.control.parallel.*
 
     Parallel.stats.startedTasks.set(0)
     Parallel.stats.finishedTasks.set(0)
@@ -130,7 +130,7 @@ class ParallelTest extends AirSpec {
   }
 
   test("be run for Iterator using syntax sugar") {
-    import wvlet.airframe.control.parallel._
+    import wvlet.airframe.control.parallel.*
 
     Parallel.stats.startedTasks.set(0)
     Parallel.stats.finishedTasks.set(0)

--- a/airframe-control/src/main/scala/wvlet/airframe/control/CircuitBreaker.scala
+++ b/airframe-control/src/main/scala/wvlet/airframe/control/CircuitBreaker.scala
@@ -74,7 +74,7 @@ object CircuitBreaker extends LogSupport {
   }
 }
 
-import CircuitBreaker._
+import CircuitBreaker.*
 
 /**
   * A safe interface for accessing CircuitBreaker states when handling events.

--- a/airframe-control/src/test/scala/wvlet/airframe/control/CircuitBreakerTest.scala
+++ b/airframe-control/src/test/scala/wvlet/airframe/control/CircuitBreakerTest.scala
@@ -1,6 +1,6 @@
 package wvlet.airframe.control
 
-import wvlet.airspec._
+import wvlet.airspec.*
 import java.util.concurrent.TimeoutException
 
 class CircuitBreakerTest extends AirSpec {

--- a/airframe-di-macros/src/main/scala-2/wvlet/airframe/AirframeMacros.scala
+++ b/airframe-di-macros/src/main/scala-2/wvlet/airframe/AirframeMacros.scala
@@ -19,7 +19,7 @@ import scala.reflect.macros.{blackbox => sm}
 
 private[wvlet] object AirframeMacros {
   private[wvlet] class BindHelper[C <: Context](val c: C) {
-    import c.universe._
+    import c.universe.*
 
     def shouldGenerateTrait(t: c.Type): Boolean = {
       val a = t.typeSymbol
@@ -254,7 +254,7 @@ private[wvlet] object AirframeMacros {
   }
 
   def designBindImpl[A: c.WeakTypeTag](c: sm.Context): c.Tree = {
-    import c.universe._
+    import c.universe.*
     val t = implicitly[c.WeakTypeTag[A]].tpe
     val h = new BindHelper[c.type](c)
     q"""{
@@ -264,7 +264,7 @@ private[wvlet] object AirframeMacros {
   }
 
   def designRemoveImpl[A: c.WeakTypeTag](c: sm.Context): c.Tree = {
-    import c.universe._
+    import c.universe.*
     val t = implicitly[c.WeakTypeTag[A]].tpe
     val h = new BindHelper[c.type](c)
     q"""{
@@ -276,7 +276,7 @@ private[wvlet] object AirframeMacros {
   }
 
   def binderToImpl[B: c.WeakTypeTag](c: sm.Context): c.Tree = {
-    import c.universe._
+    import c.universe.*
     val t = implicitly[c.WeakTypeTag[B]].tpe
     val h = new BindHelper[c.type](c)
     q""" {
@@ -287,7 +287,7 @@ private[wvlet] object AirframeMacros {
   }
 
   def binderToSingletonOfImpl[B: c.WeakTypeTag](c: sm.Context): c.Tree = {
-    import c.universe._
+    import c.universe.*
     val t = implicitly[c.WeakTypeTag[B]].tpe
     val h = new BindHelper[c.type](c)
     q""" {
@@ -302,7 +302,7 @@ private[wvlet] object AirframeMacros {
   }
 
   def binderToEagerSingletonOfImpl[B: c.WeakTypeTag](c: sm.Context): c.Tree = {
-    import c.universe._
+    import c.universe.*
     val t = implicitly[c.WeakTypeTag[B]].tpe
     val h = new BindHelper[c.type](c)
     q""" {
@@ -457,7 +457,7 @@ private[wvlet] object AirframeMacros {
   }
 
   def buildWithSession[A: c.WeakTypeTag](c: sm.Context)(body: c.Expr[A => Any]): c.Tree = {
-    import c.universe._
+    import c.universe.*
     val t = implicitly[c.WeakTypeTag[A]].tpe
     // Bind the code block to a local variable to resolve the issue #373
     val e = q"""
@@ -473,7 +473,7 @@ private[wvlet] object AirframeMacros {
   }
 
   def runWithSession[A: c.WeakTypeTag, B: c.WeakTypeTag](c: sm.Context)(body: c.Expr[A => B]): c.Tree = {
-    import c.universe._
+    import c.universe.*
     val a = implicitly[c.WeakTypeTag[A]].tpe
     val b = implicitly[c.WeakTypeTag[B]].tpe
     // Bind the code block to a local variable to resolve the issue #373
@@ -490,7 +490,7 @@ private[wvlet] object AirframeMacros {
   }
 
   def addLifeCycle[A: c.WeakTypeTag](c: sm.Context): c.Tree = {
-    import c.universe._
+    import c.universe.*
 
     val t = implicitly[c.WeakTypeTag[A]].tpe
     val h = new BindHelper[c.type](c)
@@ -502,7 +502,7 @@ private[wvlet] object AirframeMacros {
   }
 
   def addInitLifeCycle[A: c.WeakTypeTag](c: sm.Context)(body: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
     val t = implicitly[c.WeakTypeTag[A]].tpe
     val h = new BindHelper[c.type](c)
     q"""{
@@ -515,7 +515,7 @@ private[wvlet] object AirframeMacros {
   }
 
   def addInjectLifeCycle[A: c.WeakTypeTag](c: sm.Context)(body: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
     val t = implicitly[c.WeakTypeTag[A]].tpe
     val h = new BindHelper[c.type](c)
     q"""{
@@ -529,7 +529,7 @@ private[wvlet] object AirframeMacros {
   }
 
   def addStartLifeCycle[A: c.WeakTypeTag](c: sm.Context)(body: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
     val t = implicitly[c.WeakTypeTag[A]].tpe
     val h = new BindHelper[c.type](c)
     q"""{
@@ -543,7 +543,7 @@ private[wvlet] object AirframeMacros {
   }
 
   def addStartLifeCycleForFactory[F: c.WeakTypeTag](c: sm.Context)(body: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
     val t  = implicitly[c.WeakTypeTag[F]].tpe
     val i1 = t.typeArgs(0)
     val a  = t.typeArgs(1)
@@ -559,7 +559,7 @@ private[wvlet] object AirframeMacros {
   }
 
   def addPreShutdownLifeCycle[A: c.WeakTypeTag](c: sm.Context)(body: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
     val t = implicitly[c.WeakTypeTag[A]].tpe
     val h = new BindHelper[c.type](c)
     q"""{
@@ -573,7 +573,7 @@ private[wvlet] object AirframeMacros {
   }
 
   def addShutdownLifeCycle[A: c.WeakTypeTag](c: sm.Context)(body: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
     val t = implicitly[c.WeakTypeTag[A]].tpe
     val h = new BindHelper[c.type](c)
     q"""{
@@ -593,7 +593,7 @@ private[wvlet] object AirframeMacros {
   }
 
   def bind0Impl[A: c.WeakTypeTag](c: sm.Context)(provider: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
     val t = implicitly[c.WeakTypeTag[A]].tpe
     val h = new BindHelper[c.type](c)
     q"""{
@@ -604,7 +604,7 @@ private[wvlet] object AirframeMacros {
   }
 
   def bind1Impl[A: c.WeakTypeTag, D1: c.WeakTypeTag](c: sm.Context)(provider: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
     val h    = new BindHelper[c.type](c)
     val t    = implicitly[c.WeakTypeTag[A]].tpe
     val d1   = implicitly[c.WeakTypeTag[D1]].tpe
@@ -617,7 +617,7 @@ private[wvlet] object AirframeMacros {
   }
 
   def bind2Impl[A: c.WeakTypeTag, D1: c.WeakTypeTag, D2: c.WeakTypeTag](c: sm.Context)(provider: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
     val h    = new BindHelper[c.type](c)
     val t    = implicitly[c.WeakTypeTag[A]].tpe
     val d1   = implicitly[c.WeakTypeTag[D1]].tpe
@@ -634,7 +634,7 @@ private[wvlet] object AirframeMacros {
   def bind3Impl[A: c.WeakTypeTag, D1: c.WeakTypeTag, D2: c.WeakTypeTag, D3: c.WeakTypeTag](
       c: sm.Context
   )(provider: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
     val h    = new BindHelper[c.type](c)
     val t    = implicitly[c.WeakTypeTag[A]].tpe
     val d1   = implicitly[c.WeakTypeTag[D1]].tpe
@@ -653,7 +653,7 @@ private[wvlet] object AirframeMacros {
   def bind4Impl[A: c.WeakTypeTag, D1: c.WeakTypeTag, D2: c.WeakTypeTag, D3: c.WeakTypeTag, D4: c.WeakTypeTag](
       c: sm.Context
   )(provider: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
     val h    = new BindHelper[c.type](c)
     val t    = implicitly[c.WeakTypeTag[A]].tpe
     val d1   = implicitly[c.WeakTypeTag[D1]].tpe
@@ -681,7 +681,7 @@ private[wvlet] object AirframeMacros {
       D4: c.WeakTypeTag,
       D5: c.WeakTypeTag
   ](c: sm.Context)(provider: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
     val h    = new BindHelper[c.type](c)
     val t    = implicitly[c.WeakTypeTag[A]].tpe
     val d1   = implicitly[c.WeakTypeTag[D1]].tpe
@@ -704,7 +704,7 @@ private[wvlet] object AirframeMacros {
   }
 
   def bindLocal0Impl[A: c.WeakTypeTag](c: sm.Context)(provider: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
 
     val a = implicitly[c.WeakTypeTag[A]].tpe
     val h = new BindHelper[c.type](c)
@@ -719,7 +719,7 @@ private[wvlet] object AirframeMacros {
   }
 
   def bindLocal1Impl[A: c.WeakTypeTag, D1: c.WeakTypeTag](c: sm.Context)(provider: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
 
     val a    = implicitly[c.WeakTypeTag[A]].tpe
     val d1   = implicitly[c.WeakTypeTag[D1]].tpe
@@ -738,7 +738,7 @@ private[wvlet] object AirframeMacros {
   def bindLocal2Impl[A: c.WeakTypeTag, D1: c.WeakTypeTag, D2: c.WeakTypeTag](
       c: sm.Context
   )(provider: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
 
     val a    = implicitly[c.WeakTypeTag[A]].tpe
     val d1   = implicitly[c.WeakTypeTag[D1]].tpe
@@ -759,7 +759,7 @@ private[wvlet] object AirframeMacros {
   def bindLocal3Impl[A: c.WeakTypeTag, D1: c.WeakTypeTag, D2: c.WeakTypeTag, D3: c.WeakTypeTag](
       c: sm.Context
   )(provider: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
 
     val a    = implicitly[c.WeakTypeTag[A]].tpe
     val d1   = implicitly[c.WeakTypeTag[D1]].tpe
@@ -782,7 +782,7 @@ private[wvlet] object AirframeMacros {
   def bindLocal4Impl[A: c.WeakTypeTag, D1: c.WeakTypeTag, D2: c.WeakTypeTag, D3: c.WeakTypeTag, D4: c.WeakTypeTag](
       c: sm.Context
   )(provider: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
 
     val a    = implicitly[c.WeakTypeTag[A]].tpe
     val d1   = implicitly[c.WeakTypeTag[D1]].tpe
@@ -814,7 +814,7 @@ private[wvlet] object AirframeMacros {
   ](
       c: sm.Context
   )(provider: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
 
     val a    = implicitly[c.WeakTypeTag[A]].tpe
     val d1   = implicitly[c.WeakTypeTag[D1]].tpe
@@ -839,7 +839,7 @@ private[wvlet] object AirframeMacros {
   }
 
   def bindFactoryImpl[F: c.WeakTypeTag](c: sm.Context): c.Tree = {
-    import c.universe._
+    import c.universe.*
 
     import scala.language.higherKinds
     val t  = implicitly[c.WeakTypeTag[F]].tpe // F = Function[I1, A]
@@ -855,7 +855,7 @@ private[wvlet] object AirframeMacros {
   }
 
   def bindFactory2Impl[F: c.WeakTypeTag](c: sm.Context): c.Tree = {
-    import c.universe._
+    import c.universe.*
 
     import scala.language.higherKinds
     val t  = implicitly[c.WeakTypeTag[F]].tpe // F = Function[(I1, I2), A]
@@ -875,7 +875,7 @@ private[wvlet] object AirframeMacros {
   }
 
   def bindFactory3Impl[F: c.WeakTypeTag](c: sm.Context): c.Tree = {
-    import c.universe._
+    import c.universe.*
 
     import scala.language.higherKinds
     val t  = implicitly[c.WeakTypeTag[F]].tpe // F = Function[(I1, I2, I3), A]
@@ -897,7 +897,7 @@ private[wvlet] object AirframeMacros {
   }
 
   def bindFactory4Impl[F: c.WeakTypeTag](c: sm.Context): c.Tree = {
-    import c.universe._
+    import c.universe.*
 
     import scala.language.higherKinds
     val t  = implicitly[c.WeakTypeTag[F]].tpe // F = Function[(I1, I2, I3, I4), A]
@@ -921,7 +921,7 @@ private[wvlet] object AirframeMacros {
   }
 
   def bindFactory5Impl[F: c.WeakTypeTag](c: sm.Context): c.Tree = {
-    import c.universe._
+    import c.universe.*
 
     import scala.language.higherKinds
     val t  = implicitly[c.WeakTypeTag[F]].tpe // F = Function[(I1, I2, I3, I4, I4), A]
@@ -947,7 +947,7 @@ private[wvlet] object AirframeMacros {
   }
 
   def sourceCode(c: sm.Context): c.Tree = {
-    import c.universe._
+    import c.universe.*
     c.internal.enclosingOwner
     val pos = c.enclosingPosition
     q"wvlet.airframe.SourceCode(${""}, ${pos.source.file.name}, ${pos.line}, ${pos.column})"

--- a/airframe-di-macros/src/main/scala-3/wvlet/airframe/SourceCode.scala
+++ b/airframe-di-macros/src/main/scala-3/wvlet/airframe/SourceCode.scala
@@ -30,12 +30,12 @@ case class SourceCode(
 object SourceCode {
   def apply()(implicit code: SourceCode) = code
 
-  import scala.quoted._
+  import scala.quoted.*
 
   inline implicit def generate: SourceCode = ${ generateImpl }
 
   private def generateImpl(using q: Quotes): Expr[SourceCode] = {
-    import q.reflect._
+    import q.reflect.*
     val pos    = Position.ofMacroExpansion
     val line   = Expr(pos.startLine)
     val column = Expr(pos.endColumn)

--- a/airframe-di/.jvm/src/main/scala/wvlet/airframe/tracing/ChromeTracer.scala
+++ b/airframe-di/.jvm/src/main/scala/wvlet/airframe/tracing/ChromeTracer.scala
@@ -12,10 +12,10 @@
  * limitations under the License.
  */
 package wvlet.airframe.tracing
-import java.io._
+import java.io.*
 
-import wvlet.airframe.tracing.ChromeTracer._
-import wvlet.airframe.tracing.TraceEvent._
+import wvlet.airframe.tracing.ChromeTracer.*
+import wvlet.airframe.tracing.TraceEvent.*
 
 /**
   * Tracer for producing DI events in Trace Event Format (JSON):

--- a/airframe-di/.jvm/src/test/scala-2/wvlet/airframe/FactoryBindingLifecycleTest.scala
+++ b/airframe-di/.jvm/src/test/scala-2/wvlet/airframe/FactoryBindingLifecycleTest.scala
@@ -50,7 +50,7 @@ object FactoryBindingLifecycleTest {
 /**
   */
 class FactoryBindingLifecycleTest extends AirSpec {
-  import FactoryBindingLifecycleTest._
+  import FactoryBindingLifecycleTest.*
 
   test("run shutdown hooks") {
     threadCounter.get() shouldBe 0

--- a/airframe-di/.jvm/src/test/scala-2/wvlet/airframe/HigherKindedTypeBindingTest.scala
+++ b/airframe-di/.jvm/src/test/scala-2/wvlet/airframe/HigherKindedTypeBindingTest.scala
@@ -43,7 +43,7 @@ object TaglessFinalExample {
 /**
   */
 class HigherKindedTypeBindingTest extends AirSpec {
-  import TaglessFinalExample._
+  import TaglessFinalExample.*
 
   test("support higher-kinded type binding") {
     warn("TODO: This currently works only for JVM. Need to fix SurfaceMacros for Scala.js")

--- a/airframe-di/.jvm/src/test/scala-2/wvlet/airframe/SerializationTest.scala
+++ b/airframe-di/.jvm/src/test/scala-2/wvlet/airframe/SerializationTest.scala
@@ -45,8 +45,8 @@ object SerializationTest extends AirSpec {
   }
 
   test("serialize provider that involves toInstance of local var") {
-    import ProviderSerializationExample._
-    import ProviderVal._
+    import ProviderSerializationExample.*
+    import ProviderVal.*
 
     val d = newDesign
       .bind[D1].toInstance(d1)

--- a/airframe-di/.jvm/src/test/scala/wvlet/airframe/ConstructorBindingTest.scala
+++ b/airframe-di/.jvm/src/test/scala/wvlet/airframe/ConstructorBindingTest.scala
@@ -19,7 +19,7 @@ import wvlet.airspec.AirSpec
   * TODO: This works only in JVM, because we cannot extract constructor default parameters in Scala.js
   */
 class ConstructorBindingTest extends AirSpec {
-  import ConstructorBindingTest._
+  import ConstructorBindingTest.*
 
   test("build objects using default constructor parameters") {
     newSilentDesign.build[CbTest] { a =>

--- a/airframe-di/.jvm/src/test/scala/wvlet/airframe/DesignSerializationTest.scala
+++ b/airframe-di/.jvm/src/test/scala/wvlet/airframe/DesignSerializationTest.scala
@@ -15,7 +15,7 @@ package wvlet.airframe
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, InputStream, ObjectInputStream, ObjectOutputStream}
 
-import DesignTest._
+import DesignTest.*
 import wvlet.airspec.AirSpec
 
 class CustomClassLoader(in: InputStream) extends ObjectInputStream(in) {
@@ -47,7 +47,7 @@ object DesignSerializationTest {
 /**
   */
 class DesignSerializationTest extends AirSpec {
-  import DesignSerializationTest._
+  import DesignSerializationTest.*
 
   test("be serializable") {
     val b   = serialize(d1)

--- a/airframe-di/.jvm/src/test/scala/wvlet/airframe/ProviderSerializationTest.scala
+++ b/airframe-di/.jvm/src/test/scala/wvlet/airframe/ProviderSerializationTest.scala
@@ -13,9 +13,9 @@
  */
 package wvlet.airframe
 
-import wvlet.airframe.ProviderSerializationExample._
-import wvlet.airframe.ProviderVal._
-import DesignSerializationTest._
+import wvlet.airframe.ProviderSerializationExample.*
+import wvlet.airframe.ProviderVal.*
+import DesignSerializationTest.*
 import wvlet.airspec.AirSpec
 
 /**

--- a/airframe-di/.jvm/src/test/scala/wvlet/airframe/TracerTest.scala
+++ b/airframe-di/.jvm/src/test/scala/wvlet/airframe/TracerTest.scala
@@ -30,7 +30,7 @@ object TracerTest extends LogSupport {
 /**
   */
 class TracerTest extends AirSpec {
-  import TracerTest._
+  import TracerTest.*
 
   test("should trace events") {
     val d = newDesign.noLifeCycleLogging

--- a/airframe-di/src/main/scala-2/wvlet/airframe/BinderImpl.scala
+++ b/airframe-di/src/main/scala-2/wvlet/airframe/BinderImpl.scala
@@ -1,6 +1,6 @@
 package wvlet.airframe
 
-import wvlet.airframe.AirframeMacros._
+import wvlet.airframe.AirframeMacros.*
 import wvlet.log.LogSupport
 
 import scala.language.experimental.macros

--- a/airframe-di/src/main/scala-2/wvlet/airframe/package.scala
+++ b/airframe-di/src/main/scala-2/wvlet/airframe/package.scala
@@ -15,7 +15,7 @@ package wvlet
 
 import java.util.concurrent.ConcurrentHashMap
 
-import wvlet.airframe.AirframeMacros._
+import wvlet.airframe.AirframeMacros.*
 import wvlet.airframe.surface.Surface
 import wvlet.log.LogSupport
 
@@ -128,7 +128,7 @@ package object airframe {
   // For internal use to hold caches of factories of trait with a session
   def registerTraitFactory[A]: Surface = macro registerTraitFactoryImpl[A]
 
-  import scala.jdk.CollectionConverters._
+  import scala.jdk.CollectionConverters.*
   val traitFactoryCache = new ConcurrentHashMap[Surface, Session => Any].asScala
   def getOrElseUpdateTraitFactoryCache(s: Surface, factory: Session => Any): Session => Any = {
     traitFactoryCache.getOrElseUpdate(s, factory)

--- a/airframe-di/src/main/scala-3/wvlet/airframe/BinderImpl.scala
+++ b/airframe-di/src/main/scala-3/wvlet/airframe/BinderImpl.scala
@@ -3,7 +3,7 @@ package wvlet.airframe
 import wvlet.airframe.AirframeException.CYCLIC_DEPENDENCY
 import wvlet.airframe.surface.Surface
 import wvlet.log.LogSupport
-import wvlet.airframe.Binder._
+import wvlet.airframe.Binder.*
 
 /**
   */
@@ -18,7 +18,7 @@ private[airframe] trait BinderImpl[A] extends LogSupport { self: Binder[A] =>
     {
       // registerTraitFactory[B]
       val to = Surface.of[B]
-      if (self.from == to) {
+      if self.from == to then {
         wvlet.log.Logger("wvlet.airframe.Binder").warn("Binding to the same type is not allowed: " + to.toString)
         throw new wvlet.airframe.AirframeException.CYCLIC_DEPENDENCY(List(to), SourceCode())
       }
@@ -30,7 +30,7 @@ private[airframe] trait BinderImpl[A] extends LogSupport { self: Binder[A] =>
     {
       // registerTraitFactory[B]
       val to = Surface.of[B]
-      if (self.from == to) {
+      if self.from == to then {
         wvlet.log.Logger("wvlet.airframe.Binder").warn("Binding to the same type is not allowed: " + to.toString)
         throw new wvlet.airframe.AirframeException.CYCLIC_DEPENDENCY(List(to), SourceCode())
       }

--- a/airframe-di/src/main/scala-3/wvlet/airframe/package.scala
+++ b/airframe-di/src/main/scala-3/wvlet/airframe/package.scala
@@ -38,7 +38,7 @@ package object airframe {
     */
   def newSilentDesign: Design = newDesign.noLifeCycleLogging
 
-  import scala.jdk.CollectionConverters._
+  import scala.jdk.CollectionConverters.*
 
   // This will not be used in Scala 3, but left for the compatibility with Scala 2
   val traitFactoryCache = new ConcurrentHashMap[Surface, Session => Any].asScala
@@ -52,14 +52,14 @@ package object airframe {
     // registerTraitFactoryImpl[A]
   }
 
-  import scala.quoted._
+  import scala.quoted.*
 
   private def shouldGenerateTrait[A](using
       tpe: Type[A],
       q: Quotes
   ): Boolean = {
-    import quotes._
-    import quotes.reflect._
+    import quotes.*
+    import quotes.reflect.*
 
     val t = TypeRepr.of[A]
     val a = t.typeSymbol
@@ -82,18 +82,18 @@ package object airframe {
     val isLocal      = a.flags.is(Flags.Local)
     val isTrait      = a.flags.is(Flags.Trait)
 
-    val shouldInstantiateTrait = if (!isStatic) {
+    val shouldInstantiateTrait = if !isStatic then {
       // = Non static type
       // If X is non static type (= local class or trait),
       // we need to instantiate it first in order to populate its $outer variables
 
       // We cannot instantiate path-dependent types
-      if (a.fullName.contains("#")) {
+      if a.fullName.contains("#") then {
         false
       } else {
         !hasAbstractMethods && hasPublicDefaultConstructor
       }
-    } else if (a.isAbstractType) {
+    } else if a.isAbstractType then {
       // = Abstract type
       // We cannot build abstract type X that has abstract methods, so bind[X].to[ConcreteType]
       // needs to be found in the design
@@ -119,10 +119,10 @@ package object airframe {
       tpe: Type[A],
       q: Quotes
   ): Expr[Unit] = {
-    import quotes._
-    import quotes.reflect._
+    import quotes.*
+    import quotes.reflect.*
 
-    if (!shouldGenerateTrait[A]) {
+    if !shouldGenerateTrait[A] then {
       '{}
     } else {
       val name    = "$anon"

--- a/airframe-di/src/main/scala/wvlet/airframe/AirframeSession.scala
+++ b/airframe-di/src/main/scala/wvlet/airframe/AirframeSession.scala
@@ -16,13 +16,13 @@ package wvlet.airframe
 import java.util.concurrent.ConcurrentHashMap
 
 import wvlet.airframe.AirframeException.{CYCLIC_DEPENDENCY, MISSING_DEPENDENCY}
-import wvlet.airframe.Binder._
+import wvlet.airframe.Binder.*
 import wvlet.airframe.lifecycle.{CloseHook, EventHookHolder, Injectee, LifeCycleManager}
 import wvlet.airframe.surface.Surface
 import wvlet.airframe.tracing.{DIStats, DefaultTracer, Tracer}
 import wvlet.log.LogSupport
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.util.Try
 
 /**

--- a/airframe-di/src/main/scala/wvlet/airframe/Binder.scala
+++ b/airframe-di/src/main/scala/wvlet/airframe/Binder.scala
@@ -88,7 +88,7 @@ object Binder {
   }
 }
 
-import wvlet.airframe.Binder._
+import wvlet.airframe.Binder.*
 
 /**
   */

--- a/airframe-di/src/main/scala/wvlet/airframe/Design.scala
+++ b/airframe-di/src/main/scala/wvlet/airframe/Design.scala
@@ -18,8 +18,8 @@ import wvlet.airframe.surface.Surface
 import wvlet.airframe.tracing.{DIStats, Tracer}
 import wvlet.log.LogSupport
 
-import Design._
-import DesignOptions._
+import Design.*
+import DesignOptions.*
 import wvlet.airframe.lifecycle.LifeCycleHookType
 
 /**

--- a/airframe-di/src/main/scala/wvlet/airframe/DesignOptions.scala
+++ b/airframe-di/src/main/scala/wvlet/airframe/DesignOptions.scala
@@ -29,7 +29,7 @@ case class DesignOptions(
     options: Map[String, Any] = Map.empty
 ) extends Serializable {
 
-  import DesignOptions._
+  import DesignOptions.*
 
   def +(other: DesignOptions): DesignOptions = {
     // configs will be overwritten

--- a/airframe-di/src/main/scala/wvlet/airframe/lifecycle/LifeCycleManager.scala
+++ b/airframe-di/src/main/scala/wvlet/airframe/lifecycle/LifeCycleManager.scala
@@ -48,7 +48,7 @@ class LifeCycleManager(
 ) extends LogSupport {
   self =>
 
-  import LifeCycleManager._
+  import LifeCycleManager.*
 
   private val state                = new AtomicReference[LifeCycleStage](INIT)
   def currentState: LifeCycleStage = state.get()

--- a/airframe-di/src/main/scala/wvlet/airframe/tracing/DIStats.scala
+++ b/airframe-di/src/main/scala/wvlet/airframe/tracing/DIStats.scala
@@ -20,7 +20,7 @@ import wvlet.airframe.surface.Surface
 import wvlet.airframe.{Design, Session}
 import wvlet.log.LogSupport
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 case class DIStatsReport(
     coverage: Double,

--- a/airframe-di/src/main/scala/wvlet/airframe/tracing/Tracer.scala
+++ b/airframe-di/src/main/scala/wvlet/airframe/tracing/Tracer.scala
@@ -15,7 +15,7 @@ package wvlet.airframe.tracing
 
 import wvlet.airframe.lifecycle.Injectee
 import wvlet.airframe.surface.Surface
-import wvlet.airframe.tracing.TraceEvent._
+import wvlet.airframe.tracing.TraceEvent.*
 import wvlet.airframe.Session
 import wvlet.log.LogSupport
 

--- a/airframe-di/src/test/scala-2/example/BindFactory.scala
+++ b/airframe-di/src/test/scala-2/example/BindFactory.scala
@@ -20,7 +20,7 @@ import wvlet.log.LogSupport
   * bindFactory[X => Y] example
   */
 object BindFactory {
-  import wvlet.airframe._
+  import wvlet.airframe.*
 
   trait X {
     def hello: String   = "Hello"

--- a/airframe-di/src/test/scala-2/example/BindSingleton.scala
+++ b/airframe-di/src/test/scala-2/example/BindSingleton.scala
@@ -21,7 +21,7 @@ import wvlet.log.LogSupport
   * bindSingleton[X] example
   */
 object BindSingleton {
-  import wvlet.airframe._
+  import wvlet.airframe.*
 
   trait X {
     def hello: String   = "Hello"

--- a/airframe-di/src/test/scala-2/wvlet/airframe/legacy/AirframeMacrosTest.scala
+++ b/airframe-di/src/test/scala-2/wvlet/airframe/legacy/AirframeMacrosTest.scala
@@ -16,7 +16,7 @@ package wvlet.airframe.legacy
 import wvlet.airspec.AirSpec
 import wvlet.log.LogSupport
 
-import wvlet.airframe._
+import wvlet.airframe.*
 
 trait NonAbstractTrait extends LogSupport {
   debug("hello trait")

--- a/airframe-di/src/test/scala-2/wvlet/airframe/legacy/AirframeTest.scala
+++ b/airframe-di/src/test/scala-2/wvlet/airframe/legacy/AirframeTest.scala
@@ -24,7 +24,7 @@ import wvlet.airspec.AirSpec
 
 import scala.util.Random
 
-import wvlet.airframe._
+import wvlet.airframe.*
 
 case class ExecutorConfig(numThreads: Int)
 
@@ -241,7 +241,7 @@ object ServiceMixinExample {
   trait Test
 }
 
-import wvlet.airframe.legacy.ServiceMixinExample._
+import wvlet.airframe.legacy.ServiceMixinExample.*
 
 /**
   */

--- a/airframe-di/src/test/scala-2/wvlet/airframe/legacy/AssistedInjectionTest.scala
+++ b/airframe-di/src/test/scala-2/wvlet/airframe/legacy/AssistedInjectionTest.scala
@@ -16,12 +16,12 @@ package wvlet.airframe.legacy
 import wvlet.airspec.AirSpec
 import wvlet.log.LogSupport
 
-import wvlet.airframe._
+import wvlet.airframe.*
 
 /**
   */
 class AssistedInjectionTest extends AirSpec {
-  import AssistedInjectionTest._
+  import AssistedInjectionTest.*
 
   test("support assisted injection") {
     newSilentDesign

--- a/airframe-di/src/test/scala-2/wvlet/airframe/legacy/BindLocalTest.scala
+++ b/airframe-di/src/test/scala-2/wvlet/airframe/legacy/BindLocalTest.scala
@@ -17,12 +17,12 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import wvlet.airspec.AirSpec
 
-import wvlet.airframe._
+import wvlet.airframe.*
 
 /**
   */
 class BindLocalTest extends AirSpec {
-  import BindLocalTest._
+  import BindLocalTest.*
 
   class LocalX(counter: AtomicInteger) extends AutoCloseable {
     override def close(): Unit = {

--- a/airframe-di/src/test/scala-2/wvlet/airframe/legacy/BindTest.scala
+++ b/airframe-di/src/test/scala-2/wvlet/airframe/legacy/BindTest.scala
@@ -15,7 +15,7 @@ package wvlet.airframe.legacy
 
 import wvlet.airspec.AirSpec
 
-import wvlet.airframe._
+import wvlet.airframe.*
 
 object BindTest {
   class X {
@@ -30,7 +30,7 @@ object BindTest {
 /**
   */
 class BindTest extends AirSpec {
-  import BindTest._
+  import BindTest.*
 
   test("allow provider based initialization") {
     val s = newSilentDesign.build[Bind] { b =>

--- a/airframe-di/src/test/scala-2/wvlet/airframe/legacy/ChildSessionTest.scala
+++ b/airframe-di/src/test/scala-2/wvlet/airframe/legacy/ChildSessionTest.scala
@@ -18,7 +18,7 @@ import wvlet.airspec.AirSpec
 import wvlet.log.LogSupport
 
 import scala.util.Random
-import wvlet.airframe._
+import wvlet.airframe.*
 
 object ChildSessionTest {
   case class HttpRequest(path: String, userName: String)
@@ -107,7 +107,7 @@ object ChildSessionTest {
 /**
   */
 class ChildSessionTest extends AirSpec {
-  import ChildSessionTest._
+  import ChildSessionTest.*
   test("support creating a child session") {
     requestCount.get() shouldBe 0
     serverDesign.build[HttpServer] { server =>

--- a/airframe-di/src/test/scala-2/wvlet/airframe/legacy/ConstructorInjectionTest.scala
+++ b/airframe-di/src/test/scala-2/wvlet/airframe/legacy/ConstructorInjectionTest.scala
@@ -16,7 +16,7 @@ package wvlet.airframe.legacy
 import wvlet.airspec.AirSpec
 
 import scala.util.Random
-import wvlet.airframe._
+import wvlet.airframe.*
 
 object ConstructorInjectionTest {
 
@@ -32,7 +32,7 @@ object ConstructorInjectionTest {
   */
 class ConstructorInjectionTest extends AirSpec {
 
-  import ConstructorInjectionTest._
+  import ConstructorInjectionTest.*
 
   test("constructor injection should bind singleton to the same type") {
     newSilentDesign.build[Rep] { r =>

--- a/airframe-di/src/test/scala-2/wvlet/airframe/legacy/DISupportTest.scala
+++ b/airframe-di/src/test/scala-2/wvlet/airframe/legacy/DISupportTest.scala
@@ -15,7 +15,7 @@ package wvlet.airframe.legacy
 
 import wvlet.airspec.AirSpec
 
-import wvlet.airframe._
+import wvlet.airframe.*
 
 /**
   */

--- a/airframe-di/src/test/scala-2/wvlet/airframe/legacy/DefaultValueTest.scala
+++ b/airframe-di/src/test/scala-2/wvlet/airframe/legacy/DefaultValueTest.scala
@@ -25,7 +25,7 @@ object DefaultValueTest {
 /**
   */
 class DefaultValueTest extends AirSpec {
-  import DefaultValueTest._
+  import DefaultValueTest.*
   test("populate default values") { (b: B) =>
     b.a shouldBe A()
   }

--- a/airframe-di/src/test/scala-2/wvlet/airframe/legacy/DependencyTest.scala
+++ b/airframe-di/src/test/scala-2/wvlet/airframe/legacy/DependencyTest.scala
@@ -16,7 +16,7 @@ package wvlet.airframe.legacy
 import wvlet.airframe.AirframeException.MISSING_DEPENDENCY
 import wvlet.airspec.AirSpec
 
-import wvlet.airframe._
+import wvlet.airframe.*
 
 object DependencyTest1 {
   trait A {

--- a/airframe-di/src/test/scala-2/wvlet/airframe/legacy/DesignBuildTest.scala
+++ b/airframe-di/src/test/scala-2/wvlet/airframe/legacy/DesignBuildTest.scala
@@ -15,7 +15,7 @@ package wvlet.airframe.legacy
 
 import wvlet.airspec.AirSpec
 
-import wvlet.airframe._
+import wvlet.airframe.*
 
 /**
   */

--- a/airframe-di/src/test/scala-2/wvlet/airframe/legacy/DisableNoDefaultInstanceCreationTest.scala
+++ b/airframe-di/src/test/scala-2/wvlet/airframe/legacy/DisableNoDefaultInstanceCreationTest.scala
@@ -15,7 +15,7 @@ package wvlet.airframe.legacy
 
 import wvlet.airframe.AirframeException.MISSING_DEPENDENCY
 import wvlet.airspec.AirSpec
-import wvlet.airframe._
+import wvlet.airframe.*
 
 object DisableNoDefaultInstanceCreationTest {
   case class Component(config: Config)
@@ -23,7 +23,7 @@ object DisableNoDefaultInstanceCreationTest {
 }
 
 class DisableNoDefaultInstanceCreationTest extends AirSpec {
-  import DisableNoDefaultInstanceCreationTest._
+  import DisableNoDefaultInstanceCreationTest.*
 
   test("disable implicit instance creation") {
     val d = Design.newDesign.bind[Component].toSingleton.noDefaultInstanceInjection

--- a/airframe-di/src/test/scala-2/wvlet/airframe/legacy/FactoryBindingTest.scala
+++ b/airframe-di/src/test/scala-2/wvlet/airframe/legacy/FactoryBindingTest.scala
@@ -14,7 +14,7 @@
 package wvlet.airframe.legacy
 
 import wvlet.airspec.AirSpec
-import wvlet.airframe._
+import wvlet.airframe.*
 
 object FactoryBindingTest {
   case class MyConfig(a: Int)
@@ -59,7 +59,7 @@ object FactoryBindingTest {
 /**
   */
 class FactoryBindingTest extends AirSpec {
-  import FactoryBindingTest._
+  import FactoryBindingTest.*
 
   val c1 = MyConfig(10)
   val c2 = MyConfig2(20)

--- a/airframe-di/src/test/scala-2/wvlet/airframe/legacy/HigherKindTypeTest.scala
+++ b/airframe-di/src/test/scala-2/wvlet/airframe/legacy/HigherKindTypeTest.scala
@@ -16,7 +16,7 @@ package wvlet.airframe.legacy
 import wvlet.airspec.AirSpec
 
 import scala.language.higherKinds
-import wvlet.airframe._
+import wvlet.airframe.*
 
 object HigherKindTypeTest {
   trait Holder[M[_]] {
@@ -38,7 +38,7 @@ object HigherKindTypeTest {
   }
 }
 
-import HigherKindTypeTest._
+import HigherKindTypeTest.*
 
 class HigherKindTypeTest extends AirSpec {
   val d =

--- a/airframe-di/src/test/scala-2/wvlet/airframe/legacy/ImplicitArgTest.scala
+++ b/airframe-di/src/test/scala-2/wvlet/airframe/legacy/ImplicitArgTest.scala
@@ -14,7 +14,7 @@
 package wvlet.airframe.legacy
 
 import wvlet.airspec.AirSpec
-import wvlet.airframe._
+import wvlet.airframe.*
 
 object ImplicitArgTest {
   case class ImplA(a: String)(implicit val b: Int)
@@ -24,7 +24,7 @@ object ImplicitArgTest {
 /**
   */
 class ImplicitArgTest extends AirSpec {
-  import ImplicitArgTest._
+  import ImplicitArgTest.*
 
   test("support implicit args") {
     val d = newDesign

--- a/airframe-di/src/test/scala-2/wvlet/airframe/legacy/MapBindingTest.scala
+++ b/airframe-di/src/test/scala-2/wvlet/airframe/legacy/MapBindingTest.scala
@@ -14,15 +14,15 @@
 package wvlet.airframe.legacy
 
 import wvlet.log.LogSupport
-import wvlet.airframe.surface.tag._
+import wvlet.airframe.surface.tag.*
 import wvlet.airspec.AirSpec
 
-import wvlet.airframe._
+import wvlet.airframe.*
 
 /**
   */
 class MapBindingTest extends AirSpec {
-  import MapBindingTest._
+  import MapBindingTest.*
 
   test("support map binding") {
     val d = newSilentDesign.bind[Mapper].toSingleton.bind[String @@ InfoHandler].toInstance("info")

--- a/airframe-di/src/test/scala-2/wvlet/airframe/legacy/PathDependentTypeTest.scala
+++ b/airframe-di/src/test/scala-2/wvlet/airframe/legacy/PathDependentTypeTest.scala
@@ -14,13 +14,13 @@
 package wvlet.airframe.legacy
 import wvlet.airframe.surface.Surface
 import wvlet.airspec.AirSpec
-import wvlet.airframe._
+import wvlet.airframe.*
 
 /**
   */
 class PathDependentTypeTest extends AirSpec {
   test("pass dependent types") {
-    import PathDependentType._
+    import PathDependentType.*
     val s = Surface.of[JdbcProfile#Backend#Database]
 
     val d = newDesign.noLifeCycleLogging

--- a/airframe-di/src/test/scala-2/wvlet/airframe/legacy/ProviderTest.scala
+++ b/airframe-di/src/test/scala-2/wvlet/airframe/legacy/ProviderTest.scala
@@ -16,7 +16,7 @@ package wvlet.airframe.legacy
 import wvlet.airspec.AirSpec
 import wvlet.log.LogSupport
 
-import wvlet.airframe._
+import wvlet.airframe.*
 
 object ProviderExample extends Serializable {
   case class D1(id: Int)
@@ -55,7 +55,7 @@ object ProviderExample extends Serializable {
   def provider5(d1: D1, d2: D2, d3: D3, d4: D4, d5: D5): App = App(d1, d2, d3, d4, d5)
 }
 
-import wvlet.airframe.legacy.ProviderExample._
+import wvlet.airframe.legacy.ProviderExample.*
 
 trait ProviderExample {
   // Constructor binding (singleton)

--- a/airframe-di/src/test/scala-2/wvlet/airframe/legacy/SessionBuilderTest.scala
+++ b/airframe-di/src/test/scala-2/wvlet/airframe/legacy/SessionBuilderTest.scala
@@ -15,7 +15,7 @@ package wvlet.airframe.legacy
 
 import wvlet.airframe.lifecycle.{LifeCycleEventHandler, LifeCycleManager}
 import wvlet.airspec.AirSpec
-import wvlet.airframe._
+import wvlet.airframe.*
 
 /**
   */

--- a/airframe-di/src/test/scala-2/wvlet/airframe/legacy/SessionTest.scala
+++ b/airframe-di/src/test/scala-2/wvlet/airframe/legacy/SessionTest.scala
@@ -14,7 +14,7 @@
 package wvlet.airframe.legacy
 
 import wvlet.airspec.AirSpec
-import wvlet.airframe._
+import wvlet.airframe.*
 
 trait HelloBind {}
 

--- a/airframe-di/src/test/scala-2/wvlet/airframe/legacy/SingletonTest.scala
+++ b/airframe-di/src/test/scala-2/wvlet/airframe/legacy/SingletonTest.scala
@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import wvlet.airspec.AirSpec
 import wvlet.log.{LogLevel, LogSupport, Logger}
-import wvlet.airframe._
+import wvlet.airframe.*
 
 object SingletonTest {
   type TraitCounter = AtomicInteger
@@ -60,7 +60,7 @@ object SingletonTest {
   }
 }
 
-import SingletonTest._
+import SingletonTest.*
 
 /**
   */

--- a/airframe-di/src/test/scala-2/wvlet/airframe/legacy/TaggedBindingTest.scala
+++ b/airframe-di/src/test/scala-2/wvlet/airframe/legacy/TaggedBindingTest.scala
@@ -14,9 +14,9 @@
 package wvlet.airframe.legacy
 
 import wvlet.airframe.surface.Surface
-import wvlet.airframe.surface.tag._
+import wvlet.airframe.surface.tag.*
 import wvlet.airspec.AirSpec
-import wvlet.airframe._
+import wvlet.airframe.*
 
 object TaggedBindingTest {
   case class Fruit(name: String)
@@ -34,7 +34,7 @@ object TaggedBindingTest {
   }
 }
 
-import TaggedBindingTest._
+import TaggedBindingTest.*
 
 /**
   */

--- a/airframe-di/src/test/scala-2/wvlet/airframe/legacy/lifecycle/ExtendedCloseableTest.scala
+++ b/airframe-di/src/test/scala-2/wvlet/airframe/legacy/lifecycle/ExtendedCloseableTest.scala
@@ -31,7 +31,7 @@ class ExtendedCloseableTest extends AirSpec {
 
   trait B extends A
 
-  import wvlet.airframe._
+  import wvlet.airframe.*
 
   test("close only once") {
     val d = newSilentDesign

--- a/airframe-di/src/test/scala-2/wvlet/airframe/legacy/lifecycle/LazyStartTest.scala
+++ b/airframe-di/src/test/scala-2/wvlet/airframe/legacy/lifecycle/LazyStartTest.scala
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import wvlet.airframe.{bind, newSilentDesign}
 import wvlet.airspec.AirSpec
 import wvlet.log.LogSupport
-import wvlet.airframe._
+import wvlet.airframe.*
 
 object LazyStartTest {
   type F1 = AtomicBoolean
@@ -40,7 +40,7 @@ object LazyStartTest {
 /**
   */
 class LazyStartTest extends AirSpec {
-  import LazyStartTest._
+  import LazyStartTest.*
 
   val f1 = new AtomicBoolean(false)
   val f2 = new AtomicBoolean(false)

--- a/airframe-di/src/test/scala-2/wvlet/airframe/legacy/lifecycle/LifeCycleManagerTest.scala
+++ b/airframe-di/src/test/scala-2/wvlet/airframe/legacy/lifecycle/LifeCycleManagerTest.scala
@@ -19,7 +19,7 @@ import wvlet.airframe.AirframeException.{MULTIPLE_SHUTDOWN_FAILURES, SHUTDOWN_FA
 import wvlet.airframe.{bind, newDesign, newSilentDesign}
 import wvlet.airspec.AirSpec
 import wvlet.log.{LogLevel, LogSupport, Logger}
-import wvlet.airframe._
+import wvlet.airframe.*
 
 class Counter extends LogSupport {
   val initialized = new AtomicInteger(0)

--- a/airframe-di/src/test/scala-3/wvlet/airframe/di/TraitFactoryTest.scala
+++ b/airframe-di/src/test/scala-3/wvlet/airframe/di/TraitFactoryTest.scala
@@ -15,7 +15,7 @@ package wvlet.airframe.di
 
 import wvlet.airspec.AirSpec
 import scala.language.experimental
-import wvlet.airframe._
+import wvlet.airframe.*
 import wvlet.airframe.surface.Surface
 
 object TraitFactoryTest extends AirSpec {
@@ -23,7 +23,7 @@ object TraitFactoryTest extends AirSpec {
   trait A
 
   test("register trait factory") {
-    if (isScala3) {
+    if isScala3 then {
       pending("In Scala 3.3.1, creating a new trait instance via macro is still experimental")
     }
     registerTraitFactory[A]

--- a/airframe-di/src/test/scala/wvlet/airframe/ProviderExample.scala
+++ b/airframe-di/src/test/scala/wvlet/airframe/ProviderExample.scala
@@ -35,7 +35,7 @@ object ProviderVal {
 }
 
 object ProviderSerializationExample extends Serializable {
-  import wvlet.airframe.ProviderVal._
+  import wvlet.airframe.ProviderVal.*
 
   val d1 = D1(1)
   val d2 = D2(2)

--- a/airframe-di/src/test/scala/wvlet/airframe/di/ConstructorInjectionTest.scala
+++ b/airframe-di/src/test/scala/wvlet/airframe/di/ConstructorInjectionTest.scala
@@ -32,7 +32,7 @@ object ConstructorInjectionTest {
   */
 class ConstructorInjectionTest extends AirSpec {
 
-  import ConstructorInjectionTest._
+  import ConstructorInjectionTest.*
 
   test("constructor injection should bind singleton to the same type") {
     Design.newSilentDesign.build[Rep] { r =>

--- a/airframe-di/src/test/scala/wvlet/airframe/di/DITest.scala
+++ b/airframe-di/src/test/scala/wvlet/airframe/di/DITest.scala
@@ -11,7 +11,7 @@ import java.io.PrintStream
 import java.util.concurrent.atomic.AtomicInteger
 import scala.util.Random
 
-import wvlet.airframe._
+import wvlet.airframe.*
 
 /**
   */

--- a/airframe-di/src/test/scala/wvlet/airframe/di/DefaultValueTest.scala
+++ b/airframe-di/src/test/scala/wvlet/airframe/di/DefaultValueTest.scala
@@ -15,7 +15,7 @@ object DefaultValueTest {
 /**
   */
 class DefaultValueTest extends AirSpec {
-  import DefaultValueTest._
+  import DefaultValueTest.*
   test("populate default values") {
     Design.newSilentDesign.build[B] { b =>
       b.a shouldBe A()

--- a/airframe-di/src/test/scala/wvlet/airframe/di/DisableNoDefaultInstanceCreationTest.scala
+++ b/airframe-di/src/test/scala/wvlet/airframe/di/DisableNoDefaultInstanceCreationTest.scala
@@ -23,7 +23,7 @@ object DisableNoDefaultInstanceCreationTest {
 }
 
 class DisableNoDefaultInstanceCreationTest extends AirSpec {
-  import DisableNoDefaultInstanceCreationTest._
+  import DisableNoDefaultInstanceCreationTest.*
 
   test("disable implicit instance creation") {
     val d = Design.newSilentDesign.bind[Component].toSingleton.noDefaultInstanceInjection

--- a/airframe-di/src/test/scala/wvlet/airframe/di/HigherKindTypeTest.scala
+++ b/airframe-di/src/test/scala/wvlet/airframe/di/HigherKindTypeTest.scala
@@ -39,7 +39,7 @@ object HigherKindTypeTest {
   }
 }
 
-import HigherKindTypeTest._
+import HigherKindTypeTest.*
 
 class HigherKindTypeTest extends AirSpec {
   val d =

--- a/airframe-di/src/test/scala/wvlet/airframe/di/ImplicitArgTest.scala
+++ b/airframe-di/src/test/scala/wvlet/airframe/di/ImplicitArgTest.scala
@@ -24,7 +24,7 @@ object ImplicitArgTest {
 /**
   */
 class ImplicitArgTest extends AirSpec {
-  import ImplicitArgTest._
+  import ImplicitArgTest.*
 
   test("support implicit args") {
     val d = Design.newDesign

--- a/airframe-di/src/test/scala/wvlet/airframe/di/MapBindingTest.scala
+++ b/airframe-di/src/test/scala/wvlet/airframe/di/MapBindingTest.scala
@@ -20,7 +20,7 @@ import wvlet.airspec.AirSpec
 /**
   */
 class MapBindingTest extends AirSpec {
-  import MapBindingTest._
+  import MapBindingTest.*
 
   test("support map binding") {
     val d = Design.newSilentDesign

--- a/airframe-di/src/test/scala/wvlet/airframe/di/PathDependentTypeTest.scala
+++ b/airframe-di/src/test/scala/wvlet/airframe/di/PathDependentTypeTest.scala
@@ -20,7 +20,7 @@ import wvlet.airspec.AirSpec
   */
 class PathDependentTypeTest extends AirSpec {
   test("pass dependent types") {
-    import PathDependentType._
+    import PathDependentType.*
     val s = Surface.of[JdbcProfile#Backend#Database]
 
     val d = Design.newSilentDesign

--- a/airframe-di/src/test/scala/wvlet/airframe/di/ProviderTest.scala
+++ b/airframe-di/src/test/scala/wvlet/airframe/di/ProviderTest.scala
@@ -54,7 +54,7 @@ object ProviderExample extends Serializable {
   def provider5(d1: D1, d2: D2, d3: D3, d4: D4, d5: D5): App = App(d1, d2, d3, d4, d5)
 }
 
-import wvlet.airframe.di.ProviderExample._
+import wvlet.airframe.di.ProviderExample.*
 
 class SingletonProviderTest extends AirSpec {
   test("build singleton from provider bindings") {

--- a/airframe-di/src/test/scala/wvlet/airframe/di/SingletonTest.scala
+++ b/airframe-di/src/test/scala/wvlet/airframe/di/SingletonTest.scala
@@ -49,7 +49,7 @@ object SingletonTest {
 /**
   */
 class SingletonTest extends AirSpec {
-  import wvlet.airframe.di.SingletonTest._
+  import wvlet.airframe.di.SingletonTest.*
 
   val d =
     Design.newDesign

--- a/airframe-di/src/test/scala/wvlet/airframe/di/TaggedBindingTest.scala
+++ b/airframe-di/src/test/scala/wvlet/airframe/di/TaggedBindingTest.scala
@@ -14,7 +14,7 @@
 package wvlet.airframe.di
 import wvlet.airframe.Design
 import wvlet.airframe.surface.Surface
-import wvlet.airframe.surface.tag._
+import wvlet.airframe.surface.tag.*
 import wvlet.airspec.AirSpec
 
 /**

--- a/airframe-di/src/test/scala/wvlet/airframe/di/lifecycle/LazyStartTest.scala
+++ b/airframe-di/src/test/scala/wvlet/airframe/di/lifecycle/LazyStartTest.scala
@@ -31,7 +31,7 @@ object LazyStartTest {
   */
 class LazyStartTest extends AirSpec {
 
-  import LazyStartTest._
+  import LazyStartTest.*
 
   val f1 = new AtomicBoolean(false)
   val f2 = new AtomicBoolean(false)

--- a/airframe-fluentd/src/main/scala/wvlet/airframe/fluentd/FluentdLogger.scala
+++ b/airframe-fluentd/src/main/scala/wvlet/airframe/fluentd/FluentdLogger.scala
@@ -60,7 +60,7 @@ class FluentdLogger(val tagPrefix: Option[String] = None, useExtendedEventTime: 
   }
 
   private def toJavaMap(event: Map[String, Any]): java.util.Map[String, AnyRef] = {
-    import scala.jdk.CollectionConverters._
+    import scala.jdk.CollectionConverters.*
     (for ((k, v) <- event) yield {
       k -> v.asInstanceOf[AnyRef]
     }).asJava

--- a/airframe-fluentd/src/main/scala/wvlet/airframe/fluentd/MetricLogger.scala
+++ b/airframe-fluentd/src/main/scala/wvlet/airframe/fluentd/MetricLogger.scala
@@ -65,7 +65,7 @@ class MetricLoggerFactory(
   def getLoggerWithTagPrefix(tagPrefix: String): MetricLogger =
     fluentdClient.withTagPrefix(tagPrefix)
 
-  import scala.jdk.CollectionConverters._
+  import scala.jdk.CollectionConverters.*
 
   private val loggerCache = new ConcurrentHashMap[Surface, TypedMetricLogger[_]]().asScala
 

--- a/airframe-fluentd/src/test/scala/wvlet/airframe/fluentd/FluencyTest.scala
+++ b/airframe-fluentd/src/test/scala/wvlet/airframe/fluentd/FluencyTest.scala
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 import javax.annotation.{PostConstruct, PreDestroy}
 import wvlet.airframe.codec.PrimitiveCodec.ValueCodec
-import wvlet.airframe._
+import wvlet.airframe.*
 import wvlet.airspec.AirSpec
 import wvlet.log.LogSupport
 import wvlet.log.io.IOUtil

--- a/airframe-fluentd/src/test/scala/wvlet/airframe/fluentd/FluentdLoggerTest.scala
+++ b/airframe-fluentd/src/test/scala/wvlet/airframe/fluentd/FluentdLoggerTest.scala
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 package wvlet.airframe.fluentd
-import wvlet.airframe._
+import wvlet.airframe.*
 import wvlet.airframe.fluentd.FluentdLoggerTest.{
   Logger1,
   Logger2,

--- a/airframe-http-codegen/src/main/scala/wvlet/airframe/http/codegen/HttpCodeGenerator.scala
+++ b/airframe-http-codegen/src/main/scala/wvlet/airframe/http/codegen/HttpCodeGenerator.scala
@@ -147,7 +147,7 @@ object HttpCodeGenerator extends LogSupport {
 
 }
 
-import wvlet.airframe.launcher._
+import wvlet.airframe.launcher.*
 
 case class HttpCodeGeneratorOption(
     @option(prefix = "-cp", description = "application classpaths")

--- a/airframe-http-codegen/src/main/scala/wvlet/airframe/http/codegen/RouteScanner.scala
+++ b/airframe-http-codegen/src/main/scala/wvlet/airframe/http/codegen/RouteScanner.scala
@@ -111,7 +111,7 @@ object RouteScanner extends LogSupport {
     // This is because we generally cannot call classOf[MyObj$] in Scala other than scanning classes directly from class loaders.
     for (cl <- classes if !cl.getName.endsWith("$")) {
       trace(f"Searching ${cl} for HTTP endpoints")
-      import wvlet.airframe.surface.reflect._
+      import wvlet.airframe.surface.reflect.*
       lazy val s       = ReflectSurfaceFactory.ofClass(cl)
       lazy val methods = ReflectSurfaceFactory.methodsOfClass(cl)
       val hasRPC       = findDeclaredAnnotation[RPC](cl).isDefined

--- a/airframe-http-codegen/src/main/scala/wvlet/airframe/http/codegen/client/GrpcClientGenerator.scala
+++ b/airframe-http-codegen/src/main/scala/wvlet/airframe/http/codegen/client/GrpcClientGenerator.scala
@@ -29,7 +29,7 @@ import wvlet.log.LogSupport
   */
 object GrpcClientGenerator extends HttpClientGenerator with LogSupport {
 
-  import HttpClientGenerator._
+  import HttpClientGenerator.*
 
   override def name: String             = "grpc"
   override def defaultClassName: String = "ServiceGrpc"

--- a/airframe-http-codegen/src/main/scala/wvlet/airframe/http/codegen/client/RPCClientGenerator.scala
+++ b/airframe-http-codegen/src/main/scala/wvlet/airframe/http/codegen/client/RPCClientGenerator.scala
@@ -21,7 +21,7 @@ import wvlet.airframe.http.codegen.client.HttpClientGenerator.RichSurface
   * The default RPC client generator using Http.client.Sync/AsyncClient
   */
 object RPCClientGenerator extends HttpClientGenerator {
-  import ScalaHttpClientGenerator._
+  import ScalaHttpClientGenerator.*
 
   override def name: String = "rpc"
 

--- a/airframe-http-codegen/src/main/scala/wvlet/airframe/http/codegen/client/ScalaHttpClientGenerator.scala
+++ b/airframe-http-codegen/src/main/scala/wvlet/airframe/http/codegen/client/ScalaHttpClientGenerator.scala
@@ -41,11 +41,11 @@ object ScalaHttpClientGenerator {
   }
 }
 
-import ScalaHttpClientGenerator._
+import ScalaHttpClientGenerator.*
 
 object AsyncClientGenerator extends HttpClientGenerator with LogSupport {
 
-  import HttpClientGenerator._
+  import HttpClientGenerator.*
 
   override def name: String             = "async"
   override def defaultClassName: String = "ServiceClient"
@@ -105,7 +105,7 @@ object AsyncClientGenerator extends HttpClientGenerator with LogSupport {
 
 object SyncClientGenerator extends HttpClientGenerator {
 
-  import HttpClientGenerator._
+  import HttpClientGenerator.*
 
   override def name: String             = "sync"
   override def defaultClassName: String = "ServiceSyncClient"

--- a/airframe-http-codegen/src/main/scala/wvlet/airframe/http/openapi/OpenAPI.scala
+++ b/airframe-http-codegen/src/main/scala/wvlet/airframe/http/openapi/OpenAPI.scala
@@ -15,7 +15,7 @@ package wvlet.airframe.http.openapi
 
 import wvlet.airframe.codec.{MessageCodec, MessageCodecFactory}
 import wvlet.airframe.http.Router
-import wvlet.airframe.http.openapi.OpenAPI._
+import wvlet.airframe.http.openapi.OpenAPI.*
 import wvlet.airframe.json.YAMLFormatter
 import wvlet.airframe.surface.{Union2, Union3}
 

--- a/airframe-http-codegen/src/main/scala/wvlet/airframe/http/openapi/OpenAPIGenerator.scala
+++ b/airframe-http-codegen/src/main/scala/wvlet/airframe/http/openapi/OpenAPIGenerator.scala
@@ -21,8 +21,8 @@ import wvlet.airframe.json.JSON.JSONValue
 import wvlet.airframe.json.Json
 import wvlet.airframe.metrics.{Count, DataSize, ElapsedTime}
 import wvlet.airframe.msgpack.spi.{MsgPack, Value}
-import wvlet.airframe.surface._
-import wvlet.airframe.surface.reflect._
+import wvlet.airframe.surface.*
+import wvlet.airframe.surface.reflect.*
 import wvlet.airframe.ulid.ULID
 import wvlet.log.LogSupport
 
@@ -55,7 +55,7 @@ case class OpenAPIGeneratorConfig(
   */
 private[openapi] object OpenAPIGenerator extends LogSupport {
 
-  import OpenAPI._
+  import OpenAPI.*
 
   private[openapi] def buildFromRouter(router: Router, config: OpenAPIGeneratorConfig): OpenAPI = {
     val g = new OpenAPIGenerator(config)
@@ -178,10 +178,10 @@ private[openapi] object OpenAPIGenerator extends LogSupport {
 }
 
 class OpenAPIGenerator(config: OpenAPIGeneratorConfig) extends LogSupport {
-  import OpenAPI._
-  import OpenAPIGenerator._
+  import OpenAPI.*
+  import OpenAPIGenerator.*
 
-  import scala.jdk.CollectionConverters._
+  import scala.jdk.CollectionConverters.*
   private val schemaCache = {
     new ConcurrentHashMap[Surface, SchemaOrRef]().asScala
   }

--- a/airframe-http-codegen/src/test/scala/example/api/MyService.scala
+++ b/airframe-http-codegen/src/test/scala/example/api/MyService.scala
@@ -18,7 +18,7 @@ package example.api
 import java.util.UUID
 
 import wvlet.airframe.http.HttpMessage.{Request, Response}
-import wvlet.airframe.http._
+import wvlet.airframe.http.*
 
 import scala.concurrent.Future
 

--- a/airframe-http-codegen/src/test/scala/example/grpc/AliasTest.scala
+++ b/airframe-http-codegen/src/test/scala/example/grpc/AliasTest.scala
@@ -17,7 +17,7 @@ import wvlet.airframe.http.RPC
 
 @RPC
 trait AliasTest {
-  import AliasTest._
+  import AliasTest.*
   def m1(userId: UserID): StatusCode
 }
 

--- a/airframe-http-codegen/src/test/scala/example/openapi/OpenAPIExample.scala
+++ b/airframe-http-codegen/src/test/scala/example/openapi/OpenAPIExample.scala
@@ -21,7 +21,7 @@ import scala.concurrent.Future
   */
 @RPC
 trait OpenAPIRPCExample {
-  import OpenAPIRPCExample._
+  import OpenAPIRPCExample.*
 
   def zeroAryRPC: Unit
   def rpcWithPrimitive(p1: Int): Int
@@ -51,7 +51,7 @@ object OpenAPIRPCExample {
 }
 
 trait OpenAPIEndpointExample {
-  import OpenAPIEndpointExample._
+  import OpenAPIEndpointExample.*
 
   @Endpoint(method = HttpMethod.GET, path = "/v1/get0")
   def get0(): Unit

--- a/airframe-http-codegen/src/test/scala/example/rpc/RPCTestService.scala
+++ b/airframe-http-codegen/src/test/scala/example/rpc/RPCTestService.scala
@@ -18,7 +18,7 @@ import wvlet.airframe.http.{RPC, RxRouter, RxRouterProvider}
   */
 @RPC
 trait RPCTestService {
-  import RPCTestService._
+  import RPCTestService.*
   def addUser(request: CreateUserRequest): User
 }
 
@@ -31,7 +31,7 @@ object RPCTestService extends RxRouterProvider {
 
 @RPC
 trait RPCExample {
-  import RPCExample._
+  import RPCExample.*
 
   def zeroAryRPC: Unit
   def rpcWithPrimitive(p1: Int): Int

--- a/airframe-http-codegen/src/test/scala/wvlet/airframe/http/codegen/HttpClientGeneratorTest.scala
+++ b/airframe-http-codegen/src/test/scala/wvlet/airframe/http/codegen/HttpClientGeneratorTest.scala
@@ -13,8 +13,8 @@
  */
 package wvlet.airframe.http.codegen
 import java.net.URLClassLoader
-import example.api._
-import wvlet.airframe.http._
+import example.api.*
+import wvlet.airframe.http.*
 import wvlet.airframe.http.codegen.client.{AsyncClientGenerator, GrpcClientGenerator}
 import wvlet.airspec.AirSpec
 import wvlet.airframe.http.Router

--- a/airframe-http-finagle/src/main/scala/wvlet/airframe/http/finagle/FinagleClient.scala
+++ b/airframe-http-finagle/src/main/scala/wvlet/airframe/http/finagle/FinagleClient.scala
@@ -16,11 +16,11 @@ package wvlet.airframe.http.finagle
 import java.util.concurrent.TimeUnit
 import com.twitter.finagle.http.{Request, Response}
 import com.twitter.finagle.{Http, Service, http}
-import com.twitter.util._
+import com.twitter.util.*
 import wvlet.airframe.Design
 import wvlet.airframe.codec.{MessageCodec, MessageCodecFactory}
 import wvlet.airframe.control.Retry.RetryContext
-import wvlet.airframe.http._
+import wvlet.airframe.http.*
 import wvlet.airframe.http.client.HttpClients
 import wvlet.airframe.http.internal.HttpResponseBodyCodec
 import wvlet.airframe.surface.Surface

--- a/airframe-http-finagle/src/main/scala/wvlet/airframe/http/finagle/FinagleFilter.scala
+++ b/airframe-http-finagle/src/main/scala/wvlet/airframe/http/finagle/FinagleFilter.scala
@@ -18,7 +18,7 @@ import com.twitter.finagle.{Service, SimpleFilter}
 import com.twitter.util.Future
 import wvlet.airframe.Session
 import wvlet.airframe.codec.MessageCodecFactory
-import wvlet.airframe.http._
+import wvlet.airframe.http.*
 import wvlet.airframe.http.router.{ControllerProvider, HttpRequestDispatcher, ResponseHandler}
 
 /**

--- a/airframe-http-finagle/src/main/scala/wvlet/airframe/http/finagle/FinagleRetryFilter.scala
+++ b/airframe-http-finagle/src/main/scala/wvlet/airframe/http/finagle/FinagleRetryFilter.scala
@@ -16,7 +16,7 @@ package wvlet.airframe.http.finagle
 import com.twitter.finagle.http.{Request, Response, Status}
 import com.twitter.finagle.util.DefaultTimer
 import com.twitter.finagle.{Service, SimpleFilter, http}
-import com.twitter.util._
+import com.twitter.util.*
 import wvlet.airframe.control.ResultClass
 import wvlet.airframe.control.Retry.{MaxRetryException, RetryContext}
 import wvlet.airframe.http.{HttpClientException, HttpClientMaxRetryException}
@@ -28,7 +28,7 @@ import wvlet.log.LogSupport
 class FinagleRetryFilter(retry: RetryContext, timer: Timer = DefaultTimer)
     extends SimpleFilter[http.Request, http.Response]
     with LogSupport {
-  import com.twitter.conversions.DurationOps._
+  import com.twitter.conversions.DurationOps.*
 
   private[this] def schedule(d: Duration)(f: => Future[Response]) = {
     if (d > 0.seconds) {

--- a/airframe-http-finagle/src/main/scala/wvlet/airframe/http/finagle/FinagleServer.scala
+++ b/airframe-http-finagle/src/main/scala/wvlet/airframe/http/finagle/FinagleServer.scala
@@ -13,14 +13,14 @@
  */
 package wvlet.airframe.http.finagle
 import java.lang.reflect.InvocationTargetException
-import com.twitter.finagle._
+import com.twitter.finagle.*
 import com.twitter.finagle.http.{Request, Response, Status}
 import com.twitter.finagle.stats.StatsReceiver
 import com.twitter.finagle.tracing.Tracer
 import com.twitter.util.{Await, Future}
 
 import javax.annotation.PostConstruct
-import wvlet.airframe._
+import wvlet.airframe.*
 import wvlet.airframe.codec.MessageCodec
 import wvlet.airframe.control.MultipleExceptions
 import wvlet.airframe.http.finagle.FinagleServer.FinagleService

--- a/airframe-http-finagle/src/main/scala/wvlet/airframe/http/finagle/filter/HttpAccessLogFilter.scala
+++ b/airframe-http-finagle/src/main/scala/wvlet/airframe/http/finagle/filter/HttpAccessLogFilter.scala
@@ -16,7 +16,7 @@ import com.twitter.finagle.http.{HeaderMap, Request, Response}
 import com.twitter.finagle.{Service, SimpleFilter}
 import com.twitter.util.Future
 import wvlet.airframe.control.MultipleExceptions
-import wvlet.airframe.http.finagle.filter.HttpAccessLogFilter._
+import wvlet.airframe.http.finagle.filter.HttpAccessLogFilter.*
 import wvlet.airframe.http.finagle.{FinagleBackend, FinagleServer}
 import wvlet.airframe.http.internal.{HttpLogs, RPCCallContext}
 import wvlet.airframe.http.{HttpAccessLogWriter, HttpBackend, HttpHeader, HttpStatus}

--- a/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/ErrorResponseTest.scala
+++ b/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/ErrorResponseTest.scala
@@ -14,7 +14,7 @@
 package wvlet.airframe.http.finagle
 import com.twitter.finagle.http.Request
 import wvlet.airframe.codec.MessageCodec
-import wvlet.airframe.http._
+import wvlet.airframe.http.*
 import wvlet.airspec.AirSpec
 import wvlet.log.LogSupport
 

--- a/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/FinagleClientTest.scala
+++ b/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/FinagleClientTest.scala
@@ -17,7 +17,7 @@ import com.twitter.finagle.http.{Request, Response, Status}
 import com.twitter.util.Await
 import wvlet.airframe.Design
 import wvlet.airframe.control.Control.withResource
-import wvlet.airframe.http._
+import wvlet.airframe.http.*
 import wvlet.airspec.AirSpec
 import wvlet.log.LogSupport
 

--- a/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/FinagleRouterTest.scala
+++ b/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/FinagleRouterTest.scala
@@ -23,7 +23,7 @@ import com.twitter.util.{Await, Future}
 import wvlet.airframe.Design
 import wvlet.airframe.codec.{JSONCodec, MessageCodec}
 import wvlet.airframe.control.Control
-import wvlet.airframe.http._
+import wvlet.airframe.http.*
 import wvlet.airframe.msgpack.spi.MessagePack
 import wvlet.airspec.AirSpec
 import wvlet.airspec.spi.AirSpecContext

--- a/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/FinagleServerFactoryTest.scala
+++ b/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/FinagleServerFactoryTest.scala
@@ -16,7 +16,7 @@ import com.twitter.finagle.Service
 import com.twitter.finagle.http.{Request, Response, Status}
 import com.twitter.finagle.tracing.ConsoleTracer
 import com.twitter.util.Future
-import wvlet.airframe.control.Control._
+import wvlet.airframe.control.Control.*
 import wvlet.airframe.http.Router
 import wvlet.airspec.AirSpec
 

--- a/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/FinagleTest.scala
+++ b/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/FinagleTest.scala
@@ -22,7 +22,7 @@ import wvlet.airspec.AirSpec
 /**
   */
 class FinagleTest extends AirSpec {
-  import wvlet.airframe.http.finagle._
+  import wvlet.airframe.http.finagle.*
 
   test("provide facade of http requests") {
     Seq(

--- a/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/HttpAccessLogTest.scala
+++ b/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/HttpAccessLogTest.scala
@@ -18,7 +18,7 @@ import com.twitter.util.Future
 import wvlet.airframe.codec.MessageCodec
 import wvlet.airframe.control.Resource
 import wvlet.airframe.http.HttpAccessLogWriter.JSONHttpAccessLogWriter
-import wvlet.airframe.http._
+import wvlet.airframe.http.*
 import wvlet.airframe.http.finagle.filter.HttpAccessLogFilter
 import wvlet.airframe.newDesign
 import wvlet.airframe.surface.secret

--- a/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/HttpFilterTest.scala
+++ b/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/HttpFilterTest.scala
@@ -16,7 +16,7 @@ package wvlet.airframe.http.finagle
 import com.twitter.finagle.http.{Request, Response, Status, Version}
 import com.twitter.util.{Await, Future}
 import wvlet.airframe.control.Control.withResource
-import wvlet.airframe.http._
+import wvlet.airframe.http.*
 import wvlet.airspec.AirSpec
 import wvlet.log.LogSupport
 import wvlet.log.io.IOUtil
@@ -51,7 +51,7 @@ class LogStore extends LogSupport {
 }
 
 trait LogFilterExample extends FinagleFilter {
-  import wvlet.airframe._
+  import wvlet.airframe.*
   private val logStore = bind[LogStore]
 
   override def apply(request: Request, context: FinagleContext): Future[Response] = {

--- a/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/LeafFilterTest.scala
+++ b/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/LeafFilterTest.scala
@@ -31,7 +31,7 @@ object LeafFilterTest {
 /**
   */
 class LeafFilterTest extends AirSpec {
-  import LeafFilterTest._
+  import LeafFilterTest.*
 
   override protected def design: Design = {
     newFinagleServerDesign(name = "leaf-filter-test", router = Router.add[MyFilter])

--- a/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/StaticContentTest.scala
+++ b/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/StaticContentTest.scala
@@ -15,7 +15,7 @@ package wvlet.airframe.http.finagle
 import com.twitter.finagle.http.Response
 import wvlet.airframe.Design
 import wvlet.airframe.control.Control
-import wvlet.airframe.http._
+import wvlet.airframe.http.*
 import wvlet.airspec.AirSpec
 import wvlet.log.io.{IOUtil, Resource}
 

--- a/airframe-http-grpc/src/main/scala/wvlet/airframe/http/grpc/GrpcClient.scala
+++ b/airframe-http-grpc/src/main/scala/wvlet/airframe/http/grpc/GrpcClient.scala
@@ -38,7 +38,7 @@ case class GrpcMethod[Req, Resp](
 )
 
 class GrpcClient(channel: io.grpc.Channel, config: GrpcClientConfig) {
-  import GrpcClient._
+  import GrpcClient.*
 
   private def prepareRPCRequestBody[Req, Resp](method: GrpcMethod[Req, Resp], request: Req): Array[Byte] = {
     try {

--- a/airframe-http-grpc/src/main/scala/wvlet/airframe/http/grpc/GrpcClientInterceptor.scala
+++ b/airframe-http-grpc/src/main/scala/wvlet/airframe/http/grpc/GrpcClientInterceptor.scala
@@ -19,7 +19,7 @@ import wvlet.airframe.http.RPCEncoding
 
 object GrpcClientInterceptor {
   def wrap(c: Channel, encoding: RPCEncoding = RPCEncoding.MsgPack): Channel = {
-    import GrpcContext._
+    import GrpcContext.*
     val newHeaders = new Metadata()
     newHeaders.put(
       Metadata.Key.of("x-airframe-client-version", Metadata.ASCII_STRING_MARSHALLER),

--- a/airframe-http-grpc/src/main/scala/wvlet/airframe/http/grpc/GrpcContext.scala
+++ b/airframe-http-grpc/src/main/scala/wvlet/airframe/http/grpc/GrpcContext.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.http.grpc
 
-import io.grpc._
+import io.grpc.*
 import wvlet.airframe.http.{Http, HttpMessage, RPCContext, RPCEncoding}
 import wvlet.log.LogSupport
 
@@ -49,7 +49,7 @@ object GrpcContext {
 
 }
 
-import GrpcContext._
+import GrpcContext.*
 
 case class GrpcContext(
     authority: Option[String],
@@ -87,7 +87,7 @@ case class GrpcContext(
   }
 
   override def httpRequest: HttpMessage.Request = {
-    import scala.jdk.CollectionConverters._
+    import scala.jdk.CollectionConverters.*
     var request = Http.POST(s"/${descriptor.getFullMethodName}")
     for (k <- metadata.keys().asScala) {
       request = request.withHeader(k, metadata.get(Metadata.Key.of(k, Metadata.ASCII_STRING_MARSHALLER)))

--- a/airframe-http-grpc/src/main/scala/wvlet/airframe/http/grpc/GrpcServer.scala
+++ b/airframe-http-grpc/src/main/scala/wvlet/airframe/http/grpc/GrpcServer.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.http.grpc
 
-import io.grpc._
+import io.grpc.*
 import wvlet.airframe.codec.MessageCodecFactory
 import wvlet.airframe.http.{Router, RxRouter}
 import wvlet.airframe.http.grpc.internal.{GrpcRequestLogger, GrpcServiceBuilder}

--- a/airframe-http-grpc/src/main/scala/wvlet/airframe/http/grpc/internal/GrpcContextTrackInterceptor.scala
+++ b/airframe-http-grpc/src/main/scala/wvlet/airframe/http/grpc/internal/GrpcContextTrackInterceptor.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.http.grpc.internal
 
-import io.grpc._
+import io.grpc.*
 import wvlet.airframe.http.{Compat, RPCContext}
 import wvlet.airframe.http.grpc.GrpcContext
 import wvlet.log.LogSupport

--- a/airframe-http-grpc/src/main/scala/wvlet/airframe/http/grpc/internal/GrpcRequestHandler.scala
+++ b/airframe-http-grpc/src/main/scala/wvlet/airframe/http/grpc/internal/GrpcRequestHandler.scala
@@ -24,7 +24,7 @@ import wvlet.airframe.http.{RPCEncoding, RPCStatus}
 import wvlet.airframe.http.router.{Route, HttpRequestMapper}
 import wvlet.airframe.msgpack.spi.MsgPack
 import wvlet.airframe.msgpack.spi.Value.MapValue
-import wvlet.airframe.rx._
+import wvlet.airframe.rx.*
 import wvlet.airframe.surface.{CName, MethodSurface, Surface}
 import wvlet.log.LogSupport
 

--- a/airframe-http-grpc/src/main/scala/wvlet/airframe/http/grpc/internal/GrpcRequestLogger.scala
+++ b/airframe-http-grpc/src/main/scala/wvlet/airframe/http/grpc/internal/GrpcRequestLogger.scala
@@ -87,7 +87,7 @@ object GrpcRequestLogger extends LogSupport {
       }.getOrElse(Map.empty)
   }
 
-  import scala.jdk.CollectionConverters._
+  import scala.jdk.CollectionConverters.*
 
   private def logAttributes(a: Attributes): Map[String, Any] = {
     val m = ListMap.newBuilder[String, Any]

--- a/airframe-http-grpc/src/main/scala/wvlet/airframe/http/grpc/internal/GrpcResponseHeaderInterceptor.scala
+++ b/airframe-http-grpc/src/main/scala/wvlet/airframe/http/grpc/internal/GrpcResponseHeaderInterceptor.scala
@@ -30,7 +30,7 @@ private[grpc] object GrpcResponseHeaderInterceptor extends ServerInterceptor {
     next.startCall(
       new SimpleForwardingServerCall[ReqT, RespT](call) {
         override def sendHeaders(responseHeaders: Metadata): Unit = {
-          import GrpcContext._
+          import GrpcContext.*
           // [warning] Currently setting the content-type here has no effect because
           // grpc-java always uses content-type: application/grpc
           // https://github.com/grpc/grpc-java/issues/7321

--- a/airframe-http-grpc/src/main/scala/wvlet/airframe/http/grpc/internal/GrpcServiceBuilder.scala
+++ b/airframe-http-grpc/src/main/scala/wvlet/airframe/http/grpc/internal/GrpcServiceBuilder.scala
@@ -29,7 +29,7 @@ import wvlet.airframe.http.grpc.{
 import wvlet.airframe.http.router.{Route, HttpRequestMapper}
 import wvlet.airframe.msgpack.spi.MsgPack
 import wvlet.airframe.surface.{MethodParameter, MethodSurface, Surface, TypeName}
-import wvlet.airframe.rx._
+import wvlet.airframe.rx.*
 
 import java.util.concurrent.ExecutorService
 

--- a/airframe-http-grpc/src/test/scala/wvlet/airframe/http/grpc/GrpcJsonTest.scala
+++ b/airframe-http-grpc/src/test/scala/wvlet/airframe/http/grpc/GrpcJsonTest.scala
@@ -17,7 +17,7 @@ import wvlet.airframe.http.{RPCEncoding, Router}
 import wvlet.airframe.http.grpc.example.{DemoApi, DemoApiImpl}
 import wvlet.airframe.http.grpc.example.DemoApi.DemoApiClient
 import wvlet.airspec.AirSpec
-import wvlet.airframe.rx._
+import wvlet.airframe.rx.*
 
 /**
   */

--- a/airframe-http-grpc/src/test/scala/wvlet/airframe/http/grpc/GrpcTest.scala
+++ b/airframe-http-grpc/src/test/scala/wvlet/airframe/http/grpc/GrpcTest.scala
@@ -14,7 +14,7 @@
 package wvlet.airframe.http.grpc
 
 import io.grpc.MethodDescriptor.MethodType
-import io.grpc._
+import io.grpc.*
 import io.grpc.stub.{AbstractBlockingStub, ClientCalls, ServerCalls, StreamObserver}
 import wvlet.airframe.Design
 import wvlet.airspec.AirSpec

--- a/airframe-http-grpc/src/test/scala/wvlet/airframe/http/grpc/example/DemoApi.scala
+++ b/airframe-http-grpc/src/test/scala/wvlet/airframe/http/grpc/example/DemoApi.scala
@@ -28,7 +28,7 @@ import wvlet.airframe.Design
 import wvlet.airframe.codec.MessageCodecFactory
 import wvlet.airframe.http.HttpMessage.Request
 import wvlet.airframe.http.grpc.internal.{GrpcServiceBuilder, WrappedServerCallListener}
-import wvlet.airframe.http.grpc._
+import wvlet.airframe.http.grpc.*
 import wvlet.airframe.http.{Http, HttpStatus, RPC, RPCContext, RPCEncoding, RPCStatus, Router}
 import wvlet.airframe.msgpack.spi.MsgPack
 import wvlet.airframe.rx.Rx

--- a/airframe-http-netty/src/main/scala/wvlet/airframe/http/netty/NettyBackend.scala
+++ b/airframe-http-netty/src/main/scala/wvlet/airframe/http/netty/NettyBackend.scala
@@ -14,7 +14,7 @@
 package wvlet.airframe.http.netty
 
 import wvlet.airframe.http.HttpMessage.{Request, Response}
-import wvlet.airframe.http._
+import wvlet.airframe.http.*
 import wvlet.airframe.rx.Rx
 import wvlet.log.LogSupport
 

--- a/airframe-http-netty/src/main/scala/wvlet/airframe/http/netty/NettyRequestHandler.scala
+++ b/airframe-http-netty/src/main/scala/wvlet/airframe/http/netty/NettyRequestHandler.scala
@@ -15,7 +15,7 @@ package wvlet.airframe.http.netty
 
 import io.netty.buffer.Unpooled
 import io.netty.channel.{ChannelFutureListener, ChannelHandlerContext, SimpleChannelInboundHandler}
-import io.netty.handler.codec.http._
+import io.netty.handler.codec.http.*
 import wvlet.airframe.http.HttpMessage.{Request, Response}
 import wvlet.airframe.http.internal.RPCResponseFilter
 import wvlet.airframe.http.{
@@ -32,8 +32,8 @@ import wvlet.airframe.rx.{OnCompletion, OnError, OnNext, Rx, RxRunner}
 import wvlet.log.LogSupport
 
 import java.net.InetSocketAddress
-import scala.jdk.CollectionConverters._
-import NettyRequestHandler._
+import scala.jdk.CollectionConverters.*
+import NettyRequestHandler.*
 
 class NettyRequestHandler(config: NettyServerConfig, dispatcher: NettyBackend.Filter)
     extends SimpleChannelInboundHandler[FullHttpRequest]

--- a/airframe-http-netty/src/main/scala/wvlet/airframe/http/netty/NettyServer.scala
+++ b/airframe-http-netty/src/main/scala/wvlet/airframe/http/netty/NettyServer.scala
@@ -15,17 +15,17 @@ package wvlet.airframe.http.netty
 
 import io.netty.bootstrap.ServerBootstrap
 import io.netty.buffer.PooledByteBufAllocator
-import io.netty.channel._
+import io.netty.channel.*
 import io.netty.channel.epoll.{Epoll, EpollEventLoopGroup, EpollServerSocketChannel}
 import io.netty.channel.nio.NioEventLoopGroup
 import io.netty.channel.socket.nio.NioServerSocketChannel
 import io.netty.channel.unix.UnixChannelOption
-import io.netty.handler.codec.http._
+import io.netty.handler.codec.http.*
 import io.netty.handler.stream.ChunkedWriteHandler
 import wvlet.airframe.codec.MessageCodecFactory
 import wvlet.airframe.control.ThreadUtil
 import wvlet.airframe.http.HttpMessage.Response
-import wvlet.airframe.http.{HttpMessage, _}
+import wvlet.airframe.http.{HttpMessage, *}
 import wvlet.airframe.http.client.{AsyncClient, SyncClient}
 import wvlet.airframe.http.internal.{RPCLoggingFilter, LogRotationHttpLogger, RPCResponseFilter}
 import wvlet.airframe.http.router.{ControllerProvider, HttpRequestDispatcher}

--- a/airframe-http-netty/src/test/scala/wvlet/airframe/http/netty/NettyRPCServerTest.scala
+++ b/airframe-http-netty/src/test/scala/wvlet/airframe/http/netty/NettyRPCServerTest.scala
@@ -14,7 +14,7 @@
 package wvlet.airframe.http.netty
 
 import wvlet.airframe.Design
-import wvlet.airframe.http._
+import wvlet.airframe.http.*
 import wvlet.airframe.http.client.SyncClient
 import wvlet.airframe.rx.Rx
 import wvlet.airspec.AirSpec

--- a/airframe-http-netty/src/test/scala/wvlet/airframe/http/netty/RPCClientBindingTest.scala
+++ b/airframe-http-netty/src/test/scala/wvlet/airframe/http/netty/RPCClientBindingTest.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.http.netty
 
-import wvlet.airframe.http._
+import wvlet.airframe.http.*
 import wvlet.airframe.http.client.{HttpClientConfig, SyncClient}
 import wvlet.airframe.http.netty.MyRPCClient.RPCSyncClient
 import wvlet.airframe.http.netty.RPCClientBindingTest.MyApi.{HelloRequest, HelloResponse}
@@ -52,7 +52,7 @@ object MyRPCClient {
 
     object MyRPCApi {
 
-      import internal.MyRPCApiInternals._
+      import internal.MyRPCApiInternals.*
 
       def helloRPC(request: HelloRequest): HelloResponse = {
         client.rpc[__helloRPC_request, HelloResponse](
@@ -65,7 +65,7 @@ object MyRPCClient {
 }
 
 object RPCClientBindingTest extends AirSpec {
-  import MyApi._
+  import MyApi.*
   @RPC
   class MyApi {
     def hello(request: HelloRequest): HelloResponse = HelloResponse(s"Hello ${request.msg}!")

--- a/airframe-http-okhttp/src/main/scala/wvlet/airframe/http/okhttp/OkHttpChannel.scala
+++ b/airframe-http-okhttp/src/main/scala/wvlet/airframe/http/okhttp/OkHttpChannel.scala
@@ -15,7 +15,7 @@ package wvlet.airframe.http.okhttp
 
 import okhttp3.{HttpUrl, MediaType, RequestBody}
 import wvlet.airframe.http.client.{HttpChannelConfig, HttpChannel, HttpClientConfig}
-import wvlet.airframe.http._
+import wvlet.airframe.http.*
 import wvlet.airframe.rx.Rx
 import wvlet.log.LogSupport
 

--- a/airframe-http-okhttp/src/main/scala/wvlet/airframe/http/okhttp/package.scala
+++ b/airframe-http-okhttp/src/main/scala/wvlet/airframe/http/okhttp/package.scala
@@ -6,7 +6,7 @@ import wvlet.airframe.http.HttpMessage.{ByteArrayMessage, EmptyMessage, LazyByte
 import wvlet.log.LogSupport
 
 import java.io.EOFException
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 package object okhttp {
 

--- a/airframe-http-okhttp/src/test/scala/wvlet/airframe/http/okhttp/OkHttpClientTest.scala
+++ b/airframe-http-okhttp/src/test/scala/wvlet/airframe/http/okhttp/OkHttpClientTest.scala
@@ -5,7 +5,7 @@ import wvlet.airframe.control.Control.withResource
 import wvlet.airframe.http.HttpMessage.{Request, Response}
 import wvlet.airframe.http.client.{AsyncClient, SyncClient}
 import wvlet.airframe.http.netty.{Netty, NettyServer}
-import wvlet.airframe.http._
+import wvlet.airframe.http.*
 import wvlet.airspec.AirSpec
 import wvlet.log.LogSupport
 

--- a/airframe-http-recorder/src/main/scala/wvlet/airframe/http/recorder/HttpRecord.scala
+++ b/airframe-http-recorder/src/main/scala/wvlet/airframe/http/recorder/HttpRecord.scala
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 package wvlet.airframe.http.recorder
-import wvlet.airframe.codec._
+import wvlet.airframe.codec.*
 import wvlet.airframe.control.Control.withResource
 import wvlet.airframe.http.HttpMessage.Response
 import wvlet.airframe.http.recorder.HttpRecord.headerCodec

--- a/airframe-http-recorder/src/main/scala/wvlet/airframe/http/recorder/HttpRecordStore.scala
+++ b/airframe-http-recorder/src/main/scala/wvlet/airframe/http/recorder/HttpRecordStore.scala
@@ -26,7 +26,7 @@ import wvlet.log.LogSupport
 
 import java.nio.charset.StandardCharsets
 import java.sql.ResultSet
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 /**
   * Recorder for HTTP server responses

--- a/airframe-http-recorder/src/test/scala/wvlet/airframe/http/recorder/HttpRecorderTest.scala
+++ b/airframe-http-recorder/src/test/scala/wvlet/airframe/http/recorder/HttpRecorderTest.scala
@@ -19,7 +19,7 @@ import wvlet.airframe.http.{Http, HttpHeader, HttpStatus}
 import wvlet.airframe.http.HttpMessage.Response
 import wvlet.airframe.http.client.SyncClient
 import wvlet.airframe.http.recorder.HttpRequestMatcher.PathOnlyMatcher
-import wvlet.airframe.json._
+import wvlet.airframe.json.*
 import wvlet.airspec.AirSpec
 
 import scala.util.{Random, Using}

--- a/airframe-http/.js/src/main/scala/wvlet/airframe/http/client/JSHttpClientChannel.scala
+++ b/airframe-http/.js/src/main/scala/wvlet/airframe/http/client/JSHttpClientChannel.scala
@@ -15,7 +15,7 @@ package wvlet.airframe.http.client
 import org.scalajs.dom
 import org.scalajs.dom.ext.Ajax.InputData
 import wvlet.airframe.http.HttpMessage.Response
-import wvlet.airframe.http._
+import wvlet.airframe.http.*
 import wvlet.airframe.rx.Rx
 import wvlet.log.LogSupport
 

--- a/airframe-http/.js/src/test/scala/wvlet/airframe/http/client/JSHttpAsyncClientTest.scala
+++ b/airframe-http/.js/src/test/scala/wvlet/airframe/http/client/JSHttpAsyncClientTest.scala
@@ -16,7 +16,7 @@ package wvlet.airframe.http.client
 import wvlet.airframe.Design
 import wvlet.airframe.codec.MessageCodec
 import wvlet.airframe.control.{CircuitBreaker, CircuitBreakerOpenException}
-import wvlet.airframe.http._
+import wvlet.airframe.http.*
 import wvlet.airframe.json.JSON
 import wvlet.airframe.rx.Rx
 import wvlet.airspec.AirSpec

--- a/airframe-http/.jvm/src/main/scala-2/wvlet/airframe/http/router/RouterMacros.scala
+++ b/airframe-http/.jvm/src/main/scala-2/wvlet/airframe/http/router/RouterMacros.scala
@@ -25,7 +25,7 @@ import scala.reflect.macros.{blackbox => sm}
   */
 object RouterMacros {
   def of[A: c.WeakTypeTag](c: sm.Context): c.Tree = {
-    import c.universe._
+    import c.universe.*
     val t = implicitly[c.WeakTypeTag[A]].tpe
 
     if (t <:< c.typeTag[HttpFilterType].tpe) {
@@ -45,7 +45,7 @@ object RouterMacros {
   }
 
   def add[A: c.WeakTypeTag](c: sm.Context): c.Tree = {
-    import c.universe._
+    import c.universe.*
     val t = implicitly[c.WeakTypeTag[A]].tpe
 
     q"""
@@ -58,7 +58,7 @@ object RouterMacros {
   }
 
   def andThen[A: c.WeakTypeTag](c: sm.Context): c.Tree = {
-    import c.universe._
+    import c.universe.*
     val t = implicitly[c.WeakTypeTag[A]].tpe
 
     q"""

--- a/airframe-http/.jvm/src/main/scala-3/wvlet/airframe/http/router/RouterBase.scala
+++ b/airframe-http/.jvm/src/main/scala-3/wvlet/airframe/http/router/RouterBase.scala
@@ -38,13 +38,13 @@ trait RouterObjectBase {
 }
 
 private[router] object RouterObjectMacros {
-  import scala.quoted._
+  import scala.quoted.*
 
   def routerOf[Controller: Type](using quotes: Quotes): Expr[Router] = {
-    import quotes._
-    import quotes.reflect._
+    import quotes.*
+    import quotes.reflect.*
 
-    if (TypeRepr.of[Controller] <:< TypeRepr.of[HttpFilterType]) {
+    if TypeRepr.of[Controller] <:< TypeRepr.of[HttpFilterType] then {
       '{
         wvlet.airframe.registerTraitFactory[Controller]
         Router(filterSurface = Some(Surface.of[Controller]))

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/HttpAccessLogWriter.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/HttpAccessLogWriter.scala
@@ -17,7 +17,7 @@ import wvlet.airframe.codec.MessageCodec
 import wvlet.airframe.http.internal.RPCCallContext
 import wvlet.airframe.surface.{Parameter, Surface, TypeName}
 import wvlet.airframe.ulid.ULID
-import wvlet.log._
+import wvlet.log.*
 
 import java.lang.reflect.InvocationTargetException
 import java.util.Locale
@@ -200,7 +200,7 @@ object HttpAccessLogWriter {
     rpcArgsBuilder.result()
   }
 
-  import scala.jdk.CollectionConverters._
+  import scala.jdk.CollectionConverters.*
   private val headerSanitizeCache = new ConcurrentHashMap[String, String]().asScala
 
   private[http] def sanitizeHeader(h: String): String = {

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/Router.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/Router.scala
@@ -17,7 +17,7 @@ import wvlet.airframe.http.HttpMessage.Response
 import wvlet.airframe.http.Router.extractEndpointRoutes
 import wvlet.airframe.http.router.Automaton.DFA
 import wvlet.airframe.http.RxRouter.{EndpointNode, FilterNode, RxEndpointNode, StemNode}
-import wvlet.airframe.surface._
+import wvlet.airframe.surface.*
 import wvlet.log.LogSupport
 import wvlet.airframe.http.router.{ControllerRoute, RedirectToRxEndpoint, Route, RouteMatch, RouteMatcher}
 
@@ -132,7 +132,7 @@ case class Router(
     */
   def addInternal(controllerSurface: Surface, controllerMethodSurfaces: Seq[MethodSurface]): Router = {
     // Import ReflectSurface to find method annotations (Endpoint)
-    import wvlet.airframe.surface.reflect._
+    import wvlet.airframe.surface.reflect.*
 
     val endpointOpt = controllerSurface.findAnnotationOf[Endpoint]
     val rpcOpt      = controllerSurface.findAnnotationOf[RPC]
@@ -246,7 +246,7 @@ object Router extends router.RouterObjectBase with LogSupport {
 
   private[http] def findRPCInterfaceCls(controllerSurface: Surface): Class[_] = {
     // Import ReflectSurface to find RPC annotation
-    import wvlet.airframe.surface.reflect._
+    import wvlet.airframe.surface.reflect.*
 
     // We need to find the owner class of the RPC interface because the controller might be extending the RPC interface (e.g., RPCImpl)
     val rpcInterfaceCls = controllerSurface
@@ -261,7 +261,7 @@ object Router extends router.RouterObjectBase with LogSupport {
   }
 
   // Import ReflectSurface to find method annotations (RPC or Endpoint)
-  import wvlet.airframe.surface.reflect._
+  import wvlet.airframe.surface.reflect.*
 
   private def extractEndpointRoutes(
       controllerSurface: Surface,

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/StaticContent.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/StaticContent.scala
@@ -114,7 +114,7 @@ object StaticContent extends LogSupport {
   def fromDirectory(basePath: String): StaticContent = StaticContent().fromDirectory(basePath)
 }
 
-import wvlet.airframe.http.StaticContent._
+import wvlet.airframe.http.StaticContent.*
 
 case class StaticContent(resourcePaths: List[StaticContent.ResourceType] = List.empty) {
   def fromDirectory(basePath: String): StaticContent = {

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/client/JavaHttpClientChannel.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/client/JavaHttpClientChannel.scala
@@ -16,7 +16,7 @@ package wvlet.airframe.http.client
 import wvlet.airframe.control.Control.withResource
 import wvlet.airframe.control.IO
 import wvlet.airframe.http.HttpMessage.{Request, Response}
-import wvlet.airframe.http._
+import wvlet.airframe.http.*
 import wvlet.airframe.rx.Rx
 
 import java.io.InputStream
@@ -27,7 +27,7 @@ import java.net.http.HttpResponse.BodyHandlers
 import java.net.http.{HttpClient, HttpRequest, HttpResponse}
 import java.util.function.Consumer
 import java.util.zip.{GZIPInputStream, InflaterInputStream}
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 /**
   * Http connection implementation using Http Client of Java 11

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/client/URLConnectionChannel.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/client/URLConnectionChannel.scala
@@ -15,14 +15,14 @@ package wvlet.airframe.http.client
 
 import wvlet.airframe.control.{Control, IO}
 import wvlet.airframe.http.HttpMessage.{Request, Response}
-import wvlet.airframe.http._
+import wvlet.airframe.http.*
 import wvlet.airframe.rx.Rx
 
 import java.io.{IOException, InputStream, OutputStream}
 import java.net.HttpURLConnection
 import java.util.zip.{GZIPInputStream, InflaterInputStream}
 import scala.concurrent.duration.Duration
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 class URLConnectionChannel(serverAddress: ServerAddress, config: HttpClientConfig) extends HttpChannel {
   override def send(request: Request, channelConfig: HttpChannelConfig): Response = {

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/ControllerProvider.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/ControllerProvider.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.http.router
 
-import wvlet.airframe._
+import wvlet.airframe.*
 import wvlet.airframe.surface.Surface
 import wvlet.log.LogSupport
 

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/HttpRequestDispatcher.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/HttpRequestDispatcher.scala
@@ -15,7 +15,7 @@ package wvlet.airframe.http.router
 
 import wvlet.airframe.Session
 import wvlet.airframe.codec.MessageCodecFactory
-import wvlet.airframe.http._
+import wvlet.airframe.http.*
 import wvlet.log.LogSupport
 
 import scala.language.higherKinds

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/HttpRequestMapper.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/HttpRequestMapper.scala
@@ -15,12 +15,12 @@ package wvlet.airframe.http.router
 
 import wvlet.airframe.codec.PrimitiveCodec.{StringCodec, ValueCodec}
 import wvlet.airframe.codec.{JSONCodec, MessageCodecFactory}
-import wvlet.airframe.http._
+import wvlet.airframe.http.*
 import wvlet.airframe.http.internal.HttpMultiMapCodec
 import wvlet.airframe.json.JSON
 import wvlet.airframe.msgpack.spi.Value.MapValue
 import wvlet.airframe.msgpack.spi.{MessagePack, MsgPack, Value}
-import wvlet.airframe.surface._
+import wvlet.airframe.surface.*
 import wvlet.log.LogSupport
 
 import scala.language.higherKinds

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/Route.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/Route.scala
@@ -15,7 +15,7 @@ package wvlet.airframe.http.router
 
 import wvlet.airframe.{Session, http}
 import wvlet.airframe.codec.{MISSING_PARAMETER, MessageCodecException, MessageCodecFactory}
-import wvlet.airframe.http._
+import wvlet.airframe.http.*
 import wvlet.airframe.http.internal.RPCCallContext
 import wvlet.airframe.rx.Rx
 import wvlet.airframe.surface.{MethodSurface, Surface}

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/RouteMatcher.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/RouteMatcher.scala
@@ -15,9 +15,9 @@ package wvlet.airframe.http.router
 
 import wvlet.airframe.Session
 import wvlet.airframe.codec.MessageCodecFactory
-import wvlet.airframe.http._
+import wvlet.airframe.http.*
 import wvlet.log.LogSupport
-import wvlet.airframe.http.router.Automaton._
+import wvlet.airframe.http.router.Automaton.*
 
 import scala.language.higherKinds
 

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/HttpClientTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/HttpClientTest.scala
@@ -14,7 +14,7 @@
 package wvlet.airframe.http
 import java.io.EOFException
 import java.lang.reflect.InvocationTargetException
-import java.net._
+import java.net.*
 import java.util.concurrent.{ExecutionException, TimeoutException}
 import javax.net.ssl.{SSLHandshakeException, SSLKeyException, SSLPeerUnverifiedException}
 import wvlet.airspec.AirSpec
@@ -23,7 +23,7 @@ import wvlet.log.Logger
 /**
   */
 class HttpClientTest extends AirSpec {
-  import wvlet.airframe.http.client.HttpClients._
+  import wvlet.airframe.http.client.HttpClients.*
   abstract class RetryTest(expectedRetryCount: Int, expectedExecCount: Int) {
     val retryer = defaultHttpClientRetry[HttpMessage.Request, HttpMessage.Response]
       .withBackOff(initialIntervalMillis = 0)

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/client/JavaAsyncClientTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/client/JavaAsyncClientTest.scala
@@ -14,7 +14,7 @@
 package wvlet.airframe.http.client
 
 import wvlet.airframe.codec.MessageCodec
-import wvlet.airframe.http._
+import wvlet.airframe.http.*
 import wvlet.airframe.json.JSON
 import wvlet.airframe.{Design, newDesign}
 import wvlet.airspec.AirSpec

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/router/HttpRequestMapperTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/router/HttpRequestMapperTest.scala
@@ -15,7 +15,7 @@ package wvlet.airframe.http.router
 
 import wvlet.airframe.codec.MessageCodecFactory
 import wvlet.airframe.http.HttpMessage.{Request, Response}
-import wvlet.airframe.http._
+import wvlet.airframe.http.*
 import wvlet.airspec.AirSpec
 
 import scala.concurrent.Future

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/router/RouterTest.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/router/RouterTest.scala
@@ -16,8 +16,8 @@ package wvlet.airframe.http.router
 import wvlet.airframe.Session
 import wvlet.airframe.codec.MessageCodecFactory
 import wvlet.airframe.http.router.example.ControllerExample.User
-import wvlet.airframe.http.router.example._
-import wvlet.airframe.http._
+import wvlet.airframe.http.router.example.*
+import wvlet.airframe.http.*
 import wvlet.airframe.surface.Surface
 import wvlet.airspec.AirSpec
 

--- a/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/router/example/ControllerExample.scala
+++ b/airframe-http/.jvm/src/test/scala/wvlet/airframe/http/router/example/ControllerExample.scala
@@ -25,7 +25,7 @@ object ControllerExample {
 /**
   */
 trait ControllerExample extends LogSupport {
-  import ControllerExample._
+  import ControllerExample.*
 
   @Endpoint(path = "/user/:id", method = HttpMethod.GET)
   def getUser(id: String): User = {

--- a/airframe-http/src/main/scala-2/wvlet/airframe/http/RxRouterMacros.scala
+++ b/airframe-http/src/main/scala-2/wvlet/airframe/http/RxRouterMacros.scala
@@ -18,7 +18,7 @@ import scala.reflect.macros.{blackbox => sm}
 private[http] object RxRouterMacros {
 
   def of[A: c.WeakTypeTag](c: sm.Context): c.Tree = {
-    import c.universe._
+    import c.universe.*
     val t = implicitly[c.WeakTypeTag[A]].tpe
 
     q"""
@@ -30,7 +30,7 @@ private[http] object RxRouterMacros {
   }
 
   def filter[A: c.WeakTypeTag](c: sm.Context): c.Tree = {
-    import c.universe._
+    import c.universe.*
     val t = implicitly[c.WeakTypeTag[A]].tpe
 
     if (t <:< c.typeTag[wvlet.airframe.http.RxHttpFilter].tpe) {
@@ -47,7 +47,7 @@ private[http] object RxRouterMacros {
   }
 
   def andThenFilter[A: c.WeakTypeTag](c: sm.Context): c.Tree = {
-    import c.universe._
+    import c.universe.*
     val t = implicitly[c.WeakTypeTag[A]].tpe
 
     if (t <:< c.typeTag[wvlet.airframe.http.RxHttpFilter].tpe) {

--- a/airframe-http/src/main/scala-2/wvlet/airframe/http/impl/HttpMacros.scala
+++ b/airframe-http/src/main/scala-2/wvlet/airframe/http/impl/HttpMacros.scala
@@ -22,7 +22,7 @@ object HttpMacros {
   def read0[Resp: c.WeakTypeTag](c: sm.Context)(
       request: c.Tree
   ): c.Tree = {
-    import c.universe._
+    import c.universe.*
 
     val respType = implicitly[c.WeakTypeTag[Resp]]
     q"""{
@@ -37,7 +37,7 @@ object HttpMacros {
       request: c.Tree,
       requestContent: c.Tree
   ): c.Tree = {
-    import c.universe._
+    import c.universe.*
 
     val reqType  = implicitly[c.WeakTypeTag[Req]]
     val respType = implicitly[c.WeakTypeTag[Resp]]
@@ -55,7 +55,7 @@ object HttpMacros {
   def read0Async[Resp: c.WeakTypeTag](c: sm.Context)(
       request: c.Tree
   ): c.Tree = {
-    import c.universe._
+    import c.universe.*
 
     val respType = implicitly[c.WeakTypeTag[Resp]]
     q"""{
@@ -70,7 +70,7 @@ object HttpMacros {
       request: c.Tree,
       requestContent: c.Tree
   ): c.Tree = {
-    import c.universe._
+    import c.universe.*
 
     val reqType  = implicitly[c.WeakTypeTag[Req]]
     val respType = implicitly[c.WeakTypeTag[Resp]]
@@ -86,7 +86,7 @@ object HttpMacros {
   }
 
   def toJsonWithCodecFactory[A: c.WeakTypeTag](c: sm.Context)(a: c.Tree, codecFactory: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
 
     val tpe = implicitly[c.WeakTypeTag[A]].tpe
     q"""{
@@ -96,7 +96,7 @@ object HttpMacros {
   }
 
   def toJson[A: c.WeakTypeTag](c: sm.Context)(a: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
 
     val tpe = implicitly[c.WeakTypeTag[A]].tpe
     q"""{
@@ -106,7 +106,7 @@ object HttpMacros {
   }
 
   def toMsgPackWithCodecFactory[A: c.WeakTypeTag](c: sm.Context)(a: c.Tree, codecFactory: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
 
     val tpe = implicitly[c.WeakTypeTag[A]].tpe
     q"""{
@@ -116,7 +116,7 @@ object HttpMacros {
   }
 
   def toMsgPack[A: c.WeakTypeTag](c: sm.Context)(a: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
 
     val tpe = implicitly[c.WeakTypeTag[A]].tpe
     q"""{
@@ -128,7 +128,7 @@ object HttpMacros {
   def toContentWithCodecFactory[A: c.WeakTypeTag](
       c: sm.Context
   )(a: c.Tree, codecFactory: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
     q"""{
         if(${c.prefix}.isContentTypeMsgPack) {
           ${toMsgPackWithCodecFactory[A](c)(a, codecFactory)}
@@ -139,7 +139,7 @@ object HttpMacros {
   }
 
   def toContentOf[A: c.WeakTypeTag](c: sm.Context)(a: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
 
     val tpe = implicitly[c.WeakTypeTag[A]].tpe
     q"""{

--- a/airframe-http/src/main/scala-3/wvlet/airframe/http/HttpMessageBase.scala
+++ b/airframe-http/src/main/scala-3/wvlet/airframe/http/HttpMessageBase.scala
@@ -36,7 +36,7 @@ trait HttpMessageBase[Raw] {
     * Set the content body using a given object. Encoding can be JSON or MsgPack based on Content-Type header.
     */
   inline def withContentOf[A](a: A): Raw = {
-    if (self.isContentTypeMsgPack) {
+    if self.isContentTypeMsgPack then {
       self.withMsgPack(MessageCodec.of[A].toMsgPack(a))
     } else {
       self.withJson(MessageCodec.of[A].toJson(a))
@@ -48,7 +48,7 @@ trait HttpMessageBase[Raw] {
     * header.
     */
   inline def withContentOf[A](a: A, codecFactory: MessageCodecFactory): Raw = {
-    if (self.isContentTypeMsgPack) {
+    if self.isContentTypeMsgPack then {
       self.withMsgPack(codecFactory.of[A].toMsgPack(a))
     } else {
       self.withJson(codecFactory.of[A].toJson(a))

--- a/airframe-http/src/main/scala-3/wvlet/airframe/http/HttpServerExceptionBase.scala
+++ b/airframe-http/src/main/scala-3/wvlet/airframe/http/HttpServerExceptionBase.scala
@@ -38,7 +38,7 @@ trait HttpServerExceptionBase {
     * Set the content body using a given object. Encoding can be JSON or MsgPack based on Content-Type header.
     */
   inline def withContentOf[A](a: A): HttpServerException = {
-    if (self.isContentTypeMsgPack) {
+    if self.isContentTypeMsgPack then {
       self.withMsgPack(MessageCodec.of[A].toMsgPack(a))
     } else {
       self.withJson(MessageCodec.of[A].toJson(a))
@@ -50,7 +50,7 @@ trait HttpServerExceptionBase {
     * header.
     */
   inline def withContentOf[A](a: A, codecFactory: MessageCodecFactory): HttpServerException = {
-    if (self.isContentTypeMsgPack) {
+    if self.isContentTypeMsgPack then {
       self.withMsgPack(codecFactory.of[A].toMsgPack(a))
     } else {
       self.withJson(codecFactory.of[A].toJson(a))

--- a/airframe-http/src/main/scala/wvlet/airframe/http/HttpClientException.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/HttpClientException.scala
@@ -19,7 +19,7 @@ import wvlet.log.LogSupport
 
 import java.io.EOFException
 import java.lang.reflect.InvocationTargetException
-import java.net._
+import java.net.*
 import java.nio.channels.ClosedChannelException
 import java.util.concurrent.{ExecutionException, TimeoutException}
 import javax.net.ssl.{SSLException, SSLHandshakeException, SSLKeyException, SSLPeerUnverifiedException}

--- a/airframe-http/src/main/scala/wvlet/airframe/http/RPCStatus.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/RPCStatus.scala
@@ -28,7 +28,7 @@ import scala.util.Try
   */
 object RPCStatus {
 
-  import RPCStatusType._
+  import RPCStatusType.*
 
   // These variables need to be lazy to avoid NPE during the initialization
   private lazy val codeTable: Map[Int, RPCStatus]        = all.map { x => x.code -> x }.toMap
@@ -58,7 +58,7 @@ object RPCStatus {
     GrpcStatus.UNAUTHENTICATED_16    -> RPCStatus.UNAUTHENTICATED_U13
   )
 
-  import HttpStatus._
+  import HttpStatus.*
   private lazy val httpStatusMapping: Map[HttpStatus, RPCStatus] = Map(
     Unknown_000                       -> UNKNOWN_I1,
     Continue_100                      -> UNKNOWN_I1,
@@ -432,7 +432,7 @@ sealed abstract class RPCStatus(
   assert(statusType.isValidCode(code), s"Status code ${code} is invalid for ${statusType} status type")
   assert(statusType.isValidHttpStatus(httpStatus), s"Unexpected http status ${httpStatus} for the code: ${name}")
 
-  import RPCStatus._
+  import RPCStatus.*
 
   def isSuccess: Boolean = statusType == RPCStatusType.SUCCESS
   def isFailure: Boolean = !isSuccess

--- a/airframe-http/src/main/scala/wvlet/airframe/http/client/HttpClientConfig.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/client/HttpClientConfig.scala
@@ -17,7 +17,7 @@ import wvlet.airframe.codec.MessageCodecFactory
 import wvlet.airframe.control.CircuitBreaker
 import wvlet.airframe.control.Retry.RetryContext
 import wvlet.airframe.http.HttpMessage.{Request, Response}
-import wvlet.airframe.http._
+import wvlet.airframe.http.*
 
 import java.util.concurrent.TimeUnit
 import scala.collection.immutable.ListMap

--- a/airframe-http/src/main/scala/wvlet/airframe/http/client/HttpClients.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/client/HttpClients.scala
@@ -18,7 +18,7 @@ import wvlet.airframe.codec.PrimitiveCodec.UnitCodec
 import wvlet.airframe.control.Retry.{MaxRetryException, RetryContext}
 import wvlet.airframe.control.{CircuitBreaker, CircuitBreakerOpenException, Retry}
 import wvlet.airframe.http.HttpMessage.{Request, Response}
-import wvlet.airframe.http._
+import wvlet.airframe.http.*
 import wvlet.airframe.rx.Rx
 import wvlet.airframe.surface.Surface
 import wvlet.log.LogSupport

--- a/airframe-http/src/main/scala/wvlet/airframe/http/internal/HttpLogs.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/internal/HttpLogs.scala
@@ -14,7 +14,7 @@
 package wvlet.airframe.http.internal
 
 import wvlet.airframe.http.HttpMessage.{Request, Response}
-import wvlet.airframe.http._
+import wvlet.airframe.http.*
 import wvlet.airframe.http.client.HttpClientContext
 import wvlet.airframe.rx.Rx
 import wvlet.airframe.surface.{Parameter, Surface, TypeName}
@@ -276,7 +276,7 @@ object HttpLogs {
     }.mkString
   }
 
-  import scala.jdk.CollectionConverters._
+  import scala.jdk.CollectionConverters.*
   private val headerSanitizeCache = new ConcurrentHashMap[String, String]().asScala
 
   private def sanitizeHeader(h: String): String = {

--- a/airframe-http/src/test/scala/wvlet/airframe/http/client/HttpClientLoggingFilterTest.scala
+++ b/airframe-http/src/test/scala/wvlet/airframe/http/client/HttpClientLoggingFilterTest.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.http.client
 
-import wvlet.airframe.http._
+import wvlet.airframe.http.*
 import wvlet.airframe.rx.Rx
 import wvlet.airframe.surface.Surface
 import wvlet.airframe.{Design, newDesign}

--- a/airframe-http/src/test/scala/wvlet/airframe/http/router/CustomEndpointTest.scala
+++ b/airframe-http/src/test/scala/wvlet/airframe/http/router/CustomEndpointTest.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.http.router
 
-import wvlet.airframe.http._
+import wvlet.airframe.http.*
 import wvlet.airframe.rx.Rx
 import wvlet.airframe.surface.Surface
 import wvlet.airspec.AirSpec

--- a/airframe-integration-test-api/src/main/scala/wvlet/airframe/test/api/HelloRPC.scala
+++ b/airframe-integration-test-api/src/main/scala/wvlet/airframe/test/api/HelloRPC.scala
@@ -13,11 +13,11 @@
  */
 package wvlet.airframe.test.api
 
-import wvlet.airframe.http._
+import wvlet.airframe.http.*
 
 @RPC
 trait HelloRPC {
-  import HelloRPC._
+  import HelloRPC.*
 
   def hello(name: String): String
   def serverStatus: Status

--- a/airframe-jdbc/src/test/scala/wvlet/airframe/jdbc/ConnectionPoolFactoryTest.scala
+++ b/airframe-jdbc/src/test/scala/wvlet/airframe/jdbc/ConnectionPoolFactoryTest.scala
@@ -16,7 +16,7 @@ package wvlet.airframe.jdbc
 import java.sql.SQLException
 
 import wvlet.log.LogSupport
-import wvlet.airframe._
+import wvlet.airframe.*
 import wvlet.airframe.control.Control
 import wvlet.airspec.AirSpec
 
@@ -26,7 +26,7 @@ object ConnectionPoolFactoryTest {
   type MyDbConfig3 = DbConfig
 }
 
-import wvlet.airframe.jdbc.ConnectionPoolFactoryTest._
+import wvlet.airframe.jdbc.ConnectionPoolFactoryTest.*
 
 class TestConnection(connectionPoolFactory: ConnectionPoolFactory, c1: MyDbConfig1, c2: MyDbConfig2, c3: MyDbConfig3)
     extends LogSupport {

--- a/airframe-jdbc/src/test/scala/wvlet/airframe/jdbc/DbConfigTest.scala
+++ b/airframe-jdbc/src/test/scala/wvlet/airframe/jdbc/DbConfigTest.scala
@@ -39,7 +39,7 @@ class DbConfigTest extends AirSpec {
   }
 
   test("bind config") {
-    import wvlet.airframe.config._
+    import wvlet.airframe.config.*
     val d = Design.newSilentDesign
       .bindConfigFromYaml[DbConfig]("dbconfig.yml")
       .overrideConfigWithPropertiesFile("config.properties")

--- a/airframe-jmx/src/main/scala/wvlet/airframe/jmx/JMXMBean.scala
+++ b/airframe-jmx/src/main/scala/wvlet/airframe/jmx/JMXMBean.scala
@@ -16,9 +16,9 @@ package wvlet.airframe.jmx
 import java.lang.annotation.Annotation
 import java.lang.reflect.Method
 
-import javax.management._
+import javax.management.*
 import wvlet.log.LogSupport
-import wvlet.airframe.surface.reflect._
+import wvlet.airframe.surface.reflect.*
 import wvlet.airframe.surface.{MethodSurface, Parameter, ParameterBase, Surface}
 
 import wvlet.airframe.{jmx => aj}
@@ -48,7 +48,7 @@ case class JMXMBean(obj: AnyRef, mBeanInfo: MBeanInfo, attributes: Seq[MBeanPara
 
   override def setAttributes(attributes: AttributeList): AttributeList = {
     val l = new AttributeList(attributes.size())
-    import scala.jdk.CollectionConverters._
+    import scala.jdk.CollectionConverters.*
     for (a <- attributes.asList().asScala) {
       l.add(setAttribute(a))
     }
@@ -151,7 +151,7 @@ object JMXMBean extends JMXMBeanCompat with LogSupport {
   }
 
   private def isNestedMBean(p: ParameterBase): Boolean = {
-    import wvlet.airframe.surface.reflect._
+    import wvlet.airframe.surface.reflect.*
 
     // We can support only nested parameters
     p.surface.params.exists(x => x.findAnnotationOf[aj.JMX].isDefined)

--- a/airframe-jmx/src/main/scala/wvlet/airframe/jmx/JMXRegistry.scala
+++ b/airframe-jmx/src/main/scala/wvlet/airframe/jmx/JMXRegistry.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.jmx
 
-import javax.management._
+import javax.management.*
 
 import wvlet.log.LogSupport
 
@@ -78,7 +78,7 @@ object JMXRegistry {
 
     // When class is an anonymous trait
     if (name.contains("$anon$")) {
-      import scala.jdk.CollectionConverters._
+      import scala.jdk.CollectionConverters.*
       val interfaces = cl.getInterfaces
       if (interfaces != null && interfaces.length > 0) {
         // Use the first interface name instead of the anonymous name

--- a/airframe-jmx/src/main/scala/wvlet/airframe/jmx/JMXUtil.scala
+++ b/airframe-jmx/src/main/scala/wvlet/airframe/jmx/JMXUtil.scala
@@ -64,7 +64,7 @@ object JMXUtil extends LogSupport {
     p.setProperty("com.sun.management.jmxremote.authenticate", "false")
     p.setProperty("com.sun.management.jmxremote.ssl", "false")
 
-    import scala.jdk.CollectionConverters._
+    import scala.jdk.CollectionConverters.*
     if (isAtLeastJava9) {
       // TODO Java9 support
 //      Try {

--- a/airframe-json/src/main/scala/wvlet/airframe/json/JSONScanner.scala
+++ b/airframe-json/src/main/scala/wvlet/airframe/json/JSONScanner.scala
@@ -96,7 +96,7 @@ object JSONScanner {
   private[json] final val whiteSpaceBitVector: Array[Long] = {
     val b = new Array[Long](256 / 64)
     for (i <- 0 until 256) {
-      import JSONToken._
+      import JSONToken.*
       i match {
         case WS | WS_T | WS_R | WS_N =>
           b(i / 64) |= (1L << (i % 64))
@@ -140,8 +140,8 @@ class JSONScanner[J](private[this] val s: JSONSource, private[this] val handler:
   private[this] var line: Int         = 0
   private[this] val sb                = new StringBuilder()
 
-  import JSONScanner._
-  import JSONToken._
+  import JSONScanner.*
+  import JSONToken.*
 
   private def skipWhiteSpaces: Unit = {
     var toContinue = true

--- a/airframe-json/src/main/scala/wvlet/airframe/json/JSONTraverser.scala
+++ b/airframe-json/src/main/scala/wvlet/airframe/json/JSONTraverser.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.json
 
-import wvlet.airframe.json.JSON._
+import wvlet.airframe.json.JSON.*
 
 trait JSONVisitor {
   def visitObject(o: JSONObject): Unit             = {}

--- a/airframe-json/src/main/scala/wvlet/airframe/json/JSONValueBuilder.scala
+++ b/airframe-json/src/main/scala/wvlet/airframe/json/JSONValueBuilder.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.json
 
-import wvlet.airframe.json.JSON._
+import wvlet.airframe.json.JSON.*
 
 import wvlet.log.LogSupport
 

--- a/airframe-json/src/main/scala/wvlet/airframe/json/YAMLFormatter.scala
+++ b/airframe-json/src/main/scala/wvlet/airframe/json/YAMLFormatter.scala
@@ -1,5 +1,5 @@
 package wvlet.airframe.json
-import wvlet.airframe.json.JSON._
+import wvlet.airframe.json.JSON.*
 
 /**
   * Convert JSON as Yaml

--- a/airframe-json/src/test/scala/wvlet/airframe/json/JSONParserTest.scala
+++ b/airframe-json/src/test/scala/wvlet/airframe/json/JSONParserTest.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.json
 
-import wvlet.airframe.json.JSON._
+import wvlet.airframe.json.JSON.*
 import wvlet.airspec.AirSpec
 
 /**

--- a/airframe-json/src/test/scala/wvlet/airframe/json/JSONTest.scala
+++ b/airframe-json/src/test/scala/wvlet/airframe/json/JSONTest.scala
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 package wvlet.airframe.json
-import wvlet.airframe.json.JSON._
+import wvlet.airframe.json.JSON.*
 import wvlet.airspec.AirSpec
 
 /**

--- a/airframe-launcher/src/main/scala/wvlet/airframe/launcher/Launcher.scala
+++ b/airframe-launcher/src/main/scala/wvlet/airframe/launcher/Launcher.scala
@@ -53,7 +53,7 @@ object Launcher extends LauncherCompat with LogSupport {
     val defaultUsage =
       parser.schema.args.map(x => s"[${x}]").mkString(" ")
 
-    import wvlet.airframe.surface.reflect._
+    import wvlet.airframe.surface.reflect.*
     val command = surface.findAnnotationOf[command]
     // If the user specified usage and description via @command annotation, use them.
     val commandUsage       = command.map(_.usage()).find(_.nonEmpty).getOrElse(defaultUsage)
@@ -61,7 +61,7 @@ object Launcher extends LauncherCompat with LogSupport {
     val commandName        = if (name.nonEmpty) name else CName.toNaturalName(surface.name).replaceAll("\\s+", "_")
 
     // Find sub commands marked with [[wvlet.airframe.opts.command]] annotation
-    import wvlet.airframe.surface.reflect._
+    import wvlet.airframe.surface.reflect.*
     val subCommands = for (m <- methods; c <- m.findAnnotationOf[command]) yield {
       newMethodLauncher(m, c)
     }
@@ -69,7 +69,7 @@ object Launcher extends LauncherCompat with LogSupport {
     // Find the default command
     val defaultCommand = methods
       .find { m =>
-        import wvlet.airframe.surface.reflect._
+        import wvlet.airframe.surface.reflect.*
         m.findAnnotationOf[command] match {
           case Some(cmd) => cmd.isDefault
           case None      => false

--- a/airframe-launcher/src/main/scala/wvlet/airframe/launcher/OptionParser.scala
+++ b/airframe-launcher/src/main/scala/wvlet/airframe/launcher/OptionParser.scala
@@ -22,7 +22,7 @@ package wvlet.airframe.launcher
 
 import wvlet.airframe.control.CommandLineTokenizer
 import wvlet.airframe.launcher.StringTree.{Leaf, SeqLeaf}
-import wvlet.airframe.surface._
+import wvlet.airframe.surface.*
 import wvlet.airframe.surface.reflect.{GenericBuilder, ObjectBuilder, Path, ReflectSurfaceFactory}
 import wvlet.log.{LogSupport, Logger}
 
@@ -86,7 +86,7 @@ object OptionParser extends LogSupport {
 
   abstract class CLOptionItemBase(val param: Parameter) extends CLOptionItem {
     override def takesMultipleArguments: Boolean = {
-      import wvlet.airframe.surface.reflect.ReflectTypeUtil._
+      import wvlet.airframe.surface.reflect.ReflectTypeUtil.*
       val t: Class[_] = param.surface.rawType
       isArrayCls(t) || isSeq(t)
     }
@@ -175,7 +175,7 @@ object OptionParser extends LogSupport {
 class OptionParser(val schema: OptionSchema) extends LogSupport {
   def this(m: MethodSurface) = this(MethodOptionSchema(m))
 
-  import OptionParser._
+  import OptionParser.*
 
   /**
     * Parse the command-line arguments

--- a/airframe-launcher/src/main/scala/wvlet/airframe/launcher/OptionSchema.scala
+++ b/airframe-launcher/src/main/scala/wvlet/airframe/launcher/OptionSchema.scala
@@ -51,7 +51,7 @@ sealed trait OptionSchema extends LogSupport {
 }
 
 object ClassOptionSchema extends LogSupport {
-  import wvlet.airframe.surface.reflect._
+  import wvlet.airframe.surface.reflect.*
 
   /**
     * Create an option schema from a given class definition
@@ -96,7 +96,7 @@ class ClassOptionSchema(val surface: Surface, val options: Seq[CLOption], val ar
     extends OptionSchema {}
 
 object MethodOptionSchema {
-  import wvlet.airframe.surface.reflect._
+  import wvlet.airframe.surface.reflect.*
 
   def apply(method: MethodSurface, path: Path = Path.current, argIndexOffset: Int = 0): MethodOptionSchema = {
     // TODO Merge this method with ClassOptionSchema.apply as the logic is almost the same

--- a/airframe-launcher/src/test/scala/wvlet/airframe/launcher/ArgProcessorTest.scala
+++ b/airframe-launcher/src/test/scala/wvlet/airframe/launcher/ArgProcessorTest.scala
@@ -75,7 +75,7 @@ object ArgProcessorTest {
 }
 
 class ArgProcessorTest extends AirSpec {
-  import ArgProcessorTest._
+  import ArgProcessorTest.*
 
   test("should run the default command") {
     val c = capture {

--- a/airframe-launcher/src/test/scala/wvlet/airframe/launcher/LauncherTest.scala
+++ b/airframe-launcher/src/test/scala/wvlet/airframe/launcher/LauncherTest.scala
@@ -27,7 +27,7 @@ import wvlet.airspec.AirSpec
 import wvlet.log.{LogLevel, LogSupport, Logger}
 
 class LauncherTest extends AirSpec {
-  import LauncherTest._
+  import LauncherTest.*
   test("populate arguments in constructor") {
     capture {
       val l = Launcher.execute[GlobalOption]("-h -l debug")

--- a/airframe-launcher/src/test/scala/wvlet/airframe/launcher/OptionBuilderTest.scala
+++ b/airframe-launcher/src/test/scala/wvlet/airframe/launcher/OptionBuilderTest.scala
@@ -27,7 +27,7 @@ object OptionBuilderTest {
 /**
   */
 class OptionBuilderTest extends AirSpec {
-  import OptionBuilderTest._
+  import OptionBuilderTest.*
 
   test("read default value") {
     val l   = Launcher.of[Main1]

--- a/airframe-log/.jvm/src/main/scala/wvlet/log/LogLevelScanner.scala
+++ b/airframe-log/.jvm/src/main/scala/wvlet/log/LogLevelScanner.scala
@@ -21,7 +21,7 @@ import java.util.concurrent.atomic.{AtomicLong, AtomicReference}
 
 import wvlet.log.LogLevelScanner.ScannerState
 import wvlet.log.io.{IOUtil, Resource}
-import wvlet.log.io.IOUtil._
+import wvlet.log.io.IOUtil.*
 
 import scala.annotation.tailrec
 import scala.concurrent.duration.Duration
@@ -162,7 +162,7 @@ case class LogLevelScannerConfig(
     scanInterval: Duration = Duration(1, TimeUnit.MINUTES)
 )
 
-import wvlet.log.LogLevelScanner._
+import wvlet.log.LogLevelScanner.*
 
 private[log] class LogLevelScanner extends Guard { scanner =>
   private val config: AtomicReference[LogLevelScannerConfig] = new AtomicReference(LogLevelScannerConfig(List.empty))

--- a/airframe-log/.jvm/src/main/scala/wvlet/log/LogRotationHandler.scala
+++ b/airframe-log/.jvm/src/main/scala/wvlet/log/LogRotationHandler.scala
@@ -68,7 +68,7 @@ class LogRotationHandler(
 ) extends jl.Handler
     with AutoCloseable
     with Flushable {
-  import LogRotationHandler._
+  import LogRotationHandler.*
 
   recoverTempFiles(fileName)
   setFormatter(formatter)

--- a/airframe-log/.jvm/src/main/scala/wvlet/log/LogTimestampFormatter.scala
+++ b/airframe-log/.jvm/src/main/scala/wvlet/log/LogTimestampFormatter.scala
@@ -7,7 +7,7 @@ import java.util.Locale
 /**
   */
 object LogTimestampFormatter {
-  import java.time.temporal.ChronoField._
+  import java.time.temporal.ChronoField.*
 
   val systemZone = ZoneId.systemDefault().normalized()
   val noSpaceTimestampFormat = new DateTimeFormatterBuilder()

--- a/airframe-log/.jvm/src/main/scala/wvlet/log/io/IOUtil.scala
+++ b/airframe-log/.jvm/src/main/scala/wvlet/log/io/IOUtil.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.log.io
 
-import java.io._
+import java.io.*
 import java.net.{ServerSocket, URL}
 import java.nio.charset.StandardCharsets
 

--- a/airframe-log/.jvm/src/test/scala/wvlet/log/AsyncHandlerTest.scala
+++ b/airframe-log/.jvm/src/test/scala/wvlet/log/AsyncHandlerTest.scala
@@ -2,7 +2,7 @@ package wvlet.log
 
 import java.util.concurrent.{ExecutorService, Executors, TimeUnit}
 import wvlet.log.LogFormatter.{BareFormatter, ThreadLogFormatter}
-import wvlet.log.io.IOUtil._
+import wvlet.log.io.IOUtil.*
 import wvlet.log.io.Timer
 
 /**

--- a/airframe-log/.jvm/src/test/scala/wvlet/log/LogRotationHandlerTest.scala
+++ b/airframe-log/.jvm/src/test/scala/wvlet/log/LogRotationHandlerTest.scala
@@ -15,7 +15,7 @@ package wvlet.log
 
 import java.io.File
 
-import wvlet.log.io.IOUtil._
+import wvlet.log.io.IOUtil.*
 
 /**
   */

--- a/airframe-log/.jvm/src/test/scala/wvlet/log/SerializationTest.scala
+++ b/airframe-log/.jvm/src/test/scala/wvlet/log/SerializationTest.scala
@@ -14,7 +14,7 @@ object SerializationTest {
 /**
   */
 class SerializationTest extends Spec {
-  import SerializationTest._
+  import SerializationTest.*
 
   test("logger should be serializable") {
     val a = new A {}

--- a/airframe-log/src/main/scala-2/wvlet/log/LogMacros.scala
+++ b/airframe-log/src/main/scala-2/wvlet/log/LogMacros.scala
@@ -25,7 +25,7 @@ import scala.reflect.macros.blackbox.Context
   */
 private[log] object LogMacros {
   private class MacroHelper[C <: Context](val c: C) {
-    import c.universe._
+    import c.universe.*
 
     val disabledLevels: Set[c.Tree] = {
       val SettingsPrefix = "wvlet.log.disable."
@@ -78,107 +78,107 @@ private[log] object LogMacros {
   }
 
   def logAtImpl(c: Context)(logLevel: c.Tree, message: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
     new MacroHelper[c.type](c).log(logLevel, message)
   }
 
   def errorLog(c: Context)(message: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
     new MacroHelper[c.type](c).log(q"wvlet.log.LogLevel.ERROR", message)
   }
 
   def errorLogWithCause(c: Context)(message: c.Tree, cause: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
     new MacroHelper[c.type](c).logWithCause(q"wvlet.log.LogLevel.ERROR", message, cause)
   }
 
   def errorLogMethod(c: Context)(message: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
     new MacroHelper[c.type](c).logMethod(q"wvlet.log.LogLevel.ERROR", message)
   }
 
   def errorLogMethodWithCause(c: Context)(message: c.Tree, cause: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
     new MacroHelper[c.type](c).logMethodWithCause(q"wvlet.log.LogLevel.ERROR", message, cause)
   }
 
   def warnLog(c: Context)(message: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
     new MacroHelper[c.type](c).log(q"wvlet.log.LogLevel.WARN", message)
   }
 
   def warnLogWithCause(c: Context)(message: c.Tree, cause: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
     new MacroHelper[c.type](c).logWithCause(q"wvlet.log.LogLevel.WARN", message, cause)
   }
 
   def warnLogMethod(c: Context)(message: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
     new MacroHelper[c.type](c).logMethod(q"wvlet.log.LogLevel.WARN", message)
   }
 
   def warnLogMethodWithCause(c: Context)(message: c.Tree, cause: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
     new MacroHelper[c.type](c).logMethodWithCause(q"wvlet.log.LogLevel.WARN", message, cause)
   }
 
   def infoLog(c: Context)(message: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
     new MacroHelper[c.type](c).log(q"wvlet.log.LogLevel.INFO", message)
   }
 
   def infoLogWithCause(c: Context)(message: c.Tree, cause: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
     new MacroHelper[c.type](c).logWithCause(q"wvlet.log.LogLevel.INFO", message, cause)
   }
 
   def infoLogMethod(c: Context)(message: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
     new MacroHelper[c.type](c).logMethod(q"wvlet.log.LogLevel.INFO", message)
   }
 
   def infoLogMethodWithCause(c: Context)(message: c.Tree, cause: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
     new MacroHelper[c.type](c).logMethodWithCause(q"wvlet.log.LogLevel.INFO", message, cause)
   }
 
   def debugLog(c: Context)(message: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
     new MacroHelper[c.type](c).log(q"wvlet.log.LogLevel.DEBUG", message)
   }
 
   def debugLogWithCause(c: Context)(message: c.Tree, cause: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
     new MacroHelper[c.type](c).logWithCause(q"wvlet.log.LogLevel.DEBUG", message, cause)
   }
 
   def debugLogMethod(c: Context)(message: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
     new MacroHelper[c.type](c).logMethod(q"wvlet.log.LogLevel.DEBUG", message)
   }
 
   def debugLogMethodWithCause(c: Context)(message: c.Tree, cause: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
     new MacroHelper[c.type](c).logMethodWithCause(q"wvlet.log.LogLevel.DEBUG", message, cause)
   }
 
   def traceLog(c: Context)(message: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
     new MacroHelper[c.type](c).log(q"wvlet.log.LogLevel.TRACE", message)
   }
 
   def traceLogWithCause(c: Context)(message: c.Tree, cause: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
     new MacroHelper[c.type](c).logWithCause(q"wvlet.log.LogLevel.TRACE", message, cause)
   }
 
   def traceLogMethod(c: Context)(message: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
     new MacroHelper[c.type](c).logMethod(q"wvlet.log.LogLevel.TRACE", message)
   }
 
   def traceLogMethodWithCause(c: Context)(message: c.Tree, cause: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
     new MacroHelper[c.type](c).logMethodWithCause(q"wvlet.log.LogLevel.TRACE", message, cause)
   }
 }

--- a/airframe-log/src/main/scala-2/wvlet/log/LoggerBase.scala
+++ b/airframe-log/src/main/scala-2/wvlet/log/LoggerBase.scala
@@ -17,7 +17,7 @@ import scala.language.experimental.macros
 /**
   */
 trait LoggerBase {
-  import LogMacros._
+  import LogMacros.*
 
   def error(message: Any): Unit = macro errorLogMethod
   def error(message: Any, cause: Throwable): Unit =
@@ -41,7 +41,7 @@ trait LoggerBase {
 /**
   */
 trait LoggingMethods extends Serializable {
-  import wvlet.log.LogMacros._
+  import wvlet.log.LogMacros.*
 
   protected def error(message: Any): Unit = macro errorLog
   protected def error(message: Any, cause: Throwable): Unit =

--- a/airframe-log/src/main/scala-3/wvlet/log/LoggerBase.scala
+++ b/airframe-log/src/main/scala-3/wvlet/log/LoggerBase.scala
@@ -18,52 +18,52 @@ package wvlet.log
 trait LoggerBase { self: Logger =>
 
   inline def error(inline message: Any): Unit = {
-    if (self.isEnabled(LogLevel.ERROR)) {
+    if self.isEnabled(LogLevel.ERROR) then {
       self.log(LogLevel.ERROR, LoggerMacros.sourcePos(), message)
     }
   }
   inline def warn(inline message: Any): Unit = {
-    if (self.isEnabled(LogLevel.WARN)) {
+    if self.isEnabled(LogLevel.WARN) then {
       self.log(LogLevel.WARN, LoggerMacros.sourcePos(), message)
     }
   }
   inline def info(inline message: Any): Unit = {
-    if (self.isEnabled(LogLevel.INFO)) {
+    if self.isEnabled(LogLevel.INFO) then {
       self.log(LogLevel.INFO, LoggerMacros.sourcePos(), message)
     }
   }
   inline def debug(inline message: Any): Unit = {
-    if (self.isEnabled(LogLevel.DEBUG)) {
+    if self.isEnabled(LogLevel.DEBUG) then {
       self.log(LogLevel.DEBUG, LoggerMacros.sourcePos(), message)
     }
   }
   inline def trace(inline message: Any): Unit = {
-    if (self.isEnabled(LogLevel.TRACE)) {
+    if self.isEnabled(LogLevel.TRACE) then {
       self.log(LogLevel.TRACE, LoggerMacros.sourcePos(), message)
     }
   }
   inline def error(inline message: Any, inline cause: Throwable): Unit = {
-    if (self.isEnabled(LogLevel.ERROR)) {
+    if self.isEnabled(LogLevel.ERROR) then {
       self.logWithCause(LogLevel.ERROR, LoggerMacros.sourcePos(), message, cause)
     }
   }
   inline def warn(inline message: Any, inline cause: Throwable): Unit = {
-    if (self.isEnabled(LogLevel.WARN)) {
+    if self.isEnabled(LogLevel.WARN) then {
       self.logWithCause(LogLevel.WARN, LoggerMacros.sourcePos(), message, cause)
     }
   }
   inline def info(inline message: Any, inline cause: Throwable): Unit = {
-    if (self.isEnabled(LogLevel.INFO)) {
+    if self.isEnabled(LogLevel.INFO) then {
       self.logWithCause(LogLevel.INFO, LoggerMacros.sourcePos(), message, cause)
     }
   }
   inline def debug(inline message: Any, inline cause: Throwable): Unit = {
-    if (self.isEnabled(LogLevel.DEBUG)) {
+    if self.isEnabled(LogLevel.DEBUG) then {
       self.logWithCause(LogLevel.DEBUG, LoggerMacros.sourcePos(), message, cause)
     }
   }
   inline def trace(inline message: Any, inline cause: Throwable): Unit = {
-    if (self.isEnabled(LogLevel.TRACE)) {
+    if self.isEnabled(LogLevel.TRACE) then {
       self.logWithCause(LogLevel.TRACE, LoggerMacros.sourcePos(), message, cause)
     }
   }
@@ -75,70 +75,70 @@ trait LoggingMethods extends Serializable {
   protected def logger: Logger
 
   inline protected def error(inline message: Any): Unit = {
-    if (logger.isEnabled(LogLevel.ERROR)) {
+    if logger.isEnabled(LogLevel.ERROR) then {
       logger.log(LogLevel.ERROR, LoggerMacros.sourcePos(), message)
     }
   }
   inline protected def warn(inline message: Any): Unit = {
-    if (logger.isEnabled(LogLevel.WARN)) {
+    if logger.isEnabled(LogLevel.WARN) then {
       logger.log(LogLevel.WARN, LoggerMacros.sourcePos(), message)
     }
   }
   inline protected def info(inline message: Any): Unit = {
-    if (logger.isEnabled(LogLevel.INFO)) {
+    if logger.isEnabled(LogLevel.INFO) then {
       logger.log(LogLevel.INFO, LoggerMacros.sourcePos(), message)
     }
   }
   inline protected def debug(inline message: Any): Unit = {
-    if (logger.isEnabled(LogLevel.DEBUG)) {
+    if logger.isEnabled(LogLevel.DEBUG) then {
       logger.log(LogLevel.DEBUG, LoggerMacros.sourcePos(), message)
     }
   }
   inline protected def trace(inline message: Any): Unit = {
-    if (logger.isEnabled(LogLevel.TRACE)) {
+    if logger.isEnabled(LogLevel.TRACE) then {
       logger.log(LogLevel.TRACE, LoggerMacros.sourcePos(), message)
     }
   }
   inline protected def logAt(inline logLevel: LogLevel, inline message: Any): Unit = {
-    if (logger.isEnabled(logLevel)) {
+    if logger.isEnabled(logLevel) then {
       logger.log(logLevel, LoggerMacros.sourcePos(), message)
     }
   }
 
   inline protected def error(inline message: Any, inline cause: Throwable): Unit = {
-    if (logger.isEnabled(LogLevel.ERROR)) {
+    if logger.isEnabled(LogLevel.ERROR) then {
       logger.logWithCause(LogLevel.ERROR, LoggerMacros.sourcePos(), message, cause)
     }
   }
   inline protected def warn(inline message: Any, inline cause: Throwable): Unit = {
-    if (logger.isEnabled(LogLevel.WARN)) {
+    if logger.isEnabled(LogLevel.WARN) then {
       logger.logWithCause(LogLevel.WARN, LoggerMacros.sourcePos(), message, cause)
     }
   }
   inline protected def info(inline message: Any, inline cause: Throwable): Unit = {
-    if (logger.isEnabled(LogLevel.INFO)) {
+    if logger.isEnabled(LogLevel.INFO) then {
       logger.logWithCause(LogLevel.INFO, LoggerMacros.sourcePos(), message, cause)
     }
   }
   inline protected def debug(inline message: Any, inline cause: Throwable): Unit = {
-    if (logger.isEnabled(LogLevel.DEBUG)) {
+    if logger.isEnabled(LogLevel.DEBUG) then {
       logger.logWithCause(LogLevel.DEBUG, LoggerMacros.sourcePos(), message, cause)
     }
   }
   inline protected def trace(inline message: Any, inline cause: Throwable): Unit = {
-    if (logger.isEnabled(LogLevel.TRACE)) {
+    if logger.isEnabled(LogLevel.TRACE) then {
       logger.logWithCause(LogLevel.TRACE, LoggerMacros.sourcePos(), message, cause)
     }
   }
 }
 
 object LoggerMacros {
-  import scala.quoted._
+  import scala.quoted.*
 
   inline def sourcePos(): LogSource = ${ sourcePos }
 
   private def sourcePos(using q: Quotes): Expr[wvlet.log.LogSource] = {
-    import q.reflect._
+    import q.reflect.*
     val pos                         = Position.ofMacroExpansion
     val line                        = Expr(pos.startLine)
     val column                      = Expr(pos.endColumn)

--- a/airframe-log/src/main/scala/wvlet/log/LogFormat.scala
+++ b/airframe-log/src/main/scala/wvlet/log/LogFormat.scala
@@ -36,7 +36,7 @@ trait LogFormatter extends Formatter {
 }
 
 object LogFormatter extends AnsiColorPalette {
-  import LogTimestampFormatter._
+  import LogTimestampFormatter.*
 
   def currentThreadName: String = Thread.currentThread().getName
 

--- a/airframe-log/src/main/scala/wvlet/log/LogRecord.scala
+++ b/airframe-log/src/main/scala/wvlet/log/LogRecord.scala
@@ -33,7 +33,7 @@ object LogRecord {
   private[log] val leafLoggerNameCache = collection.mutable.Map[String, String]()
 }
 
-import wvlet.log.LogRecord._
+import wvlet.log.LogRecord.*
 
 case class LogRecord(level: LogLevel, source: Option[LogSource], message: String, cause: Option[Throwable])
     extends jl.LogRecord(level.jlLevel, message) {

--- a/airframe-log/src/main/scala/wvlet/log/Logger.scala
+++ b/airframe-log/src/main/scala/wvlet/log/Logger.scala
@@ -208,7 +208,7 @@ class Logger(
 object Logger {
   LogEnv.initLogManager()
 
-  import scala.jdk.CollectionConverters._
+  import scala.jdk.CollectionConverters.*
 
   private lazy val loggerCache = new ConcurrentHashMap[String, Logger].asScala
 

--- a/airframe-log/src/main/scala/wvlet/log/io/StopWatch.scala
+++ b/airframe-log/src/main/scala/wvlet/log/io/StopWatch.scala
@@ -89,7 +89,7 @@ import scala.collection.mutable.LinkedHashMap
   *   leo
   */
 trait Timer extends Serializable {
-  import scala.jdk.CollectionConverters._
+  import scala.jdk.CollectionConverters.*
   @transient private[this] val holder =
     new ThreadLocal[util.ArrayDeque[TimeReport]] {
       override def initialValue() = new util.ArrayDeque[TimeReport]()
@@ -110,7 +110,7 @@ trait Timer extends Serializable {
       def body()           = f
     }
 
-  import wvlet.log.LogLevel._
+  import wvlet.log.LogLevel.*
 
   /**
     * Measure the execution time of the code block

--- a/airframe-log/src/test/scala/wvlet/airframe/log/AirframeLogDemo.scala
+++ b/airframe-log/src/test/scala/wvlet/airframe/log/AirframeLogDemo.scala
@@ -16,7 +16,7 @@ package wvlet.airframe.log
 import java.util.logging
 
 import wvlet.airspec.AirSpec
-import wvlet.log.LogFormatter._
+import wvlet.log.LogFormatter.*
 import wvlet.log.{LocalLogSupport, LogFormatter, LogLevel, LogSupport, NullHandler}
 
 /**

--- a/airframe-log/src/test/scala/wvlet/log/LoggerTest.scala
+++ b/airframe-log/src/test/scala/wvlet/log/LoggerTest.scala
@@ -16,7 +16,7 @@ package wvlet.log
 import java.io.{ByteArrayOutputStream, PrintStream}
 import java.util.{logging => jul}
 
-import wvlet.log.LogFormatter._
+import wvlet.log.LogFormatter.*
 import wvlet.log.LogLevel.LogOrdering
 import wvlet.log.LoggerTest.capture
 

--- a/airframe-metrics/.jvm/src/main/scala/wvlet/airframe/metrics/TimeParser.scala
+++ b/airframe-metrics/.jvm/src/main/scala/wvlet/airframe/metrics/TimeParser.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.metrics
 
-import java.time._
+import java.time.*
 import java.time.format.DateTimeFormatter
 
 import wvlet.log.LogSupport

--- a/airframe-metrics/.jvm/src/main/scala/wvlet/airframe/metrics/TimeStampFormatter.scala
+++ b/airframe-metrics/.jvm/src/main/scala/wvlet/airframe/metrics/TimeStampFormatter.scala
@@ -20,7 +20,7 @@ import java.util.Locale
 /**
   */
 object TimeStampFormatter {
-  import java.time.temporal.ChronoField._
+  import java.time.temporal.ChronoField.*
 
   val noSpaceTimestampFormat = new DateTimeFormatterBuilder()
     .parseCaseInsensitive()

--- a/airframe-metrics/.jvm/src/main/scala/wvlet/airframe/metrics/TimeWindow.scala
+++ b/airframe-metrics/.jvm/src/main/scala/wvlet/airframe/metrics/TimeWindow.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.metrics
 
-import java.time._
+import java.time.*
 import java.time.temporal.ChronoUnit
 
 import wvlet.log.LogSupport
@@ -137,7 +137,7 @@ case class TimeWindow(start: ZonedDateTime, end: ZonedDateTime) {
 
 object TimeWindow extends LogSupport {
   def withTimeZone(zoneName: String): TimeWindowBuilder = {
-    import scala.jdk.CollectionConverters._
+    import scala.jdk.CollectionConverters.*
     // Add commonly used daylight saving times
     val idMap = ZoneId.SHORT_IDS.asScala ++
       Map("PDT" -> "-07:00", "EDT" -> "-04:00", "CDT" -> "-05:00", "MDT" -> "-06:00")

--- a/airframe-metrics/src/main/scala/wvlet/airframe/metrics/DataSize.scala
+++ b/airframe-metrics/src/main/scala/wvlet/airframe/metrics/DataSize.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.metrics
 
-import wvlet.airframe.metrics.DataSize._
+import wvlet.airframe.metrics.DataSize.*
 import wvlet.airframe.surface.{Surface, Zero}
 
 import scala.annotation.tailrec

--- a/airframe-metrics/src/main/scala/wvlet/airframe/metrics/ElapsedTime.scala
+++ b/airframe-metrics/src/main/scala/wvlet/airframe/metrics/ElapsedTime.scala
@@ -6,13 +6,13 @@ import java.util.regex.Pattern
 import wvlet.airframe.surface.{Surface, Zero}
 
 import scala.annotation.tailrec
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 /**
   * Scala version of io.airlift.unit.Duration
   */
 case class ElapsedTime(value: Double, unit: TimeUnit) extends Comparable[ElapsedTime] {
-  import ElapsedTime._
+  import ElapsedTime.*
 
   require(!value.isInfinite, s"infinite size")
   require(!value.isNaN, s"value is not a number")

--- a/airframe-metrics/src/test/scala/wvlet/airframe/metrics/DataSizeTest.scala
+++ b/airframe-metrics/src/test/scala/wvlet/airframe/metrics/DataSizeTest.scala
@@ -18,7 +18,7 @@ import wvlet.airspec.AirSpec
 /**
   */
 class DataSizeTest extends AirSpec {
-  import DataSize._
+  import DataSize.*
 
   test("parse string") {
     DataSize(1234) shouldBe DataSize(1234, DataSize.BYTE)

--- a/airframe-metrics/src/test/scala/wvlet/airframe/metrics/ElapsedTimeTest.scala
+++ b/airframe-metrics/src/test/scala/wvlet/airframe/metrics/ElapsedTimeTest.scala
@@ -16,7 +16,7 @@ package wvlet.airframe.metrics
 import wvlet.airspec.AirSpec
 
 import scala.concurrent.duration.TimeUnit
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 /**
   */
@@ -91,7 +91,7 @@ class ElapsedTimeTest extends AirSpec {
     ConversionExample(DAYS, HOURS, 24),
     ConversionExample(DAYS, DAYS, 1)
   )
-  import ElapsedTime._
+  import ElapsedTime.*
 
   test("parse time") {
     examples.foreach { x => ElapsedTime(x.str) shouldBe ElapsedTime(x.value, x.unit) }

--- a/airframe-msgpack/.jvm/src/main/scala/wvlet/airframe/msgpack/impl/PackerImpl.scala
+++ b/airframe-msgpack/.jvm/src/main/scala/wvlet/airframe/msgpack/impl/PackerImpl.scala
@@ -17,7 +17,7 @@ import java.math.BigInteger
 import org.msgpack.core.{MessageBufferPacker, MessagePacker}
 import org.msgpack.{value => v8}
 import wvlet.airframe.msgpack.io.ByteArrayBuffer
-import wvlet.airframe.msgpack.spi._
+import wvlet.airframe.msgpack.spi.*
 
 /**
   * Adapter to msgpack-core's MessagePacker
@@ -142,7 +142,7 @@ object PackerImpl {
   }
 
   def toMsgPackV8Value(v: Value): v8.Value = {
-    import wvlet.airframe.msgpack.spi.Value._
+    import wvlet.airframe.msgpack.spi.Value.*
     v match {
       case NilValue                   => v8.ValueFactory.newNil()
       case BooleanValue(v)            => v8.ValueFactory.newBoolean(v)
@@ -157,7 +157,7 @@ object PackerImpl {
         v8.ValueFactory.newExtension(-1, extBytes)
       }
       case ArrayValue(elems) =>
-        import scala.jdk.CollectionConverters._
+        import scala.jdk.CollectionConverters.*
         val values = elems.map(x => toMsgPackV8Value(x)).toList.asJava
         v8.ValueFactory.newArray(values)
       case MapValue(entries) =>

--- a/airframe-msgpack/.jvm/src/main/scala/wvlet/airframe/msgpack/impl/UnpackerImpl.scala
+++ b/airframe-msgpack/.jvm/src/main/scala/wvlet/airframe/msgpack/impl/UnpackerImpl.scala
@@ -18,7 +18,7 @@ import java.time.Instant
 import org.msgpack.core.{MessageInsufficientBufferException, MessageIntegerOverflowException, MessageUnpacker}
 import wvlet.airframe.msgpack.io.ByteArrayBuffer
 import wvlet.airframe.msgpack.spi.Value.{ExtensionValue, TimestampValue}
-import wvlet.airframe.msgpack.spi._
+import wvlet.airframe.msgpack.spi.*
 
 import scala.collection.immutable.ListMap
 
@@ -189,9 +189,9 @@ object UnpackerImpl {
   }
 
   import org.msgpack.{value => v8}
-  import wvlet.airframe.msgpack.spi.Value._
+  import wvlet.airframe.msgpack.spi.Value.*
 
-  import scala.jdk.CollectionConverters._
+  import scala.jdk.CollectionConverters.*
 
   def fromMsgPackV8Value(v: v8.Value): Value = {
     v match {

--- a/airframe-msgpack/src/main/scala/wvlet/airframe/msgpack/impl/PureScalaBufferUnpacker.scala
+++ b/airframe-msgpack/src/main/scala/wvlet/airframe/msgpack/impl/PureScalaBufferUnpacker.scala
@@ -16,7 +16,7 @@ package wvlet.airframe.msgpack.impl
 import java.math.BigInteger
 import java.time.Instant
 
-import wvlet.airframe.msgpack.spi._
+import wvlet.airframe.msgpack.spi.*
 
 /**
   */

--- a/airframe-msgpack/src/main/scala/wvlet/airframe/msgpack/io/ByteArrayBuffer.scala
+++ b/airframe-msgpack/src/main/scala/wvlet/airframe/msgpack/io/ByteArrayBuffer.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.msgpack.io
 
-import wvlet.airframe.msgpack.spi._
+import wvlet.airframe.msgpack.spi.*
 
 object ByteArrayBuffer {
   def newBuffer(size: Int): ByteArrayBuffer = apply(new Array[Byte](size))

--- a/airframe-msgpack/src/main/scala/wvlet/airframe/msgpack/json/StreamMessagePackBuilder.scala
+++ b/airframe-msgpack/src/main/scala/wvlet/airframe/msgpack/json/StreamMessagePackBuilder.scala
@@ -49,7 +49,7 @@ object StreamMessagePackBuilder {
 }
 
 class StreamMessagePackBuilder extends JSONContext[MsgPack] with LogSupport {
-  import StreamMessagePackBuilder._
+  import StreamMessagePackBuilder.*
   protected val packer = MessagePack.newBufferPacker
 
   protected var contextStack: List[ParseContext]         = Nil

--- a/airframe-msgpack/src/main/scala/wvlet/airframe/msgpack/spi/OffsetPacker.scala
+++ b/airframe-msgpack/src/main/scala/wvlet/airframe/msgpack/spi/OffsetPacker.scala
@@ -17,7 +17,7 @@ import java.math.BigInteger
 import java.nio.charset.StandardCharsets
 import java.time.Instant
 
-import wvlet.airframe.msgpack.spi.Code._
+import wvlet.airframe.msgpack.spi.Code.*
 
 /**
   * Write MessagePack code at a given position on the buffer and return the written byte length

--- a/airframe-msgpack/src/main/scala/wvlet/airframe/msgpack/spi/OffsetUnpacker.scala
+++ b/airframe-msgpack/src/main/scala/wvlet/airframe/msgpack/spi/OffsetUnpacker.scala
@@ -18,9 +18,9 @@ import java.nio.charset.StandardCharsets
 import java.time.Instant
 
 import wvlet.airframe.msgpack.spi.ErrorCode.{INVALID_EXT_FORMAT, INVALID_TYPE, NEVER_USED_FORMAT}
-import wvlet.airframe.msgpack.spi.MessageException._
-import wvlet.airframe.msgpack.spi.MessageFormat._
-import wvlet.airframe.msgpack.spi.Value._
+import wvlet.airframe.msgpack.spi.MessageException.*
+import wvlet.airframe.msgpack.spi.MessageFormat.*
+import wvlet.airframe.msgpack.spi.Value.*
 
 import scala.collection.immutable.ListMap
 import scala.collection.mutable

--- a/airframe-msgpack/src/main/scala/wvlet/airframe/msgpack/spi/Value.scala
+++ b/airframe-msgpack/src/main/scala/wvlet/airframe/msgpack/spi/Value.scala
@@ -18,7 +18,7 @@ import java.time.Instant
 import java.util
 import java.util.Base64
 
-import wvlet.airframe.msgpack.spi.MessageException._
+import wvlet.airframe.msgpack.spi.MessageException.*
 
 /**
   */
@@ -310,7 +310,7 @@ object Value {
 }
 
 object ValueFactory {
-  import Value._
+  import Value.*
   def newNil                            = NilValue
   def newBoolean(b: Boolean)            = BooleanValue(b)
   def newInteger(i: Int)                = LongValue(i)

--- a/airframe-msgpack/src/test/scala/wvlet/airframe/msgpack/spi/RoundTripTest.scala
+++ b/airframe-msgpack/src/test/scala/wvlet/airframe/msgpack/spi/RoundTripTest.scala
@@ -117,7 +117,7 @@ class RoundTripTest extends AirSpec with PropertyCheck {
   }
 
   test("pack/unpack values") {
-    import ValueFactory._
+    import ValueFactory.*
     val list: Seq[Value] = Seq(
       newNil,
       newBoolean(true),

--- a/airframe-msgpack/src/test/scala/wvlet/airframe/msgpack/spi/ValueTest.scala
+++ b/airframe-msgpack/src/test/scala/wvlet/airframe/msgpack/spi/ValueTest.scala
@@ -18,8 +18,8 @@ import java.util.Base64
 
 import org.scalacheck.Gen
 import wvlet.airframe.msgpack.io.ByteArrayBuffer
-import wvlet.airframe.msgpack.spi.Value._
-import wvlet.airframe.msgpack.spi.ValueFactory._
+import wvlet.airframe.msgpack.spi.Value.*
+import wvlet.airframe.msgpack.spi.ValueFactory.*
 import wvlet.airspec.spi.PropertyCheck
 import wvlet.airspec.AirSpec
 
@@ -167,7 +167,7 @@ class ValueTest extends AirSpec with PropertyCheck {
   test("check appropriate range for integers") {
     import java.lang.{Byte, Short}
 
-    import ValueFactory._
+    import ValueFactory.*
 
     newInteger(Byte.MAX_VALUE).asByte shouldBe Byte.MAX_VALUE
     newInteger(Byte.MIN_VALUE).asByte shouldBe Byte.MIN_VALUE

--- a/airframe-msgpack/src/test/scala/wvlet/airframe/msgpack/spi/ValueTypeTest.scala
+++ b/airframe-msgpack/src/test/scala/wvlet/airframe/msgpack/spi/ValueTypeTest.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.msgpack.spi
 
-import wvlet.airframe.msgpack.spi.Code._
+import wvlet.airframe.msgpack.spi.Code.*
 import wvlet.airspec.AirSpec
 
 /**

--- a/airframe-parquet/src/main/scala/wvlet/airframe/parquet/ParquetObjectWriter.scala
+++ b/airframe-parquet/src/main/scala/wvlet/airframe/parquet/ParquetObjectWriter.scala
@@ -24,7 +24,7 @@ import wvlet.airframe.msgpack.spi.{Code, MessagePack, MsgPack, Value}
 import wvlet.airframe.surface.{CName, Parameter, Surface}
 import wvlet.log.LogSupport
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 trait ParquetFieldWriter extends LogSupport {
   def index: Int

--- a/airframe-parquet/src/main/scala/wvlet/airframe/parquet/ParquetQueryPlanner.scala
+++ b/airframe-parquet/src/main/scala/wvlet/airframe/parquet/ParquetQueryPlanner.scala
@@ -36,8 +36,8 @@ case class ParquetQueryPlan(
   */
 object ParquetQueryPlanner extends LogSupport {
 
-  import LogicalPlan._
-  import wvlet.airframe.sql.model.Expression._
+  import LogicalPlan.*
+  import wvlet.airframe.sql.model.Expression.*
 
   def parse(sql: String, schema: MessageType): ParquetQueryPlan = {
     new PlanBuilder(schema).parse(sql)
@@ -75,7 +75,7 @@ object ParquetQueryPlanner extends LogSupport {
     }
 
     private def findParameterType(name: String): Option[PrimitiveTypeName] = {
-      import scala.jdk.CollectionConverters._
+      import scala.jdk.CollectionConverters.*
       schema.getFields.asScala.find(f => f.getName == name && f.isPrimitive).map { f =>
         f.asPrimitiveType().getPrimitiveTypeName
       }

--- a/airframe-parquet/src/main/scala/wvlet/airframe/parquet/ParquetReaderAdapter.scala
+++ b/airframe-parquet/src/main/scala/wvlet/airframe/parquet/ParquetReaderAdapter.scala
@@ -20,12 +20,12 @@ import org.apache.parquet.hadoop.api.ReadSupport.ReadContext
 import org.apache.parquet.hadoop.api.{InitContext, ReadSupport}
 import org.apache.parquet.hadoop.util.HadoopInputFile
 import org.apache.parquet.io.InputFile
-import org.apache.parquet.io.api._
+import org.apache.parquet.io.api.*
 import org.apache.parquet.schema.MessageType
 import wvlet.airframe.surface.{CName, Surface}
 
 import java.util
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 object ParquetReaderAdapter {
 

--- a/airframe-parquet/src/main/scala/wvlet/airframe/parquet/ParquetRecordReader.scala
+++ b/airframe-parquet/src/main/scala/wvlet/airframe/parquet/ParquetRecordReader.scala
@@ -21,7 +21,7 @@ import wvlet.airframe.codec.MessageCodec
 import wvlet.airframe.codec.PrimitiveCodec.ValueCodec
 import wvlet.airframe.surface.Surface
 import wvlet.log.LogSupport
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 object ParquetRecordReader extends LogSupport {
   private class IntConverter(fieldName: String, holder: RecordBuilder) extends PrimitiveConverter {
@@ -64,7 +64,7 @@ object ParquetRecordReader extends LogSupport {
 
 }
 
-import ParquetRecordReader._
+import ParquetRecordReader.*
 
 class ParquetRecordReader[A](
     surface: Surface,

--- a/airframe-parquet/src/main/scala/wvlet/airframe/parquet/ParquetSchema.scala
+++ b/airframe-parquet/src/main/scala/wvlet/airframe/parquet/ParquetSchema.scala
@@ -32,7 +32,7 @@ import wvlet.airframe.surface.{
 import wvlet.airframe.ulid.ULID
 
 import java.util.UUID
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 object ParquetSchema {
 

--- a/airframe-parquet/src/main/scala/wvlet/airframe/parquet/ParquetStatsReader.scala
+++ b/airframe-parquet/src/main/scala/wvlet/airframe/parquet/ParquetStatsReader.scala
@@ -21,7 +21,7 @@ import org.apache.parquet.schema.{LogicalTypeAnnotation, Type}
 import wvlet.log.LogSupport
 
 import java.util.concurrent.ConcurrentHashMap
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 case class ColumnStatistics(
     numNulls: Option[Long] = None,

--- a/airframe-parquet/src/main/scala/wvlet/airframe/parquet/ParquetWriterAdapter.scala
+++ b/airframe-parquet/src/main/scala/wvlet/airframe/parquet/ParquetWriterAdapter.scala
@@ -26,7 +26,7 @@ import org.apache.parquet.schema.MessageType
 import wvlet.airframe.surface.Surface
 import wvlet.log.LogSupport
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 /**
   */
@@ -78,7 +78,7 @@ class ParquetWriteSupportAdapter[A](surface: Surface) extends WriteSupport[A] wi
   }
 
   private var recordConsumer: RecordConsumer = null
-  import scala.jdk.CollectionConverters._
+  import scala.jdk.CollectionConverters.*
 
   override def init(configuration: Configuration): WriteSupport.WriteContext = {
     val extraMetadata: Map[String, String] = Map.empty

--- a/airframe-rx-html/.js/src/main/scala/wvlet/airframe/rx/html/DOMRenderer.scala
+++ b/airframe-rx-html/.js/src/main/scala/wvlet/airframe/rx/html/DOMRenderer.scala
@@ -258,7 +258,7 @@ object DOMRenderer extends LogSupport {
     } else {
       val targetValueToRemove = toRemove.trim
 
-      import scala.util.chaining._
+      import scala.util.chaining.*
       styleValue.trim
         .split(""";\s*""")
         .map(x => s"${x};")

--- a/airframe-rx-html/.js/src/test/scala/wvlet/airframe/http/rx/html/ElementCastTest.scala
+++ b/airframe-rx-html/.js/src/test/scala/wvlet/airframe/http/rx/html/ElementCastTest.scala
@@ -14,7 +14,7 @@
 package wvlet.airframe.http.rx.html
 
 import org.scalajs.dom.HTMLElement
-import wvlet.airframe.rx.html.all._
+import wvlet.airframe.rx.html.all.*
 import wvlet.airframe.rx.html.compat.MouseEvent
 import wvlet.airframe.rx.html.{RxDOM, RxElement}
 import wvlet.airspec.AirSpec
@@ -31,7 +31,7 @@ class ElementCastTest extends AirSpec {
   }
 
   test("cast with helper method") {
-    import RxDOM._
+    import RxDOM.*
     var handled = false
     val rx = new RxElement {
       override def render = div(

--- a/airframe-rx-html/.js/src/test/scala/wvlet/airframe/http/rx/html/HtmlRenderingTest.scala
+++ b/airframe-rx-html/.js/src/test/scala/wvlet/airframe/http/rx/html/HtmlRenderingTest.scala
@@ -15,8 +15,8 @@ package wvlet.airframe.rx.html
 
 import org.scalajs.dom
 import wvlet.airframe.rx.Rx
-import wvlet.airframe.rx.html.all._
-import wvlet.airspec._
+import wvlet.airframe.rx.html.all.*
+import wvlet.airspec.*
 
 class HtmlRenderingTest extends AirSpec {
 

--- a/airframe-rx-html/.js/src/test/scala/wvlet/airframe/http/rx/html/NestedElementTest.scala
+++ b/airframe-rx-html/.js/src/test/scala/wvlet/airframe/http/rx/html/NestedElementTest.scala
@@ -14,7 +14,7 @@
 package wvlet.airframe.rx.html
 
 import wvlet.airframe.rx.Rx
-import wvlet.airframe.rx.html.all._
+import wvlet.airframe.rx.html.all.*
 import wvlet.airspec.AirSpec
 
 /**

--- a/airframe-rx-html/.js/src/test/scala/wvlet/airframe/http/rx/html/OnClickTest.scala
+++ b/airframe-rx-html/.js/src/test/scala/wvlet/airframe/http/rx/html/OnClickTest.scala
@@ -16,8 +16,8 @@ package wvlet.airframe.rx.html
 import wvlet.airframe.rx.Rx
 import wvlet.airframe.rx.html.DOMRenderer
 import wvlet.airspec.AirSpec
-import wvlet.airframe.rx.html._
-import wvlet.airframe.rx.html.all._
+import wvlet.airframe.rx.html.*
+import wvlet.airframe.rx.html.all.*
 import org.scalajs.dom.HTMLElement
 import org.scalajs.dom.MouseEvent
 

--- a/airframe-rx-html/.js/src/test/scala/wvlet/airframe/http/rx/html/RxRenderingTest.scala
+++ b/airframe-rx-html/.js/src/test/scala/wvlet/airframe/http/rx/html/RxRenderingTest.scala
@@ -17,8 +17,8 @@ import org.scalajs.dom.{HTMLElement, document}
 import wvlet.airframe.rx.{Cancelable, Rx, html}
 import wvlet.airframe.rx.html.{DOMRenderer, Embedded, RxElement}
 import wvlet.airspec.AirSpec
-import wvlet.airframe.rx.html._
-import wvlet.airframe.rx.html.all._
+import wvlet.airframe.rx.html.*
+import wvlet.airframe.rx.html.all.*
 
 /**
   */

--- a/airframe-rx-html/src/main/scala-2/wvlet/airframe/rx/html/RxHtmlMacros.scala
+++ b/airframe-rx-html/src/main/scala-2/wvlet/airframe/rx/html/RxHtmlMacros.scala
@@ -20,7 +20,7 @@ import scala.reflect.macros.{blackbox => sm}
   */
 private[html] object RxHtmlMacros {
   def code(c: sm.Context)(rxElements: c.Tree*): c.Tree = {
-    import c.universe._
+    import c.universe.*
 
     val codes = for (rxElement <- rxElements) yield {
       val pos = rxElement.pos

--- a/airframe-rx-html/src/main/scala/wvlet/airframe/rx/html/HtmlNode.scala
+++ b/airframe-rx-html/src/main/scala/wvlet/airframe/rx/html/HtmlNode.scala
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 package wvlet.airframe.rx.html
-import wvlet.airframe.rx.html.RxEmbedding._
+import wvlet.airframe.rx.html.RxEmbedding.*
 
 trait HtmlNode extends HtmlNodeBase {
   @deprecated("Use html.when(cond, node)", since = "23.7.0")

--- a/airframe-rx-html/src/main/scala/wvlet/airframe/rx/html/RxElement.scala
+++ b/airframe-rx-html/src/main/scala/wvlet/airframe/rx/html/RxElement.scala
@@ -15,7 +15,7 @@ package wvlet.airframe.rx.html
 
 import wvlet.airframe.rx.{Cancelable, Rx}
 import wvlet.log.LogSupport
-import wvlet.airframe.rx.html.RxEmbedding._
+import wvlet.airframe.rx.html.RxEmbedding.*
 
 /**
   */

--- a/airframe-rx-html/src/main/scala/wvlet/airframe/rx/html/RxEmbedding.scala
+++ b/airframe-rx-html/src/main/scala/wvlet/airframe/rx/html/RxEmbedding.scala
@@ -20,7 +20,7 @@ import scala.language.higherKinds
 import scala.language.implicitConversions
 
 trait RxEmbedding {
-  import RxEmbedding._
+  import RxEmbedding.*
   implicit def embedAsNode[A: EmbeddableNode](v: A): RxElement = Embedded(v)
 }
 

--- a/airframe-rx-html/src/test/scala/wvlet/airframe/rx/html/HtmlTest.scala
+++ b/airframe-rx-html/src/test/scala/wvlet/airframe/rx/html/HtmlTest.scala
@@ -14,8 +14,8 @@
 package wvlet.airframe.rx.html
 
 import wvlet.airframe.rx.Rx
-import wvlet.airframe.rx.html._
-import wvlet.airframe.rx.html.all._
+import wvlet.airframe.rx.html.*
+import wvlet.airframe.rx.html.all.*
 import wvlet.airspec.AirSpec
 
 /**
@@ -146,7 +146,7 @@ class HtmlTest extends AirSpec {
   }
 
   test("extra tags") {
-    import tags_extra._
+    import tags_extra.*
     div(
       abbr(),
       acronym(),
@@ -191,8 +191,8 @@ class HtmlTest extends AirSpec {
   }
 
   test(s"svg tags") {
-    import svgTags._
-    import svgAttrs._
+    import svgTags.*
+    import svgAttrs.*
     svg(
       circle(
         color -> "",
@@ -202,8 +202,8 @@ class HtmlTest extends AirSpec {
   }
 
   test("svg group") {
-    import svgTags._
-    import svgAttrs._
+    import svgTags.*
+    import svgAttrs.*
     g(
       // timeline background
       rect(

--- a/airframe-rx-html/src/test/scala/wvlet/airframe/rx/html/RxComponentTest.scala
+++ b/airframe-rx-html/src/test/scala/wvlet/airframe/rx/html/RxComponentTest.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.rx.html
 
-import wvlet.airframe.rx.html.all._
+import wvlet.airframe.rx.html.all.*
 import wvlet.airspec.AirSpec
 
 /**

--- a/airframe-rx-html/src/test/scala/wvlet/airframe/rx/html/RxElementTest.scala
+++ b/airframe-rx-html/src/test/scala/wvlet/airframe/rx/html/RxElementTest.scala
@@ -14,7 +14,7 @@
 package wvlet.airframe.rx.html
 
 import wvlet.airframe.rx.{Cancelable, Rx}
-import wvlet.airframe.rx.html.all._
+import wvlet.airframe.rx.html.all.*
 import wvlet.airspec.AirSpec
 
 /**

--- a/airframe-rx-widget/src/main/scala/wvlet/airframe/rx/html/widget/auth/GoogleAuth.scala
+++ b/airframe-rx-widget/src/main/scala/wvlet/airframe/rx/html/widget/auth/GoogleAuth.scala
@@ -16,7 +16,7 @@ package wvlet.airframe.rx.html.widget.auth
 /**
   */
 
-import wvlet.airframe.rx._
+import wvlet.airframe.rx.*
 import wvlet.log.LogSupport
 
 import scala.concurrent.Promise

--- a/airframe-rx-widget/src/main/scala/wvlet/airframe/rx/html/widget/editor/Monaco.scala
+++ b/airframe-rx-widget/src/main/scala/wvlet/airframe/rx/html/widget/editor/Monaco.scala
@@ -3987,9 +3987,10 @@ package editor {
         @JSGlobal("monaco.languages.typescript")
         object Typescript extends js.Object {
           type CompilerOptionsValue =
-            String | Double | Boolean | js.Array[String | Double] | js.Array[String] | MapLike[
-              js.Array[String]
-            ] | Null | Unit
+            String | Double | Boolean | js.Array[String | Double] | js.Array[String] |
+              MapLike[
+                js.Array[String]
+              ] | Null | Unit
         }
 
       }
@@ -4342,9 +4343,10 @@ package editor {
         type IMonarchLanguageRule =
           IShortMonarchLanguageRule1 | IShortMonarchLanguageRule2 | IExpandedMonarchLanguageRule
         type IShortMonarchLanguageAction = String
-        type IMonarchLanguageAction = IShortMonarchLanguageAction | IExpandedMonarchLanguageAction | js.Array[
-          IShortMonarchLanguageAction
-        ] | js.Array[IExpandedMonarchLanguageAction]
+        type IMonarchLanguageAction = IShortMonarchLanguageAction | IExpandedMonarchLanguageAction |
+          js.Array[
+            IShortMonarchLanguageAction
+          ] | js.Array[IExpandedMonarchLanguageAction]
       }
 
     }

--- a/airframe-rx-widget/src/main/scala/wvlet/airframe/rx/html/widget/editor/Monaco.scala
+++ b/airframe-rx-widget/src/main/scala/wvlet/airframe/rx/html/widget/editor/Monaco.scala
@@ -1,7 +1,7 @@
 package wvlet.airframe.rx.html.widget
 
 import scala.scalajs.js
-import js.annotation._
+import js.annotation.*
 import js.|
 
 package editor {

--- a/airframe-rx-widget/src/main/scala/wvlet/airframe/rx/html/widget/ui/bootstrap/Alert.scala
+++ b/airframe-rx-widget/src/main/scala/wvlet/airframe/rx/html/widget/ui/bootstrap/Alert.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.rx.html.widget.ui.bootstrap
 import wvlet.airframe.rx.html.RxComponent
-import wvlet.airframe.rx.html.all._
+import wvlet.airframe.rx.html.all.*
 
 /**
   */

--- a/airframe-rx-widget/src/main/scala/wvlet/airframe/rx/html/widget/ui/bootstrap/Button.scala
+++ b/airframe-rx-widget/src/main/scala/wvlet/airframe/rx/html/widget/ui/bootstrap/Button.scala
@@ -14,7 +14,7 @@
 package wvlet.airframe.rx.html.widget.ui.bootstrap
 
 import wvlet.airframe.rx.html.RxElement
-import wvlet.airframe.rx.html._
+import wvlet.airframe.rx.html.*
 import wvlet.airframe.rx.html.all.{button, cls, disabled, tpe}
 import wvlet.log.LogSupport
 

--- a/airframe-rx-widget/src/main/scala/wvlet/airframe/rx/html/widget/ui/bootstrap/bootstrap.scala
+++ b/airframe-rx-widget/src/main/scala/wvlet/airframe/rx/html/widget/ui/bootstrap/bootstrap.scala
@@ -14,7 +14,7 @@
 package wvlet.airframe.rx.html.widget.ui.bootstrap
 
 import wvlet.airframe.rx.html.{RxElement, tags}
-import wvlet.airframe.rx.html.all._
+import wvlet.airframe.rx.html.all.*
 
 /**
   * Twitter Bootstrap extensions

--- a/airframe-rx-widget/src/test/scala/wvlet/airframe/http/rx/widget/RxWidgetTest.scala
+++ b/airframe-rx-widget/src/test/scala/wvlet/airframe/http/rx/widget/RxWidgetTest.scala
@@ -15,11 +15,11 @@ package wvlet.airframe.rx.html.widget
 
 import org.scalajs.dom
 import wvlet.airframe.rx.Rx
-import wvlet.airframe.rx.html._
-import wvlet.airframe.rx.html.all._
+import wvlet.airframe.rx.html.*
+import wvlet.airframe.rx.html.all.*
 import wvlet.airframe.rx.html.{DOMRenderer, Embedded, RxComponent, RxElement}
-import wvlet.airframe.rx.html.widget.ui.bootstrap._
-import wvlet.airspec._
+import wvlet.airframe.rx.html.widget.ui.bootstrap.*
+import wvlet.airspec.*
 
 object RxWidgetTest {}
 

--- a/airframe-rx/src/main/scala/wvlet/airframe/rx/Rx.scala
+++ b/airframe-rx/src/main/scala/wvlet/airframe/rx/Rx.scala
@@ -24,7 +24,7 @@ import scala.util.{Failure, Success, Try}
   * @tparam A
   */
 trait RxOps[+A] { self =>
-  import Rx._
+  import Rx.*
 
   def parents: Seq[RxOps[_]]
 
@@ -132,7 +132,7 @@ trait Rx[+A] extends RxOps[A] {
     compat.toSeq(this)
   }
 
-  import Rx._
+  import Rx.*
 
   override def toRx: Rx[A] = this
   def toOption[X, A1 >: A](implicit ev: A1 <:< Option[X]): RxOption[X] = RxOptionOp(

--- a/airframe-rx/src/main/scala/wvlet/airframe/rx/RxRunner.scala
+++ b/airframe-rx/src/main/scala/wvlet/airframe/rx/RxRunner.scala
@@ -73,7 +73,7 @@ class RxRunner(
     continuous: Boolean
 ) extends LogSupport { runner =>
 
-  import Rx._
+  import Rx.*
 
   /**
     * Build an executable chain of Rx operators. The resulting chain will be registered as a subscriber to the root node

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/CTEResolver.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/CTEResolver.scala
@@ -15,7 +15,7 @@ package wvlet.airframe.sql.analyzer
 
 import wvlet.airframe.sql.SQLErrorCode
 import wvlet.airframe.sql.model.LogicalPlan
-import wvlet.airframe.sql.model.LogicalPlan._
+import wvlet.airframe.sql.model.LogicalPlan.*
 import wvlet.log.LogSupport
 
 /**

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/InOutTableFinder.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/InOutTableFinder.scala
@@ -16,7 +16,7 @@ package wvlet.airframe.sql.analyzer
 import wvlet.airframe.sql.analyzer.InOutTableFinder.TableScanContext
 import wvlet.airframe.sql.analyzer.TableGraph.{Alias, SourceTable, TargetTable}
 import wvlet.airframe.sql.model.LogicalPlan
-import wvlet.airframe.sql.model.LogicalPlan._
+import wvlet.airframe.sql.model.LogicalPlan.*
 
 /**
   * Find input/output tables in an SQL statement

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/SQLAnalyzer.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/SQLAnalyzer.scala
@@ -14,7 +14,7 @@
 package wvlet.airframe.sql.analyzer
 
 import wvlet.airframe.sql.catalog.Catalog
-import wvlet.airframe.sql.model._
+import wvlet.airframe.sql.model.*
 import wvlet.airframe.sql.parser.SQLParser
 import wvlet.log.LogSupport
 

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/SQLAnonymizer.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/SQLAnonymizer.scala
@@ -16,7 +16,7 @@ package wvlet.airframe.sql.analyzer
 import java.util.concurrent.atomic.AtomicInteger
 
 import wvlet.log.LogSupport
-import wvlet.airframe.sql.model._
+import wvlet.airframe.sql.model.*
 import wvlet.airframe.sql.parser.{SQLGenerator, SQLParser}
 
 class SQLAnonymizer(dict: Map[Expression, Expression]) {
@@ -66,7 +66,7 @@ object SQLAnonymizer extends LogSupport {
     b.build
   }
 
-  import Expression._
+  import Expression.*
 
   private class DictBuilder {
     val m                  = Map.newBuilder[Expression, Expression]

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala
@@ -14,9 +14,9 @@
 package wvlet.airframe.sql.analyzer
 import wvlet.airframe.sql.{SQLError, SQLErrorCode}
 import wvlet.airframe.sql.analyzer.RewriteRule.PlanRewriter
-import wvlet.airframe.sql.model.Expression._
-import wvlet.airframe.sql.model.LogicalPlan._
-import wvlet.airframe.sql.model._
+import wvlet.airframe.sql.model.Expression.*
+import wvlet.airframe.sql.model.LogicalPlan.*
+import wvlet.airframe.sql.model.*
 import wvlet.log.LogSupport
 
 import scala.annotation.tailrec

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/catalog/DataTypeParser.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/catalog/DataTypeParser.scala
@@ -20,7 +20,7 @@ import scala.util.parsing.combinator.RegexParsers
 
 object DataTypeParser extends RegexParsers with LogSupport {
 
-  import DataType._
+  import DataType.*
 
   override def skipWhitespace = true
 

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/catalog/FunctionCatalog.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/catalog/FunctionCatalog.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.sql.catalog
 
-import wvlet.airframe.sql.Assertion._
+import wvlet.airframe.sql.Assertion.*
 
 /**
   * Manage the list of unbounded functions, whose types are not resolved yet.

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/Expression.scala
@@ -16,10 +16,10 @@ package wvlet.airframe.sql.model
 
 import wvlet.airframe.sql.analyzer.AnalyzerContext
 import wvlet.airframe.sql.catalog.DataType
-import wvlet.airframe.sql.catalog.DataType._
+import wvlet.airframe.sql.catalog.DataType.*
 import wvlet.airframe.sql.model.Expression.{AllColumns, MultiSourceColumn}
 import wvlet.airframe.sql.parser.SQLGenerator
-import wvlet.airframe.sql.Assertion._
+import wvlet.airframe.sql.Assertion.*
 import wvlet.log.LogSupport
 
 import java.util.Locale

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/model/LogicalPlan.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.sql.model
 import wvlet.airframe.sql.analyzer.{QuerySignatureConfig}
-import wvlet.airframe.sql.Assertion._
+import wvlet.airframe.sql.Assertion.*
 import wvlet.log.LogSupport
 
 import java.util.UUID
@@ -474,7 +474,7 @@ trait SQLSig {
 }
 
 object LogicalPlan {
-  import Expression._
+  import Expression.*
 
   private def isSelectAll(selectItems: Seq[Attribute]): Boolean = {
     selectItems.exists {

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLGenerator.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLGenerator.scala
@@ -14,14 +14,14 @@
 
 package wvlet.airframe.sql.parser
 import wvlet.log.LogSupport
-import wvlet.airframe.sql.model._
-import wvlet.airframe.sql.model.LogicalPlan._
+import wvlet.airframe.sql.model.*
+import wvlet.airframe.sql.model.LogicalPlan.*
 
 /**
   * Print LogicalPlans As SQL statements
   */
 object SQLGenerator extends LogSupport {
-  import Expression._
+  import Expression.*
 
   private def unknown(e: Any): String = {
     if (e != null) {

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLInterpreter.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLInterpreter.scala
@@ -17,9 +17,9 @@ import org.antlr.v4.runtime.{ParserRuleContext, Token}
 import org.antlr.v4.runtime.tree.TerminalNode
 import wvlet.airframe.sql.SQLErrorCode
 import wvlet.log.LogSupport
-import wvlet.airframe.sql.model._
-import wvlet.airframe.sql.model.LogicalPlan._
-import wvlet.airframe.sql.parser.SqlBaseParser._
+import wvlet.airframe.sql.model.*
+import wvlet.airframe.sql.model.LogicalPlan.*
+import wvlet.airframe.sql.parser.SqlBaseParser.*
 
 object SQLInterpreter {
   private[parser] def unquote(s: String): String = {
@@ -31,10 +31,10 @@ object SQLInterpreter {
   * ANTLR parse tree -> SQL LogicalPlan
   */
 class SQLInterpreter(withNodeLocation: Boolean = true) extends SqlBaseBaseVisitor[Any] with LogSupport {
-  import SQLInterpreter._
-  import wvlet.airframe.sql.model.Expression._
+  import SQLInterpreter.*
+  import wvlet.airframe.sql.model.Expression.*
 
-  import scala.jdk.CollectionConverters._
+  import scala.jdk.CollectionConverters.*
 
   private val parserRules            = SqlBaseParser.ruleNames.toList.asJava
   private var parameterPosition: Int = 0

--- a/airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLParser.scala
+++ b/airframe-sql/src/main/scala/wvlet/airframe/sql/parser/SQLParser.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.sql.parser
 
-import org.antlr.v4.runtime.{DefaultErrorStrategy, RecognitionException, _}
+import org.antlr.v4.runtime.{DefaultErrorStrategy, RecognitionException, *}
 import wvlet.airframe.sql.SQLErrorCode
 import wvlet.log.LogSupport
 import wvlet.airframe.sql.model.{Expression, LogicalPlan, NodeLocation}

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
@@ -13,11 +13,11 @@
  */
 package wvlet.airframe.sql.analyzer
 
-import wvlet.airframe.sql.catalog.Catalog._
+import wvlet.airframe.sql.catalog.Catalog.*
 import wvlet.airframe.sql.catalog.{Catalog, DataType, InMemoryCatalog}
-import wvlet.airframe.sql.model.Expression._
-import wvlet.airframe.sql.model.LogicalPlan._
-import wvlet.airframe.sql.model._
+import wvlet.airframe.sql.model.Expression.*
+import wvlet.airframe.sql.model.LogicalPlan.*
+import wvlet.airframe.sql.model.*
 import wvlet.airframe.sql.{SQLError, SQLErrorCode}
 import wvlet.airspec.AirSpec
 import wvlet.airspec.spi.AssertionFailure

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/catalog/DataTypeTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/catalog/DataTypeTest.scala
@@ -13,7 +13,7 @@
  */
 
 package wvlet.airframe.sql.catalog
-import wvlet.airframe.sql.catalog.DataType._
+import wvlet.airframe.sql.catalog.DataType.*
 import wvlet.airspec.AirSpec
 
 class DataTypeTest extends AirSpec {

--- a/airframe-surface/.js/src/main/scala/wvlet/airframe/surface/package.scala
+++ b/airframe-surface/.js/src/main/scala/wvlet/airframe/surface/package.scala
@@ -15,7 +15,7 @@ package wvlet.airframe
 
 import java.util.concurrent.ConcurrentHashMap
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.collection.mutable
 
 /**

--- a/airframe-surface/.jvm/src/main/scala-2/wvlet/airframe/surface/package.scala
+++ b/airframe-surface/.jvm/src/main/scala-2/wvlet/airframe/surface/package.scala
@@ -17,7 +17,7 @@ import wvlet.airframe.surface.reflect.ReflectSurfaceFactory
 
 import java.util.concurrent.ConcurrentHashMap
 import scala.collection.mutable
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 /**
   */

--- a/airframe-surface/.jvm/src/main/scala-2/wvlet/airframe/surface/reflect/ReflectSurfaceFactory.scala
+++ b/airframe-surface/.jvm/src/main/scala-2/wvlet/airframe/surface/reflect/ReflectSurfaceFactory.scala
@@ -17,16 +17,16 @@ import wvlet.airframe.surface.TypeName.sanitizeTypeName
 
 import java.lang.reflect.{Constructor, InvocationTargetException}
 import java.util.concurrent.ConcurrentHashMap
-import wvlet.airframe.surface._
+import wvlet.airframe.surface.*
 import wvlet.log.LogSupport
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.reflect.runtime.{universe => ru}
 
 /**
   */
 object ReflectSurfaceFactory extends LogSupport {
-  import ru._
+  import ru.*
 
   private type TypeName = String
 

--- a/airframe-surface/.jvm/src/main/scala-2/wvlet/airframe/surface/reflect/RuntimeSurface.scala
+++ b/airframe-surface/.jvm/src/main/scala-2/wvlet/airframe/surface/reflect/RuntimeSurface.scala
@@ -14,7 +14,7 @@
 package wvlet.airframe.surface.reflect
 
 import wvlet.log.LogSupport
-import wvlet.airframe.surface._
+import wvlet.airframe.surface.*
 
 import scala.reflect.runtime.{universe => ru}
 

--- a/airframe-surface/.jvm/src/main/scala-3/wvlet/airframe/surface/package.scala
+++ b/airframe-surface/.jvm/src/main/scala-3/wvlet/airframe/surface/package.scala
@@ -2,7 +2,7 @@ package wvlet.airframe
 
 import java.util.concurrent.ConcurrentHashMap
 import scala.collection.mutable
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 package object surface {
   val surfaceCache       = new ConcurrentHashMap[String, Surface]().asScala

--- a/airframe-surface/.jvm/src/main/scala-3/wvlet/airframe/surface/reflect/ReflectSurfaceFactory.scala
+++ b/airframe-surface/.jvm/src/main/scala-3/wvlet/airframe/surface/reflect/ReflectSurfaceFactory.scala
@@ -14,9 +14,9 @@
 package wvlet.airframe.surface.reflect
 
 import wvlet.log.LogSupport
-import wvlet.airframe.surface._
+import wvlet.airframe.surface.*
 
 object ReflectSurfaceFactory {
-  def ofClass(cl: Class[_]): Surface                   = TastySurfaceFactory.ofClass(cl)
-  def methodsOfClass(cl: Class[_]): Seq[MethodSurface] = TastySurfaceFactory.methodsOfClass(cl)
+  def ofClass(cl: Class[?]): Surface                   = TastySurfaceFactory.ofClass(cl)
+  def methodsOfClass(cl: Class[?]): Seq[MethodSurface] = TastySurfaceFactory.methodsOfClass(cl)
 }

--- a/airframe-surface/.jvm/src/main/scala-3/wvlet/airframe/surface/reflect/TastySurfaceFactory.scala
+++ b/airframe-surface/.jvm/src/main/scala-3/wvlet/airframe/surface/reflect/TastySurfaceFactory.scala
@@ -5,8 +5,8 @@ import wvlet.airframe.surface.{MethodSurface, Surface, Primitive}
 import wvlet.airframe.surface.CompileTimeSurfaceFactory
 
 import java.util.concurrent.ConcurrentHashMap
-import scala.quoted._
-import scala.tasty.inspector._
+import scala.quoted.*
+import scala.tasty.inspector.*
 
 object TastySurfaceFactory extends LogSupport {
 
@@ -14,17 +14,17 @@ object TastySurfaceFactory extends LogSupport {
 
   inline def of[A]: Surface = ${ CompileTimeSurfaceFactory.surfaceOf[A] }
 
-  import scala.jdk.CollectionConverters._
+  import scala.jdk.CollectionConverters.*
   private val cache = new ConcurrentHashMap[Class[_], Surface]().asScala
 
-  def ofClass(cl: Class[_]): Surface = {
+  def ofClass(cl: Class[?]): Surface = {
     debug(s"ofClass: ${cl}")
     cache.getOrElseUpdate(
       cl, {
         debug(s"Update cache for ${cl}")
         // Generates Surface from a runtime class
         staging.run { (quotes: Quotes) ?=>
-          import quotes.reflect._
+          import quotes.reflect.*
           val tastyType = quotes.reflect.TypeRepr.typeConstructorOf(cl)
           debug(tastyType)
           val f = new CompileTimeSurfaceFactory(using quotes)
@@ -40,10 +40,10 @@ object TastySurfaceFactory extends LogSupport {
     )
   }
 
-  def methodsOfClass(cl: Class[_]): Seq[MethodSurface] = {
+  def methodsOfClass(cl: Class[?]): Seq[MethodSurface] = {
     // Generates Surface from a runtime class
     val code: Seq[MethodSurface] = staging.run { (quotes: Quotes) ?=>
-      import quotes.reflect._
+      import quotes.reflect.*
       val tastyType = quotes.reflect.TypeRepr.typeConstructorOf(cl)
       debug(tastyType)
       val f = new CompileTimeSurfaceFactory(using quotes)

--- a/airframe-surface/.jvm/src/main/scala/wvlet/airframe/surface/reflect/MethodCallBuilder.scala
+++ b/airframe-surface/.jvm/src/main/scala/wvlet/airframe/surface/reflect/MethodCallBuilder.scala
@@ -15,7 +15,7 @@ package wvlet.airframe.surface.reflect
 
 /**
   */
-import wvlet.airframe.surface.CanonicalNameFormatter._
+import wvlet.airframe.surface.CanonicalNameFormatter.*
 import wvlet.airframe.surface.{CName, MethodParameter, MethodSurface, Zero}
 import wvlet.log.LogSupport
 

--- a/airframe-surface/.jvm/src/main/scala/wvlet/airframe/surface/reflect/ObjectBuilder.scala
+++ b/airframe-surface/.jvm/src/main/scala/wvlet/airframe/surface/reflect/ObjectBuilder.scala
@@ -13,14 +13,14 @@
  */
 package wvlet.airframe.surface.reflect
 
-import wvlet.airframe.surface.CanonicalNameFormatter._
-import wvlet.airframe.surface._
-import wvlet.airframe.surface.reflect.ReflectTypeUtil._
+import wvlet.airframe.surface.CanonicalNameFormatter.*
+import wvlet.airframe.surface.*
+import wvlet.airframe.surface.reflect.ReflectTypeUtil.*
 import wvlet.log.LogSupport
 
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.language.existentials
 
 //--------------------------------------
@@ -72,7 +72,7 @@ trait ObjectBuilder extends GenericBuilder {
   * ObjectBuilder support overriding nested parameters by specifying a parameter path (Path)
   */
 trait StandardBuilder extends GenericBuilder with LogSupport {
-  import ObjectBuilder._
+  import ObjectBuilder.*
 
   protected val holder = collection.mutable.Map.empty[String, BuilderElement]
 

--- a/airframe-surface/.jvm/src/main/scala/wvlet/airframe/surface/reflect/RuntimeMethodParameter.scala
+++ b/airframe-surface/.jvm/src/main/scala/wvlet/airframe/surface/reflect/RuntimeMethodParameter.scala
@@ -16,7 +16,7 @@ package wvlet.airframe.surface.reflect
 import java.{lang => jl}
 import java.lang.invoke.MethodHandles
 import java.lang.reflect.Method
-import wvlet.airframe.surface._
+import wvlet.airframe.surface.*
 import wvlet.log.LogSupport
 
 import scala.util.Try

--- a/airframe-surface/.jvm/src/main/scala/wvlet/airframe/surface/reflect/TypeConverter.scala
+++ b/airframe-surface/.jvm/src/main/scala/wvlet/airframe/surface/reflect/TypeConverter.scala
@@ -22,14 +22,14 @@ import wvlet.airframe.surface.{Primitive, Surface, Zero}
 
 import scala.collection.mutable
 import scala.reflect.ClassTag
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 /**
   */
 object TypeConverter extends LogSupport {
   import java.lang.{reflect => jr}
 
-  import ReflectTypeUtil._
+  import ReflectTypeUtil.*
 
   def convert[T](value: T, targetType: Surface): Option[Any] = {
     if (value == null) {

--- a/airframe-surface/.jvm/src/test/scala/wvlet/airframe/surface/ClassSurfaceTest.scala
+++ b/airframe-surface/.jvm/src/test/scala/wvlet/airframe/surface/ClassSurfaceTest.scala
@@ -14,7 +14,7 @@
 
 package wvlet.airframe.surface
 
-import wvlet.airframe.surface.tag._
+import wvlet.airframe.surface.tag.*
 
 object ClassSurfaceTest {
   class A(val id: Int)(implicit val context: String)
@@ -23,7 +23,7 @@ object ClassSurfaceTest {
   case class B(v: Int @@ MyTag)
 }
 
-import wvlet.airframe.surface.ClassSurfaceTest._
+import wvlet.airframe.surface.ClassSurfaceTest.*
 
 class ClassSurfaceTest extends SurfaceSpec {
   test("support multiple param blocks") {

--- a/airframe-surface/.jvm/src/test/scala/wvlet/airframe/surface/SurfaceJVMTest.scala
+++ b/airframe-surface/.jvm/src/test/scala/wvlet/airframe/surface/SurfaceJVMTest.scala
@@ -21,7 +21,7 @@ object SurfaceJVMTest {
   type MyChrono = ChronoUnit
 }
 
-import SurfaceJVMTest._
+import SurfaceJVMTest.*
 class SurfaceJVMTest extends SurfaceSpec {
   test("resolve ParSeq") {
     pendingUntil("ParSeq is not available in Scala 2.13")

--- a/airframe-surface/.jvm/src/test/scala/wvlet/airframe/surface/reflect/PathTest.scala
+++ b/airframe-surface/.jvm/src/test/scala/wvlet/airframe/surface/reflect/PathTest.scala
@@ -18,7 +18,7 @@ import wvlet.airframe.surface.SurfaceSpec
 /**
   */
 class PathTest extends SurfaceSpec {
-  import Path._
+  import Path.*
 
   test("define root") {
     val r = Path.root

--- a/airframe-surface/.jvm/src/test/scala/wvlet/airframe/surface/reflect/RuntimeSurfaceTest.scala
+++ b/airframe-surface/.jvm/src/test/scala/wvlet/airframe/surface/reflect/RuntimeSurfaceTest.scala
@@ -45,7 +45,7 @@ object RuntimeExamples {
 /**
   */
 class RuntimeSurfaceTest extends SurfaceSpec {
-  import RuntimeExamples._
+  import RuntimeExamples.*
 
   test("resolve types") {
     val a = check(RuntimeSurface.of[A], "A")

--- a/airframe-surface/.jvm/src/test/scala/wvlet/airframe/surface/reflect/RuntimeTaggedTypeTest.scala
+++ b/airframe-surface/.jvm/src/test/scala/wvlet/airframe/surface/reflect/RuntimeTaggedTypeTest.scala
@@ -15,7 +15,7 @@ package wvlet.airframe.surface.reflect
 
 import wvlet.airframe.surface.{Surface, SurfaceSpec}
 
-import wvlet.airframe.surface.tag._
+import wvlet.airframe.surface.tag.*
 
 object RuntimeTaggedTypeTest {
   case class Person(id: Int, name: String)
@@ -29,7 +29,7 @@ object RuntimeTaggedTypeTest {
 
 /**
   */
-import RuntimeTaggedTypeTest._
+import RuntimeTaggedTypeTest.*
 class RuntimeTaggedTypeTest extends SurfaceSpec {
   test("pass sanity check") {
     val e: Person @@ Employee = new Person(1, "leo").taggedWith[Employee]

--- a/airframe-surface/src/main/scala-2/wvlet/airframe/surface/SurfaceMacros.scala
+++ b/airframe-surface/src/main/scala-2/wvlet/airframe/surface/SurfaceMacros.scala
@@ -23,7 +23,7 @@ import scala.reflect.macros.{blackbox => sm}
   */
 private[surface] object SurfaceMacros {
   def surfaceOf[A: c.WeakTypeTag](c: sm.Context): c.Tree = {
-    import c.universe._
+    import c.universe.*
     val targetType = implicitly[c.WeakTypeTag[A]].tpe
     val t          = targetType.typeSymbol
     if (t.isStatic) {
@@ -41,7 +41,7 @@ private[surface] object SurfaceMacros {
   }
 
   def methodSurfaceOf[A: c.WeakTypeTag](c: sm.Context): c.Tree = {
-    import c.universe._
+    import c.universe.*
     val targetType = implicitly[c.WeakTypeTag[A]].tpe
     q"wvlet.airframe.surface.SurfaceFactory.methodsOf[${targetType}]"
   }
@@ -62,7 +62,7 @@ private[surface] object SurfaceMacros {
   }
 
   private[surface] class SurfaceGenerator[C <: sm.Context](val c: C) {
-    import c.universe._
+    import c.universe.*
 
     private val seen       = scala.collection.mutable.Set[Type]()
     private val memo       = scala.collection.mutable.Map[Type, c.Tree]()

--- a/airframe-surface/src/main/scala-3/wvlet/airframe/surface/Surface.scala
+++ b/airframe-surface/src/main/scala-3/wvlet/airframe/surface/Surface.scala
@@ -19,7 +19,7 @@ package wvlet.airframe.surface
   * in the same file, so this interface is copied.
   */
 trait Surface extends Serializable {
-  def rawType: Class[_]
+  def rawType: Class[?]
   def typeArgs: Seq[Surface]
   def params: Seq[Parameter]
   def name: String
@@ -44,7 +44,7 @@ trait Surface extends Serializable {
 object Surface {
   private[surface] val scalaMajorVersion: Int = 3
 
-  import scala.quoted._
+  import scala.quoted.*
 
   inline def of[A]: Surface                   = ${ CompileTimeSurfaceFactory.surfaceOf[A] }
   inline def methodsOf[A]: Seq[MethodSurface] = ${ CompileTimeSurfaceFactory.methodsOf[A] }

--- a/airframe-surface/src/main/scala/wvlet/airframe/surface/Zero.scala
+++ b/airframe-surface/src/main/scala/wvlet/airframe/surface/Zero.scala
@@ -24,7 +24,7 @@ import scala.reflect.ClassTag
   * Create a default instance (zero) from Surface
   */
 object Zero extends LogSupport {
-  import scala.jdk.CollectionConverters._
+  import scala.jdk.CollectionConverters.*
   private val preregisteredZeroInstance = new ConcurrentHashMap[Surface, Any]().asScala
 
   /**

--- a/airframe-surface/src/test/scala/wvlet/airframe/surface/EnumTest.scala
+++ b/airframe-surface/src/test/scala/wvlet/airframe/surface/EnumTest.scala
@@ -30,7 +30,7 @@ object EnumTest {
 }
 
 class EnumTest extends munit.FunSuite {
-  import EnumTest._
+  import EnumTest.*
 
   test("Find Surface.stringExtractor") {
     Surface.of[Color] match {

--- a/airframe-surface/src/test/scala/wvlet/airframe/surface/GenericMethodTest.scala
+++ b/airframe-surface/src/test/scala/wvlet/airframe/surface/GenericMethodTest.scala
@@ -20,7 +20,7 @@ object GenericMethodTest {
 }
 
 class GenericMethodTest extends SurfaceSpec {
-  import GenericMethodTest._
+  import GenericMethodTest.*
 
   test("generic method") {
     val methods = Surface.methodsOf[A]

--- a/airframe-surface/src/test/scala/wvlet/airframe/surface/MethodSurfaceTest.scala
+++ b/airframe-surface/src/test/scala/wvlet/airframe/surface/MethodSurfaceTest.scala
@@ -52,7 +52,7 @@ object MethodExamples {
   }
 }
 
-import wvlet.airframe.surface.MethodExamples._
+import wvlet.airframe.surface.MethodExamples.*
 
 /**
   */

--- a/airframe-surface/src/test/scala/wvlet/airframe/surface/MultipleConstructorArgsTest.scala
+++ b/airframe-surface/src/test/scala/wvlet/airframe/surface/MultipleConstructorArgsTest.scala
@@ -19,7 +19,7 @@ object MultipleConstructorArgsTest {
   }
 }
 
-import MultipleConstructorArgsTest._
+import MultipleConstructorArgsTest.*
 class MultipleConstructorArgsTest extends SurfaceSpec {
   test("support muliple constructor args") {
     val s: Surface = Surface.of[MultiC]

--- a/airframe-surface/src/test/scala/wvlet/airframe/surface/QuoteParamTest.scala
+++ b/airframe-surface/src/test/scala/wvlet/airframe/surface/QuoteParamTest.scala
@@ -18,7 +18,7 @@ object QuoteParamTest {
 }
 
 class QuoteParamTest extends SurfaceSpec {
-  import QuoteParamTest._
+  import QuoteParamTest.*
 
   test("read quoted params") {
     val s   = Surface.of[QP]

--- a/airframe-surface/src/test/scala/wvlet/airframe/surface/RecursiveHigherKindTypeTest.scala
+++ b/airframe-surface/src/test/scala/wvlet/airframe/surface/RecursiveHigherKindTypeTest.scala
@@ -25,7 +25,7 @@ object RecursiveHigherKindTypeTest {
     def bySkinny: Holder[BySkinny] = new InterpretedHolder
   }
 
-  import Holder._
+  import Holder.*
   class InterpretedHolder extends Holder[BySkinny] {}
 }
 
@@ -33,7 +33,7 @@ object RecursiveHigherKindTypeTest {
   */
 class RecursiveHigherKindTypeTest extends SurfaceSpec {
 
-  import RecursiveHigherKindTypeTest._
+  import RecursiveHigherKindTypeTest.*
   import Holder.BySkinny
 
   test("support recursive higher kind types") {

--- a/airframe-surface/src/test/scala/wvlet/airframe/surface/RecursiveMethodParamTest.scala
+++ b/airframe-surface/src/test/scala/wvlet/airframe/surface/RecursiveMethodParamTest.scala
@@ -22,7 +22,7 @@ object RecursiveMethodParamTest {
 }
 
 class RecursiveMethodParamTest extends munit.FunSuite {
-  import RecursiveMethodParamTest._
+  import RecursiveMethodParamTest.*
 
   // ....
   test("Compile method surfaces with recursive method param") {

--- a/airframe-surface/src/test/scala/wvlet/airframe/surface/RecursiveSurfaceTest.scala
+++ b/airframe-surface/src/test/scala/wvlet/airframe/surface/RecursiveSurfaceTest.scala
@@ -22,7 +22,7 @@ object RecursiveSurfaceTest {
 /**
   */
 class RecursiveSurfaceTest extends SurfaceSpec {
-  import RecursiveSurfaceTest._
+  import RecursiveSurfaceTest.*
 
   test("find recursive surface cache from the full type name string") {
     val s = Surface.of[Cons]

--- a/airframe-surface/src/test/scala/wvlet/airframe/surface/SurfaceTest.scala
+++ b/airframe-surface/src/test/scala/wvlet/airframe/surface/SurfaceTest.scala
@@ -47,7 +47,7 @@ object Examples {
   case class F(p0: Int = 10)
 }
 
-import wvlet.airframe.surface.Examples._
+import wvlet.airframe.surface.Examples.*
 
 /**
   */

--- a/airframe-surface/src/test/scala/wvlet/airframe/surface/TaggedTypeTest.scala
+++ b/airframe-surface/src/test/scala/wvlet/airframe/surface/TaggedTypeTest.scala
@@ -14,7 +14,7 @@
 
 package wvlet.airframe.surface
 
-import wvlet.airframe.surface.tag._
+import wvlet.airframe.surface.tag.*
 
 object TaggedTypeTest {
   case class Person(id: Int, name: String)
@@ -26,7 +26,7 @@ object TaggedTypeTest {
   type Name = String
 }
 
-import TaggedTypeTest._
+import TaggedTypeTest.*
 class TaggedTypeTest extends SurfaceSpec {
   test("pass sanity check") {
     val e: Person @@ Employee = new Person(1, "leo").taggedWith[Employee]

--- a/airframe-surface/src/test/scala/wvlet/airframe/surface/ZeroTest.scala
+++ b/airframe-surface/src/test/scala/wvlet/airframe/surface/ZeroTest.scala
@@ -21,7 +21,7 @@ import java.math.BigInteger
 /**
   */
 class ZeroTest extends SurfaceSpec {
-  import ZeroTest._
+  import ZeroTest.*
 
   protected def zeroCheck[P](surface: Surface, v: P): P = {
     val z = Zero.zeroOf(surface).asInstanceOf[P]

--- a/airspec/.js/src/main/scala/wvlet/airspec/spi/JsObjectMatcher.scala
+++ b/airspec/.js/src/main/scala/wvlet/airspec/spi/JsObjectMatcher.scala
@@ -19,7 +19,7 @@ import scala.scalajs.js
   */
 private[airspec] object JsObjectMatcher {
 
-  import Asserts._
+  import Asserts.*
 
   def matcher: PartialFunction[(Any, Any), TestResult] = { case (a: js.Object, b: js.Object) =>
     check(jsObjEquals(a, b))

--- a/airspec/.js/src/test/scala/jsexamples/JSMatcherTest.scala
+++ b/airspec/.js/src/test/scala/jsexamples/JSMatcherTest.scala
@@ -27,7 +27,7 @@ object JSMatcherTest {
 /**
   */
 class JSMatcherTest extends AirSpec {
-  import JSMatcherTest._
+  import JSMatcherTest.*
 
   test("equal if both are empty") {
     new js.Object() shouldNotBeTheSameInstanceAs new js.Object()

--- a/airspec/.jvm/src/test/scala/wvlet/airspec/TestExtension.scala
+++ b/airspec/.jvm/src/test/scala/wvlet/airspec/TestExtension.scala
@@ -16,7 +16,7 @@ package wvlet.airspec
 import java.util.concurrent.atomic.AtomicInteger
 
 import javax.annotation.{PostConstruct, PreDestroy}
-import wvlet.airframe.{Design, _}
+import wvlet.airframe.{Design, *}
 import wvlet.log.LogSupport
 
 case class MyServerConfig(name: String)

--- a/airspec/build.sbt
+++ b/airspec/build.sbt
@@ -81,7 +81,9 @@ val buildSettings = Seq[Setting[_]](
     } else {
       Seq(
         // Necessary for tracking source code range in airframe-rx demo
-        "-Yrangepos"
+        "-Yrangepos",
+        // For using import * syntax
+        "-Xsource:3"
       )
     }
   },
@@ -105,7 +107,7 @@ def crossBuildSources(scalaBinaryVersion: String, baseDir: String, srcType: Stri
 // https://stackoverflow.com/questions/41670018/how-to-prevent-sbt-to-include-test-dependencies-into-the-pom
 import sbt.ThisBuild
 
-import scala.xml.{Node => XmlNode, NodeSeq => XmlNodeSeq, _}
+import scala.xml.{Node => XmlNode, NodeSeq => XmlNodeSeq, *}
 import scala.xml.transform.{RewriteRule, RuleTransformer}
 
 def excludePomDependency(excludes: Seq[String]) = { node: XmlNode =>
@@ -128,7 +130,8 @@ def excludePomDependency(excludes: Seq[String]) = { node: XmlNode =>
   }).transform(node).head
 }
 
-/** AirSpec build definitions.
+/**
+  * AirSpec build definitions.
   *
   * To make AirSpec a standalone library without any cyclic project references, AirSpec embeds the source code of
   * airframe-log, di, surface, etc.

--- a/airspec/src/main/scala-2/wvlet/airspec/AirSpecMacros.scala
+++ b/airspec/src/main/scala-2/wvlet/airspec/AirSpecMacros.scala
@@ -7,21 +7,21 @@ import scala.reflect.macros.{blackbox => sm}
   */
 private[airspec] object AirSpecMacros {
   def sourceCode(c: sm.Context): c.Tree = {
-    import c.universe._
+    import c.universe.*
     c.internal.enclosingOwner
     val pos = c.enclosingPosition
     q"wvlet.airframe.SourceCode(${""}, ${pos.source.file.name}, ${pos.line}, ${pos.column})"
   }
 
   def pendingImpl(c: sm.Context): c.Tree = {
-    import c.universe._
+    import c.universe.*
     q"""
        throw wvlet.airspec.spi.Pending("pending", ${sourceCode(c)})
      """
   }
 
   def test0Impl[R: c.WeakTypeTag](c: sm.Context)(body: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
     q"""{
       import wvlet.airspec.AirSpecTestBuilder._
       val self = ${c.prefix}
@@ -30,7 +30,7 @@ private[airspec] object AirSpecMacros {
   }
 
   def test1Impl[D1: c.WeakTypeTag, R: c.WeakTypeTag](c: sm.Context)(body: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
     val d1 = implicitly[c.WeakTypeTag[D1]].tpe
     q"""{
       import wvlet.airspec.AirSpecTestBuilder._
@@ -41,7 +41,7 @@ private[airspec] object AirSpecMacros {
   }
 
   def test2Impl[D1: c.WeakTypeTag, D2: c.WeakTypeTag, R: c.WeakTypeTag](c: sm.Context)(body: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
     val d1 = implicitly[c.WeakTypeTag[D1]].tpe
     val d2 = implicitly[c.WeakTypeTag[D2]].tpe
     q"""{
@@ -56,7 +56,7 @@ private[airspec] object AirSpecMacros {
   def test3Impl[D1: c.WeakTypeTag, D2: c.WeakTypeTag, D3: c.WeakTypeTag, R: c.WeakTypeTag](
       c: sm.Context
   )(body: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
     val d1 = implicitly[c.WeakTypeTag[D1]].tpe
     val d2 = implicitly[c.WeakTypeTag[D2]].tpe
     val d3 = implicitly[c.WeakTypeTag[D3]].tpe
@@ -73,7 +73,7 @@ private[airspec] object AirSpecMacros {
   def test4Impl[D1: c.WeakTypeTag, D2: c.WeakTypeTag, D3: c.WeakTypeTag, D4: c.WeakTypeTag, R: c.WeakTypeTag](
       c: sm.Context
   )(body: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
     val d1 = implicitly[c.WeakTypeTag[D1]].tpe
     val d2 = implicitly[c.WeakTypeTag[D2]].tpe
     val d3 = implicitly[c.WeakTypeTag[D3]].tpe
@@ -99,7 +99,7 @@ private[airspec] object AirSpecMacros {
   ](
       c: sm.Context
   )(body: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
     val d1 = implicitly[c.WeakTypeTag[D1]].tpe
     val d2 = implicitly[c.WeakTypeTag[D2]].tpe
     val d3 = implicitly[c.WeakTypeTag[D3]].tpe

--- a/airspec/src/main/scala/wvlet/airspec/AirSpecDef.scala
+++ b/airspec/src/main/scala/wvlet/airspec/AirSpecDef.scala
@@ -1,7 +1,7 @@
 package wvlet.airspec
 
 import wvlet.airframe.AirframeException.MISSING_DEPENDENCY
-import wvlet.airframe._
+import wvlet.airframe.*
 import wvlet.airframe.surface.{MethodSurface, Surface}
 import wvlet.airspec.spi.{AirSpecContext, MissingTestDependency}
 

--- a/airspec/src/main/scala/wvlet/airspec/AirSpecLauncher.scala
+++ b/airspec/src/main/scala/wvlet/airspec/AirSpecLauncher.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airspec
 
-import sbt.testing._
+import sbt.testing.*
 import wvlet.airspec.runner.AirSpecSbtRunner.AirSpecConfig
 import wvlet.airspec.runner.{AirSpecEventHandler, AirSpecLogger, AirSpecTaskRunner}
 import wvlet.log.LogSupport

--- a/airspec/src/main/scala/wvlet/airspec/Framework.scala
+++ b/airspec/src/main/scala/wvlet/airspec/Framework.scala
@@ -21,7 +21,7 @@ import wvlet.airspec.runner.AirSpecSbtRunner
   * Include this class to your build.sbt: testFrameworks += new TestFramework("wvlet.airspec.AirSpecFramework")
   */
 class Framework extends sbt.testing.Framework {
-  import Framework._
+  import Framework.*
   override def name(): String                     = "airspec"
   override def fingerprints(): Array[Fingerprint] = Array(AirSpecClassFingerPrint, AirSpecObjectFingerPrint)
   override def runner(args: Array[String], remoteArgs: Array[String], testClassLoader: ClassLoader): testing.Runner = {

--- a/airspec/src/main/scala/wvlet/airspec/runner/AirSpecLogger.scala
+++ b/airspec/src/main/scala/wvlet/airspec/runner/AirSpecLogger.scala
@@ -15,7 +15,7 @@ package wvlet.airspec.runner
 
 import java.util.concurrent.TimeUnit
 
-import sbt.testing._
+import sbt.testing.*
 import wvlet.airframe.log.AnsiColorPalette
 import wvlet.airframe.metrics.ElapsedTime
 import wvlet.airspec.spi.AirSpecFailureBase

--- a/airspec/src/main/scala/wvlet/airspec/runner/AirSpecLogger.scala
+++ b/airspec/src/main/scala/wvlet/airspec/runner/AirSpecLogger.scala
@@ -30,14 +30,14 @@ private[airspec] case class AirSpecEvent(
     override val throwable: OptionalThrowable,
     durationNanos: Long
 ) extends Event {
-  override def fullyQualifiedName: String = {
+  override def fullyQualifiedName(): String = {
     testName.getOrElse(taskDef.fullyQualifiedName())
   }
   override def fingerprint(): Fingerprint = taskDef.fingerprint()
   override def selector(): Selector = {
     testName match {
       case Some(x) => new TestSelector(x)
-      case _       => taskDef.selectors.headOption.getOrElse(new SuiteSelector)
+      case _       => taskDef.selectors().headOption.getOrElse(new SuiteSelector)
     }
   }
   override def duration(): Long = TimeUnit.NANOSECONDS.toMillis(durationNanos)
@@ -117,7 +117,7 @@ private[airspec] class AirSpecLogger() extends AnsiColorPalette {
 
     val prefix = {
       if (showTestName) {
-        s"${withColor(GRAY, " -")} ${withColor(baseColor, e.fullyQualifiedName)} ${elapsedTime}"
+        s"${withColor(GRAY, " -")} ${withColor(baseColor, e.fullyQualifiedName())} ${elapsedTime}"
       } else {
         s"${withColor(GRAY, " <")} ${elapsedTime}"
       }

--- a/airspec/src/main/scala/wvlet/airspec/runner/AirSpecTask.scala
+++ b/airspec/src/main/scala/wvlet/airspec/runner/AirSpecTask.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airspec.runner
 
-import sbt.testing._
+import sbt.testing.*
 import wvlet.airframe.Design
 import wvlet.airspec.runner.AirSpecSbtRunner.AirSpecConfig
 import wvlet.log.LogSupport

--- a/airspec/src/main/scala/wvlet/airspec/runner/AirSpecTaskRunner.scala
+++ b/airspec/src/main/scala/wvlet/airspec/runner/AirSpecTaskRunner.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airspec.runner
 
-import sbt.testing._
+import sbt.testing.*
 import wvlet.airframe.{Design, Session}
 import wvlet.airspec.runner.AirSpecSbtRunner.AirSpecConfig
 import wvlet.airspec.spi.{AirSpecContext, AirSpecException}
@@ -38,7 +38,7 @@ private[airspec] class AirSpecTaskRunner(
     eventHandler: EventHandler,
     classLoader: ClassLoader
 ) extends LogSupport {
-  import wvlet.airspec._
+  import wvlet.airspec.*
 
   private implicit val ec: ExecutionContext = Compat.executionContext
 
@@ -249,7 +249,7 @@ private[airspec] class AirSpecTaskRunner(
     }
 
     def runTest(childSession: Session, context: AirSpecContext): Future[_] = {
-      import wvlet.airframe.rx._
+      import wvlet.airframe.rx.*
 
       try {
         m.run(context, childSession) match {

--- a/airspec/src/main/scala/wvlet/airspec/spi/AirSpecException.scala
+++ b/airspec/src/main/scala/wvlet/airspec/spi/AirSpecException.scala
@@ -15,7 +15,7 @@ package wvlet.airspec.spi
 
 import sbt.testing.Status
 import wvlet.airframe.SourceCode
-import wvlet.airspec._
+import wvlet.airspec.*
 
 /**
   * Define exceptions that will be used for various test failures

--- a/airspec/src/main/scala/wvlet/airspec/spi/RichAsserts.scala
+++ b/airspec/src/main/scala/wvlet/airspec/spi/RichAsserts.scala
@@ -17,7 +17,7 @@ import java.util
 
 import wvlet.airframe.SourceCode
 import wvlet.airspec.AirSpecSpi
-import wvlet.airspec.spi.Asserts._
+import wvlet.airspec.spi.Asserts.*
 import wvlet.log.LogSupport
 
 /**

--- a/airspec/src/test/scala/examples/DITest.scala
+++ b/airspec/src/test/scala/examples/DITest.scala
@@ -19,7 +19,7 @@ import wvlet.airspec.AirSpec
 /**
   */
 class DITest extends AirSpec {
-  import wvlet.airframe._
+  import wvlet.airframe.*
 
   protected val v: Int = 1000
 

--- a/airspec/src/test/scala/examples/RxTest.scala
+++ b/airspec/src/test/scala/examples/RxTest.scala
@@ -14,7 +14,7 @@
 package examples
 
 import wvlet.airspec.AirSpec
-import wvlet.airframe.rx._
+import wvlet.airframe.rx.*
 
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
 

--- a/airspec/src/test/scala/examples/TestSyntaxSpec.scala
+++ b/airspec/src/test/scala/examples/TestSyntaxSpec.scala
@@ -1,7 +1,7 @@
 package examples
 
-import wvlet.airspec._
-import wvlet.airframe._
+import wvlet.airspec.*
+import wvlet.airframe.*
 
 class TestSyntaxSpec extends AirSpec {
   override protected def design =

--- a/build.sbt
+++ b/build.sbt
@@ -100,7 +100,7 @@ val buildSettings = Seq[Setting[_]](
   mimaPreviousArtifacts := Set("org.wvlet.airframe" %%% s"${name.value}" % AIRFRAME_BINARY_COMPAT_VERSION),
   mimaFailOnNoPrevious  := false,
   mimaBinaryIssueFilters ++= {
-    import com.typesafe.tools.mima.core._
+    import com.typesafe.tools.mima.core.*
     Seq(
       ProblemFilters.exclude[MissingClassProblem]("wvlet.airframe.http.internal.*")
     )
@@ -109,17 +109,17 @@ val buildSettings = Seq[Setting[_]](
   scalacOptions ++= Seq(
     "-feature",
     "-deprecation"
-    // Use this for debugging Macros
-    // "-Xcheck-macros"
+    // Use this flag for debugging Macros
+    // "-Xcheck-macros",
   ) ++ {
     if (scalaVersion.value.startsWith("3.")) {
       Seq.empty
     } else {
       Seq(
-        // For using import * syntax
-        "-Xsource:3",
         // Necessary for tracking source code range in airframe-rx demo
-        "-Yrangepos"
+        "-Yrangepos",
+        // For using the new import * syntax even in Scala 2.x
+        "-Xsource:3"
       )
     }
   },
@@ -341,7 +341,7 @@ def parallelCollection(scalaVersion: String) = {
 }
 
 // https://stackoverflow.com/questions/41670018/how-to-prevent-sbt-to-include-test-dependencies-into-the-pom
-import scala.xml.{Node => XmlNode, NodeSeq => XmlNodeSeq, _}
+import scala.xml.{Node => XmlNode, NodeSeq => XmlNodeSeq, *}
 import scala.xml.transform.{RewriteRule, RuleTransformer}
 
 def excludePomDependency(excludes: Seq[String]) = { node: XmlNode =>

--- a/examples/src/main/scala/wvlet/airframe/examples/di/DI_01_HelloAirframe.scala
+++ b/examples/src/main/scala/wvlet/airframe/examples/di/DI_01_HelloAirframe.scala
@@ -18,7 +18,7 @@ import wvlet.log.LogSupport
   * A basic example of three-step DI: Bind - Design - Build
   */
 object DI_01_HelloAirframe extends App {
-  import wvlet.airframe._
+  import wvlet.airframe.*
 
   case class MyAppConfig(name: String)
 

--- a/examples/src/main/scala/wvlet/airframe/examples/di/DI_02_ConstructorInjection.scala
+++ b/examples/src/main/scala/wvlet/airframe/examples/di/DI_02_ConstructorInjection.scala
@@ -20,7 +20,7 @@ import wvlet.log.LogSupport
   * This pattern is useful if you do not want to include the dependency to Airframe to some classes.
   */
 object DI_02_ConstructorInjection extends App {
-  import wvlet.airframe._
+  import wvlet.airframe.*
 
   case class MyAppConfig(port: Int = 8080)
   // Use Constructor Injection

--- a/examples/src/main/scala/wvlet/airframe/examples/di/DI_03_InTraitInjection.scala
+++ b/examples/src/main/scala/wvlet/airframe/examples/di/DI_03_InTraitInjection.scala
@@ -17,7 +17,7 @@ import wvlet.log.LogSupport
 /**
   */
 object DI_03_InTraitInjection extends App {
-  import wvlet.airframe._
+  import wvlet.airframe.*
 
   case class MyAppConfig(port: Int = 8080)
 

--- a/examples/src/main/scala/wvlet/airframe/examples/di/DI_04_Session.scala
+++ b/examples/src/main/scala/wvlet/airframe/examples/di/DI_04_Session.scala
@@ -17,7 +17,7 @@ package wvlet.airframe.examples.di
   * An example of manually creating a session
   */
 object DI_04_Session extends App {
-  import wvlet.airframe._
+  import wvlet.airframe.*
 
   trait MyApp
 

--- a/examples/src/main/scala/wvlet/airframe/examples/di/DI_05_LifecycleHooks.scala
+++ b/examples/src/main/scala/wvlet/airframe/examples/di/DI_05_LifecycleHooks.scala
@@ -21,7 +21,7 @@ import wvlet.log.LogSupport
   * An example of adding lifecycle hooks to the injected service
   */
 object DI_05_LifecycleHooks extends App {
-  import wvlet.airframe._
+  import wvlet.airframe.*
 
   trait MyApp extends LogSupport {
     private val threadManager = bind[ExecutorService] { Executors.newCachedThreadPool() }

--- a/examples/src/main/scala/wvlet/airframe/examples/di/DI_06_ProviderBinding.scala
+++ b/examples/src/main/scala/wvlet/airframe/examples/di/DI_06_ProviderBinding.scala
@@ -21,7 +21,7 @@ import wvlet.log.LogSupport
   * Provider binding is useful to build objects by using dependencies defined in Design.
   */
 object DI_06_ProviderBinding extends App {
-  import wvlet.airframe._
+  import wvlet.airframe.*
 
   case class MyAppConfig(numThreads: Int = 5)
 

--- a/examples/src/main/scala/wvlet/airframe/examples/di/DI_07_JSR250Annotation.scala
+++ b/examples/src/main/scala/wvlet/airframe/examples/di/DI_07_JSR250Annotation.scala
@@ -34,7 +34,7 @@ object DI_07_JSR250Annotation extends App {
     }
   }
 
-  import wvlet.airframe._
+  import wvlet.airframe.*
 
   newSilentDesign.build[MyService] { service =>
     // PostConstrct method will be called here

--- a/examples/src/main/scala/wvlet/airframe/examples/di/DI_08_OverrideBinding.scala
+++ b/examples/src/main/scala/wvlet/airframe/examples/di/DI_08_OverrideBinding.scala
@@ -19,7 +19,7 @@ import wvlet.log.LogSupport
   * To switch the implementation, override the binding in the design
   */
 object DI_08_OverrideBinding extends App {
-  import wvlet.airframe._
+  import wvlet.airframe.*
 
   trait DB extends LogSupport {
     def query(sql: String): Unit = {

--- a/examples/src/main/scala/wvlet/airframe/examples/di/DI_09_ComposingDesigns.scala
+++ b/examples/src/main/scala/wvlet/airframe/examples/di/DI_09_ComposingDesigns.scala
@@ -19,7 +19,7 @@ import wvlet.log.LogSupport
   * Design objects are composable
   */
 object DI_09_ComposingDesigns extends App with LogSupport {
-  import wvlet.airframe._
+  import wvlet.airframe.*
 
   val d1 = newSilentDesign
     .bind[Int].toInstance(10)

--- a/examples/src/main/scala/wvlet/airframe/examples/di/DI_10_TypeAliasBinding.scala
+++ b/examples/src/main/scala/wvlet/airframe/examples/di/DI_10_TypeAliasBinding.scala
@@ -20,7 +20,7 @@ import wvlet.log.LogSupport
   * as different types when binding dependencies.
   */
 object DI_10_TypeAliasBinding extends App {
-  import wvlet.airframe._
+  import wvlet.airframe.*
 
   case class DbConfig(db: String)
 

--- a/examples/src/main/scala/wvlet/airframe/examples/di/DI_11_ProductionMode.scala
+++ b/examples/src/main/scala/wvlet/airframe/examples/di/DI_11_ProductionMode.scala
@@ -19,7 +19,7 @@ import wvlet.log.LogSupport
 /**
   */
 object DI_11_ProductionMode extends App with LogSupport {
-  import wvlet.airframe._
+  import wvlet.airframe.*
 
   trait MyService extends LogSupport {
     @PostConstruct

--- a/examples/src/main/scala/wvlet/airframe/examples/di/DI_12_ReusingService.scala
+++ b/examples/src/main/scala/wvlet/airframe/examples/di/DI_12_ReusingService.scala
@@ -26,7 +26,7 @@ import wvlet.log.LogSupport
   * multiple times, shutdown hooks will be called only once per the resource.
   */
 object DI_12_ReusingService extends App {
-  import wvlet.airframe._
+  import wvlet.airframe.*
 
   trait DB extends LogSupport {
     def query(sql: String) = {}

--- a/examples/src/main/scala/wvlet/airframe/examples/di/DI_20_BindSession.scala
+++ b/examples/src/main/scala/wvlet/airframe/examples/di/DI_20_BindSession.scala
@@ -19,7 +19,7 @@ import wvlet.log.LogSupport
   * If you need to terminate a session explicitly (e.g., via REST call), bind[Session] is useful.
   */
 object DI_20_BindSession extends App {
-  import wvlet.airframe._
+  import wvlet.airframe.*
 
   trait MyApi extends LogSupport {
     private val session = bind[Session]

--- a/examples/src/main/scala/wvlet/airframe/examples/di/DI_21_BindConfig.scala
+++ b/examples/src/main/scala/wvlet/airframe/examples/di/DI_21_BindConfig.scala
@@ -22,9 +22,9 @@ object DI_21_BindConfig extends App {
   case class ServerConfig(host: String)
   case class X()
 
-  import wvlet.airframe._
+  import wvlet.airframe.*
   // Import config._ to use bindConfigXXX methods
-  import wvlet.airframe.config._
+  import wvlet.airframe.config.*
 
   // Load "production" configurations from Yaml files
   val design =

--- a/examples/src/main/scala/wvlet/airframe/examples/di/DI_90_Tracing.scala
+++ b/examples/src/main/scala/wvlet/airframe/examples/di/DI_90_Tracing.scala
@@ -20,7 +20,7 @@ import wvlet.airframe.tracing.ChromeTracer
   * Trace Event Format: https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview
   */
 object DI_90_Tracing extends App {
-  import wvlet.airframe._
+  import wvlet.airframe.*
 
   case class MyAppConfig(port: Int = 8080)
 

--- a/examples/src/main/scala/wvlet/airframe/examples/di/DI_91_Stats.scala
+++ b/examples/src/main/scala/wvlet/airframe/examples/di/DI_91_Stats.scala
@@ -20,7 +20,7 @@ import wvlet.airframe.tracing.DIStats
   * This is useful to see unused bindings in the design.
   */
 object DI_91_Stats extends App {
-  import wvlet.airframe._
+  import wvlet.airframe.*
   trait A {
     val b = bind[B]
   }

--- a/examples/src/main/scala/wvlet/airframe/examples/http/Http_02_ObjectMapping.scala
+++ b/examples/src/main/scala/wvlet/airframe/examples/http/Http_02_ObjectMapping.scala
@@ -22,7 +22,7 @@ import wvlet.log.LogSupport
 /**
   */
 object Http_02_ObjectMapping extends App with LogSupport {
-  import wvlet.airframe._
+  import wvlet.airframe.*
 
   case class ListRequest(name: String, page: Int)
   case class ListResponse(name: String, page: Int, nextPageToken: Option[String], data: String)

--- a/examples/src/test/scala/wvlet/airframe/examples/airspec/AirSpec_03_DI.scala
+++ b/examples/src/test/scala/wvlet/airframe/examples/airspec/AirSpec_03_DI.scala
@@ -23,7 +23,7 @@ object AirSpec_03_DI extends AirSpec {
   class MyService(val config: Config)
 
   protected override def design: Design = {
-    import wvlet.airframe._
+    import wvlet.airframe.*
 
     val d = newDesign
       .bind[Config].toInstance(Config(port = 8080))

--- a/examples/src/test/scala/wvlet/airframe/examples/airspec/AirSpec_04_Session.scala
+++ b/examples/src/test/scala/wvlet/airframe/examples/airspec/AirSpec_04_Session.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.examples.airspec
 
-import wvlet.airframe._
+import wvlet.airframe.*
 import wvlet.airspec.AirSpec
 
 /**

--- a/sbt-airframe/build.sbt
+++ b/sbt-airframe/build.sbt
@@ -32,17 +32,9 @@ val buildSettings = Seq[Setting[_]](
   javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
   scalacOptions ++= Seq(
     "-feature",
-    "-deprecation"
-  ) ++ {
-    if(scalaVersion.value.startsWith("3.x")) {
-      Seq.empty
-    }
-    else {
-      Seq(
-        // For using import * syntax
-        "-Xsource:3"
-      )
-    }
+    "-deprecation",
+    // For using import * syntax
+    "-Xsource:3"
   ),
   testFrameworks += new TestFramework("wvlet.airspec.Framework"),
   libraryDependencies ++= Seq(

--- a/sbt-airframe/build.sbt
+++ b/sbt-airframe/build.sbt
@@ -32,7 +32,9 @@ val buildSettings = Seq[Setting[_]](
   javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
   scalacOptions ++= Seq(
     "-feature",
-    "-deprecation"
+    "-deprecation",
+    // For using import * syntax
+    "-Xsource:3"
   ),
   testFrameworks += new TestFramework("wvlet.airspec.Framework"),
   libraryDependencies ++= Seq(

--- a/sbt-airframe/build.sbt
+++ b/sbt-airframe/build.sbt
@@ -32,9 +32,17 @@ val buildSettings = Seq[Setting[_]](
   javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
   scalacOptions ++= Seq(
     "-feature",
-    "-deprecation",
-    // For using import * syntax
-    "-Xsource:3"
+    "-deprecation"
+  ) ++ {
+    if(scalaVersion.value.startsWith("3.x")) {
+      Seq.empty
+    }
+    else {
+      Seq(
+        // For using import * syntax
+        "-Xsource:3"
+      )
+    }
   ),
   testFrameworks += new TestFramework("wvlet.airspec.Framework"),
   libraryDependencies ++= Seq(


### PR DESCRIPTION
- internal: Use the new wildcard import syntax (*) in Scala 3 - https://dotty.epfl.ch/docs/reference/changed-features/imports.html
  - This syntax is supported in Scala 2 by setting "-Xsource:3" scalac option
- Add a scalafmt configuration to use the new syntax and refomat the code
