### PR TITLE
breaking: Drop JDK11 support and make JDK17 the default version

### DIFF
--- a/.github/workflows/package-test.yml
+++ b/.github/workflows/package-test.yml
@@ -19,6 +19,6 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: '11'
+          java-version: '17'
       - name: Packaging test
         run: ./sbt publishAllLocal

--- a/.github/workflows/release-airspec.yml
+++ b/.github/workflows/release-airspec.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: '11'
+          java-version: '17'
       - name: Setup GPG
         env:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}

--- a/.github/workflows/release-js.yml
+++ b/.github/workflows/release-js.yml
@@ -19,12 +19,12 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: '11'
+          java-version: '17'
       - name: Setup GPG
         env:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
         run: echo $PGP_SECRET | base64 --decode | gpg --import --batch --yes
-      - name: Build for Scala.js 1.0.x
+      - name: Build for Scala.js
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
         run: ./sbt publishJSSigned

--- a/.github/workflows/release-sbt-plugin.yml
+++ b/.github/workflows/release-sbt-plugin.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: '11'
+          java-version: '17'
       - name: Setup GPG
         env:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: '11'
+          java-version: '17'
       - name: Setup GPG
         env:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: '11'
+          java-version: '17'
       - name: Get Airframe version
         run: echo "AIRFRAME_VERSION=$(./scripts/dynver.sh)" >> $GITHUB_ENV
       - name: Check Airframe version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,25 +76,6 @@ jobs:
           check_name: Test Report Scala 2.13
           annotate_only: true
           detailed_summary: true
-  test_2_13_legacy_jdk:
-    name: Scala 2.13 + JDK11
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v3
-        with:
-          distribution: 'zulu'
-          java-version: '11'
-      - name: Scala 2.13 + JDK11 test
-        run: ./sbt ++2.13 projectJVM/test
-      - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v4
-        if: always() # always run even if the previous step fails
-        with:
-          report_paths: '**/target/test-reports/TEST-*.xml'
-          check_name: Test Report Scala 2.13 + JDK11
-          annotate_only: true
-          detailed_summary: true
   test_2_13_latest_jdk:
     name: Scala 2.13 + JDK21
     runs-on: ubuntu-latest
@@ -115,7 +96,7 @@ jobs:
           annotate_only: true
           detailed_summary: true
   test_3:
-    name: Scala 3.x (Dotty)
+    name: Scala 3
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -132,6 +113,26 @@ jobs:
         with:
           report_paths: '**/target/test-reports/TEST-*.xml'
           check_name: Test Report Scala 3.x
+          annotate_only: true
+          detailed_summary: true
+  test_3_latest_jdk:
+    name: Scala 3 + JDK21
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '21'
+      - name: Scala 3 test
+        # Test only Scala 3 supported projects
+        run: ./sbt "++ 3; projectDotty/test; dottyTest/run"
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v4
+        if: always() # always run even if the previous step fails
+        with:
+          report_paths: '**/target/test-reports/TEST-*.xml'
+          check_name: Test Report Scala 3 + JDK21
           annotate_only: true
           detailed_summary: true
   test_integration:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -6,9 +6,9 @@ pull_request_rules:
       - check-success=sbt-airframe
       - check-success=Code format
       - check-success=Scala 2.12
-      - check-success=Scala 2.13 + JDK11
       - check-success=Scala 2.13 + JDK21
-      - check-success=Scala 3.x (Dotty)
+      - check-success=Scala 3
+      - check-success=Scala 3 + JDK21
       - check-success=Scala.js / Scala 2.12
       - check-success=Scala.js / Scala 2.13
       - check-success=Scala.js / Scala 3

--- a/build.sbt
+++ b/build.sbt
@@ -105,7 +105,7 @@ val buildSettings = Seq[Setting[_]](
       ProblemFilters.exclude[MissingClassProblem]("wvlet.airframe.http.internal.*")
     )
   },
-  javacOptions ++= Seq("--release", "17"),
+  javacOptions ++= Seq("-source", "11", "-target", "11"),
   scalacOptions ++= Seq(
     "-feature",
     "-deprecation"

--- a/build.sbt
+++ b/build.sbt
@@ -105,7 +105,7 @@ val buildSettings = Seq[Setting[_]](
       ProblemFilters.exclude[MissingClassProblem]("wvlet.airframe.http.internal.*")
     )
   },
-  javacOptions ++= Seq("-source", "11", "-target", "11"),
+  javacOptions ++= Seq("--release", "17"),
   scalacOptions ++= Seq(
     "-feature",
     "-deprecation"


### PR DESCRIPTION
Make JDK17 the default version for 24.x series because JDK11 will have no public updates from October 2024. https://endoflife.date/oracle-jdk