### PR TITLE
Surface internal - Fix tree owner in `surfaceDefs` `ValDef`

### DIFF
--- a/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
+++ b/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
@@ -725,7 +725,7 @@ private[surface] class CompileTimeSurfaceFactory[Q <: Quotes](using quotes: Q):
     seenMethodParent.clear()
 
     val surfaceDefs: List[ValDef] = surfaceToVar.toSeq.map { case (tpe, sym) =>
-      ValDef(sym, Some(surfaceOf(tpe, useVarRef = false).asTerm))
+      ValDef(sym, Some(surfaceOf(tpe, useVarRef = false).asTerm.changeOwner(sym)))
     }.toList
 
     /**


### PR DESCRIPTION
Fixes issue investigated as https://github.com/scala/scala3/issues/20072

Unfortunately there are still other issues preventing compiling with `-Xcheck-macros` (https://stackoverflow.com/questions/78193025/how-to-extract-type-parameter-from-typelambda-correctly), but this fix is an important step in that direction.