### PR TITLE
surface: Fix #3454 - methods in generic classes - for Scala 3

### DIFF
--- a/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
+++ b/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
@@ -312,10 +312,9 @@ private[surface] class CompileTimeSurfaceFactory[Q <: Quotes](using quotes: Q):
       case _              => List.empty[TypeRepr]
 
     // Build a table for resolving type parameters, e.g., class MyClass[A, B]  -> Map("A" -> TypeRepr, "B" -> TypeRepr)
-    (classTypeParams zip classTypeArgs)
-      .map { (paramType, argType) =>
-        paramType.name -> argType
-      }.toMap[String, TypeRepr]
+    (classTypeParams zip classTypeArgs).map { (paramType, argType) =>
+      paramType.name -> argType
+    }.toMap[String, TypeRepr]
 
   // Get a constructor with its generic types are resolved
   private def getResolvedConstructorOf(t: TypeRepr): Option[Term] =

--- a/airframe-surface/src/test/scala-3/wvlet/airframe/surface/GenericMethodTest.scala
+++ b/airframe-surface/src/test/scala-3/wvlet/airframe/surface/GenericMethodTest.scala
@@ -15,10 +15,9 @@ package wvlet.airframe.surface
 
 import wvlet.airspec.AirSpec
 
-object GenericMethodTest extends AirSpec {
-  class A {
+object GenericMethodTest extends AirSpec:
+  class A:
     def helloX[X](v: X): String = "hello"
-  }
 
   test("generic method") {
     val methods = Surface.methodsOf[A]
@@ -29,4 +28,21 @@ object GenericMethodTest extends AirSpec {
     m.call(obj, "dummy") shouldBe "hello"
   }
 
-}
+  case class Gen[X](value: X):
+    def pass(x: X): X        = x
+    def myself: Gen[X]       = this
+    def wrap(x: X): Gen[X]   = Gen[X](value)
+    def unwrap(x: Gen[X]): X = x.value
+
+  test("Methods of generic type") {
+    val typeSurface = Surface.of[Gen[String]]
+    val methods     = Surface.methodsOf[Gen[String]]
+    val pass        = methods.find(_.name == "pass").get
+    pass.returnType shouldBe Surface.of[String]
+    val myself = methods.find(_.name == "myself").get
+    myself.returnType shouldBe typeSurface
+    val wrap = methods.find(_.name == "wrap").get
+    wrap.returnType shouldBe typeSurface
+    val unwrap = methods.find(_.name == "unwrap").get
+    unwrap.returnType shouldBe Surface.of[String]
+  }


### PR DESCRIPTION
This PR implements a test and Scala 3 fix of #3454. The major part of the fix is a simplification of `typeMappingTable` function. I am not 100% sure what the previous implementation using `method.paramSymss` was trying to do, I only hope whatever it was, it had tests in place for that.

@xerial The new test fails on Scala 2 - if you or anyone is interested in completing the fix, feel free to continue.