### PR TITLE
rx-html (fix): Show warning logs when RxElement rendering failed

### DIFF
--- a/airframe-rx-html/.js/src/main/scala/wvlet/airframe/rx/html/DOMRenderer.scala
+++ b/airframe-rx-html/.js/src/main/scala/wvlet/airframe/rx/html/DOMRenderer.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.rx.html
 import org.scalajs.dom
-import wvlet.airframe.rx.{Cancelable, OnNext, Rx, RxOps, RxRunner}
+import wvlet.airframe.rx.{Cancelable, OnNext, OnError, Rx, RxOps, RxRunner}
 import wvlet.log.LogSupport
 
 import scala.scalajs.js
@@ -153,6 +153,9 @@ object DOMRenderer extends LogSupport {
                 val ctx = new RenderingContext()
                 c1 = traverse(value, Some(start), ctx)
                 ctx.onFinish()
+              case OnError(e) =>
+                warn(s"An unhandled error occurred while rendering ${rx}", e)
+                c1 = Cancelable.empty
               case other =>
                 c1 = Cancelable.empty
             }
@@ -288,6 +291,9 @@ object DOMRenderer extends LogSupport {
             ev match {
               case OnNext(value) =>
                 c1 = traverse(value)
+              case OnError(e) =>
+                warn(s"An unhandled error occurred while rendering ${rx}", e)
+                c1 = Cancelable.empty
               case other =>
                 c1 = Cancelable.empty
             }

--- a/airframe-rx-html/.js/src/test/scala/wvlet/airframe/http/rx/html/RenderErrorTest.scala
+++ b/airframe-rx-html/.js/src/test/scala/wvlet/airframe/http/rx/html/RenderErrorTest.scala
@@ -31,7 +31,7 @@ object RenderErrorTest extends AirSpec {
   }
 
   test("report an error during rendering") {
-    val el   = MyElem()
+    val el   = new MyElem()
     val node = el.renderTo("main")
     node.node shouldMatch { case h: HTMLElement =>
       h.innerHTML shouldBe "<div>hello world: 1</div>"
@@ -54,7 +54,7 @@ object RenderErrorTest extends AirSpec {
   }
 
   test("report an error during rendering nested Rx elements") {
-    val el   = RxElem()
+    val el   = new RxElem()
     val node = el.renderTo("main2")
     node.node shouldMatch { case h: HTMLElement =>
       h.innerHTML shouldBe "<div>hello world:<i>1</i></div>"

--- a/airframe-rx-html/.js/src/test/scala/wvlet/airframe/http/rx/html/RenderErrorTest.scala
+++ b/airframe-rx-html/.js/src/test/scala/wvlet/airframe/http/rx/html/RenderErrorTest.scala
@@ -26,21 +26,19 @@ object RenderErrorTest extends AirSpec {
 
     override def render = div(
       "hello",
-      x.map { x => s" world: ${1/x}" }
+      x.map { x => s" world: ${1 / x}" }
     )
   }
 
-  test("error during rendering") {
-    val el = MyElem()
+  test("report an error during rendering") {
+    val el   = MyElem()
     val node = el.renderTo("main")
-    node.node shouldMatch {
-      case h: HTMLElement =>
-        h.innerHTML shouldBe "<div>hello world: 1</div>"
+    node.node shouldMatch { case h: HTMLElement =>
+      h.innerHTML shouldBe "<div>hello world: 1</div>"
     }
     el.x := 0
-    node.node shouldMatch {
-      case h: HTMLElement =>
-        h.innerHTML shouldBe "<div>hello</div>"
+    node.node shouldMatch { case h: HTMLElement =>
+      h.innerHTML shouldBe "<div>hello</div>"
     }
   }
 
@@ -55,17 +53,15 @@ object RenderErrorTest extends AirSpec {
     }
   }
 
-  test("error while rendering nested Rx elements") {
-    val el = RxElem()
+  test("report an error during rendering nested Rx elements") {
+    val el   = RxElem()
     val node = el.renderTo("main2")
-    node.node shouldMatch {
-      case h: HTMLElement =>
-        h.innerHTML shouldBe "<div>hello world:<i>1</i></div>"
+    node.node shouldMatch { case h: HTMLElement =>
+      h.innerHTML shouldBe "<div>hello world:<i>1</i></div>"
     }
     el.y := 0
-    node.node shouldMatch {
-      case h: HTMLElement =>
-        h.innerHTML shouldBe "<div>hello<i></i></div>"
+    node.node shouldMatch { case h: HTMLElement =>
+      h.innerHTML shouldBe empty
     }
   }
 

--- a/airframe-rx-html/.js/src/test/scala/wvlet/airframe/http/rx/html/RenderErrorTest.scala
+++ b/airframe-rx-html/.js/src/test/scala/wvlet/airframe/http/rx/html/RenderErrorTest.scala
@@ -32,7 +32,7 @@ object RenderErrorTest extends AirSpec {
 
   test("report an error during rendering") {
     val el   = new MyElem()
-    val node = el.renderTo("main")
+    val node = el.renderTo("test1")
     node.node shouldMatch { case h: HTMLElement =>
       h.innerHTML shouldBe "<div>hello world: 1</div>"
     }
@@ -55,7 +55,7 @@ object RenderErrorTest extends AirSpec {
 
   test("report an error during rendering nested Rx elements") {
     val el   = new RxElem()
-    val node = el.renderTo("main2")
+    val node = el.renderTo("test2")
     node.node shouldMatch { case h: HTMLElement =>
       h.innerHTML shouldBe "<div>hello world:<i>1</i></div>"
     }

--- a/airframe-rx-html/.js/src/test/scala/wvlet/airframe/http/rx/html/RenderErrorTest.scala
+++ b/airframe-rx-html/.js/src/test/scala/wvlet/airframe/http/rx/html/RenderErrorTest.scala
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.http.rx.html
+
+import org.scalajs.dom.HTMLElement
+import wvlet.airframe.rx.Rx
+import wvlet.airframe.rx.html.all.*
+import wvlet.airframe.rx.html.RxElement
+import wvlet.airspec.AirSpec
+
+object RenderErrorTest extends AirSpec {
+
+  class MyElem extends RxElement {
+    val x = Rx.variable(1)
+
+    override def render = div(
+      "hello",
+      x.map { x => s" world: ${1/x}" }
+    )
+  }
+
+  test("error during rendering") {
+    val el = MyElem()
+    val node = el.renderTo("main")
+    node.node shouldMatch {
+      case h: HTMLElement =>
+        h.innerHTML shouldBe "<div>hello world: 1</div>"
+    }
+    el.x := 0
+    node.node shouldMatch {
+      case h: HTMLElement =>
+        h.innerHTML shouldBe "<div>hello</div>"
+    }
+  }
+
+  class RxElem extends RxElement {
+    val y = Rx.variable(1)
+
+    override def render: RxElement = y.map { v =>
+      div(
+        "hello world:",
+        i(1 / v)
+      )
+    }
+  }
+
+  test("error while rendering nested Rx elements") {
+    val el = RxElem()
+    val node = el.renderTo("main2")
+    node.node shouldMatch {
+      case h: HTMLElement =>
+        h.innerHTML shouldBe "<div>hello world:<i>1</i></div>"
+    }
+    el.y := 0
+    node.node shouldMatch {
+      case h: HTMLElement =>
+        h.innerHTML shouldBe "<div>hello<i></i></div>"
+    }
+  }
+
+}


### PR DESCRIPTION
- **Reproduce vanished DOM nodes upon errors**
- **Add test case**
