### PR TITLE
airframe-sql: Resolve UNNEST earlier to prevent cyclic references

### DIFF
--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
@@ -967,6 +967,30 @@ class TypeResolverTest extends AirSpec with ResolverTestHelper {
         ResolvedAttribute("value", DataType.LongType, Some("t"), None, None, None)
       )
     }
+
+    test("un3: resolve UNNEST array column without CROSS JOIN") {
+      val p = analyze("SELECT id, n FROM A, UNNEST (name) AS t (n)")
+      p.outputAttributes shouldMatch { case List(c1: Attribute, c2: Attribute) =>
+        c1.fullName shouldBe "id"
+        c2.fullName shouldBe "n"
+      }
+    }
+
+    test("un4: resolve UNNEST array column with the same output name") {
+      val p = analyze("SELECT id, t.name FROM A CROSS JOIN UNNEST (name) AS t (name)")
+      p.outputAttributes shouldMatch { case List(c1: Attribute, c2: Attribute) =>
+        c1.fullName shouldBe "id"
+        c2.fullName shouldBe "t.name"
+      }
+    }
+
+    test("un5: resolve UNNEST array column with qualifier") {
+      val p = analyze("SELECT id, t.name FROM A CROSS JOIN UNNEST (A.name) AS t (name)")
+      p.outputAttributes shouldMatch { case List(c1: Attribute, c2: Attribute) =>
+        c1.fullName shouldBe "id"
+        c2.fullName shouldBe "t.name"
+      }
+    }
   }
 
   test("resolve select from values") {

--- a/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
+++ b/airframe-sql/src/test/scala/wvlet/airframe/sql/analyzer/TypeResolverTest.scala
@@ -980,15 +980,19 @@ class TypeResolverTest extends AirSpec with ResolverTestHelper {
       val p = analyze("SELECT id, t.name FROM A CROSS JOIN UNNEST (name) AS t (name)")
       p.outputAttributes shouldMatch { case List(c1: Attribute, c2: Attribute) =>
         c1.fullName shouldBe "id"
+        c1.sourceColumns.map(_.column) shouldBe Seq(a1)
         c2.fullName shouldBe "t.name"
+        c2.sourceColumns.map(_.column) shouldBe Seq(a2)
       }
     }
 
     test("un5: resolve UNNEST array column with qualifier") {
-      val p = analyze("SELECT id, t.name FROM A CROSS JOIN UNNEST (A.name) AS t (name)")
+      val p = analyze("SELECT A.id, t.name FROM A INNER JOIN B ON A.id = B.id CROSS JOIN UNNEST (A.name) AS t (name)")
       p.outputAttributes shouldMatch { case List(c1: Attribute, c2: Attribute) =>
-        c1.fullName shouldBe "id"
+        c1.fullName shouldBe "A.id"
+        c1.sourceColumns.map(_.column) shouldBe Seq(a1)
         c2.fullName shouldBe "t.name"
+        c2.sourceColumns.map(_.column) shouldBe Seq(a2)
       }
     }
   }
@@ -1171,6 +1175,21 @@ class TypeResolverTest extends AirSpec with ResolverTestHelper {
         col.fullName shouldBe "xid"
         col.sourceColumn.map(_.column) shouldBe Some(a1)
       }
+    }
+  }
+
+  test("Resolve identifier refers to column in AliasedRelation") {
+    // with column alias (id -> t.xid)
+    val p1 = analyze("select t.xid from (select id from A) as t(xid)")
+    p1.outputAttributes shouldMatch { case List(col: ResolvedAttribute) =>
+      col.fullName shouldBe "t.xid"
+      col.sourceColumn.map(_.column) shouldBe Some(a1)
+    }
+    // without column alias (id -> t.td)
+    val p2 = analyze("select t.id from (select id from A) as t(id)")
+    p2.outputAttributes shouldMatch { case List(col: ResolvedAttribute) =>
+      col.fullName shouldBe "t.id"
+      col.sourceColumn.map(_.column) shouldBe Some(a1)
     }
   }
 }


### PR DESCRIPTION
## Case 1

```sql
SELECT id, t.name FROM A CROSS JOIN UNNEST (name) AS t (name)
```

This SQL is valid but fails to resolve with the following error:

```
wvlet.airframe.sql.SQLError: [SyntaxError] line 1:45 name is ambiguous:
- *name:string <- A.name
- *name:?
```

Because the output attribute of AliasedRelation (`t (name)`) is included in the source attributes when resolve `UNNEST (name)` here:

https://github.com/wvlet/airframe/blob/49d31bad29eccd2459eb4c02593d371c1b55082a/airframe-sql/src/main/scala/wvlet/airframe/sql/analyzer/TypeResolver.scala#L319-L321

- `r` is CrossJoin
- `r.inputAttributes` is `left.outputAttributes + right.outputAttributes`
- `right` is AliasedRelation(Unnest)

I think output attributes of AliasedRelation shouldn't be in the scope when Unnest is resolved but I didn't come up with an easy fix for this issue.

## Case 2

```sql
SELECT id, t.name FROM A CROSS JOIN UNNEST (A.name) AS t (name)
```

This SQL is also valid but fails to resolve with the following error:

```
Found unresolved expressions in:
[sql]
SELECT id, t.name FROM A CROSS JOIN UNNEST (A.name) AS t (name)
[plan]
[Project]: (id:long, name:string, name:string) => (id:long, name:?)
  - *id:long <- A.id
  - UnresolvedAttribute(t.name)
  [CrossJoin]: (id:long, name:string, name:string) => (id:long, name:string, name:string)
    - NaturalJoin
    [TableScan] default.A:  => (id:long, name:string)
    [AliasedRelation]:  => (name:string)
      - ResolvedIdentifier(Id(t))
      [Unnest]:  => (name:string)
        - *A.name:string <- A.name
```

Maybe this is because the resolved UNNEST column has a qualifier. This case might not be UNNEST specific.