### PR TITLE
Surface - Method type exploration

### DIFF
--- a/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
+++ b/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
@@ -863,18 +863,23 @@ private[surface] class CompileTimeSurfaceFactory[Q <: Quotes](using quotes: Q):
           name != "<init>"
         }
 
-    allMethods.filter(m => isOwnedByTargetClass(m, t))
+    allMethods.filter(m => isOwnedByTargetClass(m, t) && !enumerationWorkaround(m, t))
 
   private def nonObject(x: Symbol): Boolean =
     !x.flags.is(Flags.Synthetic) &&
       !x.flags.is(Flags.Artifact) &&
       x.fullName != "scala.Any" &&
       x.fullName != "java.lang.Object" &&
-      // Exclude caes class methods
+      // Exclude case class methods
       x.fullName != "scala.Product"
 
   private def isOwnedByTargetClass(m: Symbol, t: TypeRepr): Boolean =
     m.owner == t.typeSymbol || t.baseClasses.filter(nonObject).exists(_ == m.owner)
+
+  // workaround https://github.com/lampepfl/dotty/issues/19825 - surface of enumeration value methods fails
+  private def enumerationWorkaround(m: Symbol, t: TypeRepr): Boolean =
+    t.baseClasses.exists(_.fullName.startsWith("scala.Enumeration.")) // this will match both Value and ValueSet
+    // note: it would be possible to let id, hashCode and equals pass through if desired
 
   private def modifierBitMaskOf(m: Symbol): Int =
     var mod = 0

--- a/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
+++ b/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
@@ -574,6 +574,7 @@ private[surface] class CompileTimeSurfaceFactory[Q <: Quotes](using quotes: Q):
     val methodName = method.name
     val methodArgs = methodArgsOf(t, method).flatten
     val argClasses = methodArgs.map { arg =>
+      // check if type is referencing t, which is something.InnerType, but via a base class, like Base.this.InnerType
       clsOf(arg.tpe.dealias)
     }
     val isConstructor = t.typeSymbol.primaryConstructor == method
@@ -678,6 +679,7 @@ private[surface] class CompileTimeSurfaceFactory[Q <: Quotes](using quotes: Q):
           methodArgAccessor = ${ methodArgAccessor }
         )
       }
+    println(paramExprs.map(_.show).mkString("\n"))
     Expr.ofSeq(paramExprs)
 
   private def getTree(e: Expr[?]): Tree =
@@ -745,7 +747,7 @@ private[surface] class CompileTimeSurfaceFactory[Q <: Quotes](using quotes: Q):
       methodsOfInternal(t).asTerm
     ).asExprOf[Seq[MethodSurface]]
 
-    // println(s"===  methodOf: ${t.typeSymbol.fullName} => \n${expr.show}")
+    println(s"===  methodOf: ${t.typeSymbol.fullName} => \n${expr.show}")
     expr
 
   private val seenMethodParent = scala.collection.mutable.Set[TypeRepr]()
@@ -877,8 +879,12 @@ private[surface] class CompileTimeSurfaceFactory[Q <: Quotes](using quotes: Q):
     m.owner == t.typeSymbol || t.baseClasses.filter(nonObject).exists(_ == m.owner)
 
   // workaround https://github.com/lampepfl/dotty/issues/19825 - surface of enumeration value methods fails
-  private def enumerationWorkaround(m: Symbol, t: TypeRepr): Boolean =
+  private def enumerationWorkaround(m: Symbol, t: TypeRepr): Boolean = {
+    val params = methodParametersOf(t, m)
+    val args = methodArgsOf(t, m).flatten
+    println(s"m $m ${args.map(_.tpe.show).mkString(",")}  ${params.show}")
     t.baseClasses.exists(_.fullName.startsWith("scala.Enumeration.")) // this will match both Value and ValueSet
+  }
     // note: it would be possible to let id, hashCode and equals pass through if desired
 
   private def modifierBitMaskOf(m: Symbol): Int =

--- a/airframe-surface/src/test/scala/wvlet/airframe/surface/i3411.scala
+++ b/airframe-surface/src/test/scala/wvlet/airframe/surface/i3411.scala
@@ -17,20 +17,19 @@ import wvlet.airspec.AirSpec
 
 object i3411 extends AirSpec {
 
-  object SomeEnum extends Enumeration {
-    type SomeEnum = Value
-
-    val A, B, C = Value
+  trait Base {
+    class InnerType {
+      def compare(that: InnerType): Int = 0
+    }
   }
 
-  import SomeEnum.SomeEnum
+  object OuterType extends Base {
+    def create: InnerType = new InnerType
+  }
 
-  test("Handle a Scala 2 enumeration") {
-    val s = Surface.of[SomeEnum] // just check there is no error - no expected properties
-    val m = Surface.methodsOf[SomeEnum]
-    debug(s.params)
-    // enumeration type (value) usually contains at least the compare method
-    // note: we are unable to handle compare at the moment and some other methods inherited from Value, see https://github.com/lampepfl/dotty/issues/19825
-    // m.map(_.name) shouldContain "compare"
+  test("Handle inherited inner class") {
+    //val mm = Surface.methodsOf[OuterType.type]
+    val m = Surface.methodsOf[OuterType.InnerType]
+    //m.map(_.name) shouldContain "compare"
   }
 }

--- a/airframe-surface/src/test/scala/wvlet/airframe/surface/i3411.scala
+++ b/airframe-surface/src/test/scala/wvlet/airframe/surface/i3411.scala
@@ -30,6 +30,7 @@ object i3411 extends AirSpec {
     val m = Surface.methodsOf[SomeEnum]
     debug(s.params)
     // enumeration type (value) usually contains at least the compare method
-    m.map(_.name) shouldContain "compare"
+    // note: we are unable to handle compare at the moment and some other methods inherited from Value, see https://github.com/lampepfl/dotty/issues/19825
+    // m.map(_.name) shouldContain "compare"
   }
 }

--- a/airframe-surface/src/test/scala/wvlet/airframe/surface/i3411.scala
+++ b/airframe-surface/src/test/scala/wvlet/airframe/surface/i3411.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.surface
+
+import wvlet.airspec.AirSpec
+
+object i3411 extends AirSpec {
+
+  object SomeEnum extends Enumeration {
+    type SomeEnum = Value
+
+    val A, B, C = Value
+  }
+
+  import SomeEnum.SomeEnum
+
+  test("Handle a Scala 2 enumeration") {
+    val s = Surface.of[SomeEnum] // just check there is no error - no expected properties
+    val m = Surface.methodsOf[SomeEnum]
+    debug(s.params)
+    // enumeration type (value) usually contains at least the compare method
+    m.map(_.name) shouldContain "compare"
+  }
+}

--- a/airframe-surface/src/test/scala/wvlet/airframe/surface/i3439.scala
+++ b/airframe-surface/src/test/scala/wvlet/airframe/surface/i3439.scala
@@ -15,7 +15,7 @@ package wvlet.airframe.surface
 
 import wvlet.airspec.AirSpec
 
-object i3411 extends AirSpec {
+object i3439 extends AirSpec {
 
   trait Base {
     class InnerType {


### PR DESCRIPTION
This an exploratory PR for #3433 and #3429

I would like to know where exactly is the type mismatch happening and if perhaps there is a way to avoid it completely, even at cost of reported method surfaces being not 100% accurate.