### PR TITLE
surface (internal): Use .typeMember instead of .tree to get parameter types

### DIFF
--- a/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
+++ b/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
@@ -518,8 +518,8 @@ private[surface] class CompileTimeSurfaceFactory[Q <: Quotes](using quotes: Q):
 
     paramss.map { params =>
       params.zipWithIndex
-        .map((x, i) => (x, i + 1, x.tree))
-        .collect { case (s: Symbol, i: Int, v: ValDef) =>
+        .map((x, i) => (x, i + 1, t.memberType(x)))
+        .collect { case (s: Symbol, i: Int, v: TypeRepr) =>
           // E.g. case class Foo(a: String)(implicit b: Int)
           // println(s"=== ${v.show} ${s.flags.show} ${s.flags.is(Flags.Implicit)}")
           // Substitute type param to actual types
@@ -543,7 +543,7 @@ private[surface] class CompileTimeSurfaceFactory[Q <: Quotes](using quotes: Q):
               case other =>
                 other
 
-          val resolved: TypeRepr = resolveType(v.tpt.tpe)
+          val resolved: TypeRepr = resolveType(v)
 
           val isSecret           = hasSecretAnnotation(s)
           val isRequired         = hasRequiredAnnotation(s)
@@ -556,7 +556,7 @@ private[surface] class CompileTimeSurfaceFactory[Q <: Quotes](using quotes: Q):
               // println(s"=== target: ${m.name}, ${m.owner.name}")
               m.name == targetMethodName
             }
-          MethodArg(v.name, resolved, defaultValueGetter, defaultMethodArgGetter, isImplicit, isRequired, isSecret)
+          MethodArg(s.name, resolved, defaultValueGetter, defaultMethodArgGetter, isImplicit, isRequired, isSecret)
         }
     }
 

--- a/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
+++ b/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
@@ -330,8 +330,8 @@ private[surface] class CompileTimeSurfaceFactory[Q <: Quotes](using quotes: Q):
         else
           val lookupTable = typeMappingTable(t, pc)
           // println(s"--- ${lookupTable}")
-          val typeArgs = pc.paramSymss.headOption.getOrElse(List.empty).map(_.tree).collect { case t: TypeDef =>
-            lookupTable.getOrElse(t.name, TypeRepr.of[AnyRef])
+          val typeArgs = pc.paramSymss.headOption.getOrElse(List.empty).filter(_.isTypeParam).map { p =>
+            lookupTable.getOrElse(p.name, TypeRepr.of[AnyRef])
           }
           Some(cstr.appliedToTypes(typeArgs))
 

--- a/airframe-surface/src/test/scala/wvlet/airframe/surface/i3417.scala
+++ b/airframe-surface/src/test/scala/wvlet/airframe/surface/i3417.scala
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.surface
+
+import wvlet.airspec.AirSpec
+
+/**
+  * note: this is a regression test for a non-deterministic issue, see https://github.com/scala/scala3/issues/19795
+  */
+
+object i3417 extends AirSpec {
+  trait MyOption[T]
+
+  class Wrap(val option: MyOption[Int])
+  class MultiWrap(option: MyOption[Int], seq: Seq[(Double, MyOption[String])], map: Map[MyOption[Double], Double])
+
+  test("handle generic types on parameters") {
+    val s = Surface.of[Wrap]
+    s.params.size shouldBe 1
+    s.params.head.surface.name shouldBe "MyOption[Int]"
+
+    val m = Surface.of[MultiWrap]
+    m.params.size shouldBe 3
+    m.params(0).surface.name shouldBe "MyOption[Int]"
+    m.params(1).surface.name shouldBe "Seq[Tuple2[Double,MyOption[String]]]"
+    m.params(2).surface.name shouldBe "Map[MyOption[Double],Double]"
+  }
+
+}


### PR DESCRIPTION
Do not use `.tree` to obtain parameter types, use `typeMember` instead. The code is simpler and more reliable, avoiding issue https://github.com/scala/scala3/issues/19795 (#3417)
