### PR TITLE
Surface - Method type exploration

### DIFF
--- a/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
+++ b/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
@@ -772,8 +772,11 @@ private[surface] class CompileTimeSurfaceFactory[Q <: Quotes](using quotes: Q):
             targetTypeParent
 
           case TypeRef(ThisType(parent), _) =>
-            val result = simplifyTypeRef(parent).typeSymbol.typeMember(typeRepr.typeSymbol.name).typeRef
-            println(s"  case non-base ${typeRepr.show} $typeRepr -> $result")
+            println(s"  case non-base ${typeRepr.show} $typeRepr")
+            val parentRef = simplifyTypeRef(parent)
+            val result = parentRef.typeSymbol.typeMember(typeRepr.typeSymbol.name).typeRef
+            println(s"    -> parentRef: $result")
+            println(s"    -> result: $result")
             result
 
           case _ =>

--- a/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
+++ b/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
@@ -764,20 +764,20 @@ private[surface] class CompileTimeSurfaceFactory[Q <: Quotes](using quotes: Q):
       val TypeRef(targetTypeParent, _) = targetType: @unchecked  // it seems irefutable, but compiler does not agree
       //println(s"  ${targetTypeParent.baseClasses}")
       def simplifyTypeRef(typeRepr: TypeRepr): TypeRepr = {
-        //println(s"simplifyTypeRef ${typeRepr.show} in ${targetType.show}: ${typeRepr}")
+        println(s"simplifyTypeRef ${typeRepr.show} in ${targetType.show}: ${typeRepr}")
         typeRepr match {
           // Pattern matching to skip 'Base' and directly access 'InnerType'
           case _ if targetTypeParent.baseClasses.exists(_.typeRef == typeRepr) =>
-            //println(s"  case base ${typeRepr.show} $typeRepr -> $targetType")
-            targetType
+            println(s"  case base ${typeRepr.show} $typeRepr -> $targetTypeParent")
+            targetTypeParent
 
           case TypeRef(ThisType(parent), _) =>
             val result = simplifyTypeRef(parent).typeSymbol.typeMember(typeRepr.typeSymbol.name).typeRef
-            //println(s"  case non-base ${typeRepr.show} $typeRepr -> $result")
+            println(s"  case non-base ${typeRepr.show} $typeRepr -> $result")
             result
 
           case _ =>
-            //println(s"  case other ${typeRepr.show} $typeRepr")
+            println(s"  case other ${typeRepr.show} $typeRepr")
             typeRepr
         }
       }

--- a/airframe-surface/src/test/scala/wvlet/airframe/surface/i3411.scala
+++ b/airframe-surface/src/test/scala/wvlet/airframe/surface/i3411.scala
@@ -17,6 +17,22 @@ import wvlet.airspec.AirSpec
 
 object i3411 extends AirSpec {
 
+  trait Base {
+    class InnerType {
+      def compare(that: InnerType): Int = 0
+    }
+  }
+
+  object OuterType extends Base {
+    def create: InnerType = new InnerType
+  }
+
+  test("Handle inherited inner class") {
+    //val mm = Surface.methodsOf[OuterType.type]
+    val m = Surface.methodsOf[OuterType.InnerType]
+    //m.map(_.name) shouldContain "compare"
+  }
+
   object SomeEnum extends Enumeration {
     type SomeEnum = Value
 
@@ -26,10 +42,10 @@ object i3411 extends AirSpec {
   import SomeEnum.SomeEnum
 
   test("Handle a Scala 2 enumeration") {
-    val s = Surface.of[SomeEnum] // just check there is no error - no expected properties
-    val m = Surface.methodsOf[SomeEnum]
-    debug(s.params)
+    //val s = Surface.of[SomeEnum] // just check there is no error - no expected properties
+    //val m = Surface.methodsOf[SomeEnum]
+    //debug(s.params)
     // enumeration type (value) usually contains at least the compare method
-    m.map(_.name) shouldContain "compare"
+    //m.map(_.name) shouldContain "compare"
   }
 }

--- a/airframe-surface/src/test/scala/wvlet/airframe/surface/i3411.scala
+++ b/airframe-surface/src/test/scala/wvlet/airframe/surface/i3411.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.surface
+
+import wvlet.airspec.AirSpec
+
+object i3411 extends AirSpec {
+
+  object SomeEnum extends Enumeration {
+    type SomeEnum = Value
+
+    val A, B, C = Value
+  }
+
+  import SomeEnum.SomeEnum
+
+  test("Handle a Scala 2 enumeration") {
+    val s = Surface.of[SomeEnum] // just check there is no error - no expected properties
+    val m = Surface.methodsOf[SomeEnum]
+    debug(s.params)
+    // enumeration type (value) usually contains at least the compare method
+    m.map(_.name) shouldContain "compare"
+  }
+}


### PR DESCRIPTION
This an exploratory PR for #3433 and #3429

I would like to know where exactly is the type mismatch happening and if perhaps there is a way to avoid it completely, even at cost of reported method surfaces being not 100% accurate.