### PR TITLE
airspec (internal): Prepare for Scala Native 0.5 support 

### DIFF
--- a/airframe-di/.native/src/main/scala-3/wvlet/airframe/lifecycle/AddShutdownHook.scala
+++ b/airframe-di/.native/src/main/scala-3/wvlet/airframe/lifecycle/AddShutdownHook.scala
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.lifecycle
+
+/**
+  */
+object AddShutdownHook extends LifeCycleEventHandler {
+  override def beforeStart(lifeCycleManager: LifeCycleManager): Unit = {
+    // no-op for Scala.js since there is no shutdown hook
+  }
+}

--- a/airframe-di/.native/src/main/scala-3/wvlet/airframe/lifecycle/JSR250LifeCycleExecutor.scala
+++ b/airframe-di/.native/src/main/scala-3/wvlet/airframe/lifecycle/JSR250LifeCycleExecutor.scala
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.lifecycle
+
+/**
+  */
+object JSR250LifeCycleExecutor extends LifeCycleEventHandler {
+  // Do nothing in Scala.js
+}

--- a/airframe-log/.native/src/main/scala/wvlet/log/LogEnv.scala
+++ b/airframe-log/.native/src/main/scala/wvlet/log/LogEnv.scala
@@ -22,10 +22,10 @@ private[log] object LogEnv extends LogEnvBase {
     // do nothing by default
   }
 
-  override def isScalaJS: Boolean = false
-  override def defaultLogLevel: LogLevel = LogLevel.INFO
+  override def isScalaJS: Boolean                        = false
+  override def defaultLogLevel: LogLevel                 = LogLevel.INFO
   override def defaultHandler: java.util.logging.Handler = new ConsoleLogHandler(SourceCodeLogFormatter)
-  override def defaultConsoleOutput: PrintStream = System.err
+  override def defaultConsoleOutput: PrintStream         = System.err
 
   /**
     * @param cl
@@ -33,7 +33,7 @@ private[log] object LogEnv extends LogEnvBase {
     */
   override def getLoggerName(cl: Class[_]): String = cl.getName
 
-  override def scheduleLogLevelScan: Unit = {}
+  override def scheduleLogLevelScan: Unit      = {}
   override def stopScheduledLogLevelScan: Unit = {}
 
   /**

--- a/airframe-log/.native/src/main/scala/wvlet/log/LogEnv.scala
+++ b/airframe-log/.native/src/main/scala/wvlet/log/LogEnv.scala
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.log
+
+import java.io.PrintStream
+import wvlet.log.LogFormatter.SourceCodeLogFormatter
+
+private[log] object LogEnv extends LogEnvBase {
+
+  override def initLogManager(): Unit = {
+    // do nothing by default
+  }
+
+  override def isScalaJS: Boolean = false
+  override def defaultLogLevel: LogLevel = LogLevel.INFO
+  override def defaultHandler: java.util.logging.Handler = new ConsoleLogHandler(SourceCodeLogFormatter)
+  override def defaultConsoleOutput: PrintStream = System.err
+
+  /**
+    * @param cl
+    * @return
+    */
+  override def getLoggerName(cl: Class[_]): String = cl.getName
+
+  override def scheduleLogLevelScan: Unit = {}
+  override def stopScheduledLogLevelScan: Unit = {}
+
+  /**
+    * Scan the default log level file only once. To periodically scan, use scheduleLogLevelScan
+    */
+  override def scanLogLevels: Unit = {}
+
+  /**
+    * Scan the specified log level file
+    *
+    * @param loglevelFileCandidates
+    */
+  override def scanLogLevels(loglevelFileCandidates: Seq[String]): Unit = {}
+
+  override def registerJMX: Unit = {}
+
+  /**
+    */
+  override def unregisterJMX: Unit = {}
+
+}

--- a/airframe-log/.native/src/main/scala/wvlet/log/LogTimestampFormatter.scala
+++ b/airframe-log/.native/src/main/scala/wvlet/log/LogTimestampFormatter.scala
@@ -1,0 +1,17 @@
+package wvlet.log
+
+
+/**
+  * Use scalajs.js.Date to foramte timestamp
+  */
+object LogTimestampFormatter {
+  def formatTimestamp(timeMillis: Long): String = {
+    // TODO
+    ""
+  }
+
+  def formatTimestampWithNoSpaace(timeMillis: Long): String = {
+    // TODO
+    ""
+  }
+}

--- a/airframe-log/.native/src/main/scala/wvlet/log/LogTimestampFormatter.scala
+++ b/airframe-log/.native/src/main/scala/wvlet/log/LogTimestampFormatter.scala
@@ -1,6 +1,5 @@
 package wvlet.log
 
-
 /**
   * Use scalajs.js.Date to foramte timestamp
   */

--- a/airframe-rx/.native/src/main/scala-3/wvlet/airframe/rx/compat.scala
+++ b/airframe-rx/.native/src/main/scala-3/wvlet/airframe/rx/compat.scala
@@ -14,39 +14,17 @@
 package wvlet.airframe.rx
 
 import scala.util.Try
-import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.{Executors, TimeUnit}
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Promise}
 
 /**
   */
 object compat {
-  def defaultExecutionContext: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global
+  def defaultExecutionContext: scala.concurrent.ExecutionContext = ???
 
   def newTimer: Timer = ???
 
-  def scheduleOnce[U](delayMills: Long)(body: => U): Cancelable = {
-    val thread = Executors.newScheduledThreadPool(1)
-    val schedule = thread.schedule(
-      new Runnable {
-        override def run(): Unit = {
-          body
-        }
-      },
-      delayMills,
-      TimeUnit.MILLISECONDS
-    )
-    // Immediately start the thread pool shutdown to avoid thread leak
-    thread.shutdown()
-    Cancelable { () =>
-      try {
-        schedule.cancel(false)
-      } finally {
-        thread.shutdown()
-      }
-    }
-  }
+  def scheduleOnce[U](delayMills: Long)(body: => U): Cancelable = ???
 
   def toSeq[A](rx: Rx[A]): Seq[A] = {
     throw new UnsupportedOperationException("Rx.toSeq is unsupported in Scala.native")

--- a/airframe-rx/.native/src/main/scala-3/wvlet/airframe/rx/compat.scala
+++ b/airframe-rx/.native/src/main/scala-3/wvlet/airframe/rx/compat.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.rx
+
+import scala.util.Try
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.{Executors, TimeUnit}
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Promise}
+
+/**
+  */
+object compat {
+  def defaultExecutionContext: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global
+
+  def newTimer: Timer = ???
+
+  def scheduleOnce[U](delayMills: Long)(body: => U): Cancelable = {
+    val thread = Executors.newScheduledThreadPool(1)
+    val schedule = thread.schedule(
+      new Runnable {
+        override def run(): Unit = {
+          body
+        }
+      },
+      delayMills,
+      TimeUnit.MILLISECONDS
+    )
+    // Immediately start the thread pool shutdown to avoid thread leak
+    thread.shutdown()
+    Cancelable { () =>
+      try {
+        schedule.cancel(false)
+      } finally {
+        thread.shutdown()
+      }
+    }
+  }
+
+  def toSeq[A](rx: Rx[A]): Seq[A] = {
+    throw new UnsupportedOperationException("Rx.toSeq is unsupported in Scala.native")
+  }
+
+  private[rx] def await[A](rx: RxOps[A]): A = {
+    throw new UnsupportedOperationException("Rx.await is unsupported in Scala.native")
+  }
+}

--- a/airframe-surface/.native/src/main/scala-3/wvlet/airframe/surface/SurfaceFactory.scala
+++ b/airframe-surface/.native/src/main/scala-3/wvlet/airframe/surface/SurfaceFactory.scala
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.surface
+
+/**
+  */
+object SurfaceFactory:
+  inline def of[A]: Surface                   = ${ CompileTimeSurfaceFactory.surfaceOf[A] }
+  inline def methodsOf[A]: Seq[MethodSurface] = ${ CompileTimeSurfaceFactory.methodsOf[A] }
+
+  // TODO support inner clases in Scala.js
+  def localSurfaceOf[A](context: Any): Surface = ???

--- a/airframe-surface/.native/src/main/scala-3/wvlet/airframe/surface/package.scala
+++ b/airframe-surface/.native/src/main/scala-3/wvlet/airframe/surface/package.scala
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe
+
+import java.util.concurrent.ConcurrentHashMap
+import scala.collection.mutable
+import scala.jdk.CollectionConverters.*
+
+package object surface:
+  val surfaceCache       = new ConcurrentHashMap[String, Surface]().asScala
+  val methodSurfaceCache = new ConcurrentHashMap[String, Seq[MethodSurface]]().asScala
+
+  def getCached(fullName: String): Surface =
+    surfaceCache(fullName)
+
+  def newCacheMap[A, B]: scala.collection.mutable.Map[A, B] = new mutable.WeakHashMap[A, B]()

--- a/airframe-surface/.native/src/main/scala-3/wvlet/airframe/surface/surface.scala
+++ b/airframe-surface/.native/src/main/scala-3/wvlet/airframe/surface/surface.scala
@@ -11,17 +11,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.airframe
+package wvlet.airframe.surface
 
 import java.util.concurrent.ConcurrentHashMap
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
 
-package object surface:
-  val surfaceCache       = new ConcurrentHashMap[String, Surface]().asScala
-  val methodSurfaceCache = new ConcurrentHashMap[String, Seq[MethodSurface]]().asScala
 
-  def getCached(fullName: String): Surface =
-    surfaceCache(fullName)
+val surfaceCache       = new ConcurrentHashMap[String, Surface]().asScala
+val methodSurfaceCache = new ConcurrentHashMap[String, Seq[MethodSurface]]().asScala
 
-  def newCacheMap[A, B]: scala.collection.mutable.Map[A, B] = new mutable.WeakHashMap[A, B]()
+def getCached(fullName: String): Surface =
+  surfaceCache(fullName)
+
+def newCacheMap[A, B]: scala.collection.mutable.Map[A, B] = new mutable.WeakHashMap[A, B]()

--- a/airframe-surface/src/main/scala/wvlet/airframe/surface/CName.scala
+++ b/airframe-surface/src/main/scala/wvlet/airframe/surface/CName.scala
@@ -15,7 +15,7 @@
 package wvlet.airframe.surface
 
 import java.util.regex.Pattern
-
+import wvlet.airframe.surface
 import scala.collection.mutable.WeakHashMap
 
 //--------------------------------------
@@ -37,15 +37,15 @@ import scala.collection.mutable.WeakHashMap
   *   leo
   */
 object CName {
-  private val cnameTable = newCacheMap[String, CName]
+  private val cnameTable = surface.newCacheMap[String, CName]
 
   def apply(name: String): CName = {
     cnameTable.getOrElseUpdate(name, new CName(toCanonicalName(name), toNaturalName(name)))
   }
 
   private val paramNameReplacePattern = Pattern.compile("[\\s-_]");
-  private val canonicalNameTable      = newCacheMap[String, String]
-  private val naturalNameTable        = newCacheMap[String, String]
+  private val canonicalNameTable      = surface.newCacheMap[String, String]
+  private val naturalNameTable        = surface.newCacheMap[String, String]
 
   private def isSplitChar(c: Char)    = c.isUpper || c == '_' || c == '-' || c == ' '
   private def isUpcasePrefix(c: Char) = c.isUpper || c.isDigit

--- a/airspec/.native/src/main/scala-3/wvlet/airspec/Compat.scala
+++ b/airspec/.native/src/main/scala-3/wvlet/airspec/Compat.scala
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airspec
+
+import sbt.testing.Fingerprint
+import wvlet.airframe.surface.MethodSurface
+import wvlet.airspec.Framework.{AirSpecClassFingerPrint, AirSpecObjectFingerPrint}
+import wvlet.airspec.spi.Asserts
+import wvlet.log.LogFormatter.SourceCodeLogFormatter
+import wvlet.log.{ConsoleLogHandler, LogSupport, Logger}
+
+import java.lang.reflect.InvocationTargetException
+import java.util.concurrent.{Executors, ThreadFactory}
+import scala.concurrent.ExecutionContext
+
+import scala.concurrent.ExecutionContext
+import scala.util.Try
+import scala.util.{Success, Failure}
+
+/**
+  */
+private[airspec] object Compat extends CompatApi with LogSupport {
+  override def isScalaJs = false
+
+  override private[airspec] val executionContext: ExecutionContext = ExecutionContext.global
+
+  private[airspec] def findCompanionObjectOf(fullyQualifiedName: String, classLoader: ClassLoader): Option[Any] = {
+    None
+  }
+
+  private[airspec] def getFingerprint(fullyQualifiedName: String, classLoader: ClassLoader): Option[Fingerprint] = {
+    Try(findCompanionObjectOf(fullyQualifiedName, classLoader)).toOption
+      .flatMap {
+        case Some(spec: AirSpecSpi) =>
+          Some(AirSpecObjectFingerPrint)
+        case other =>
+          None
+      }
+      .orElse {
+        Try(classLoader.loadClass(fullyQualifiedName)).toOption
+          .flatMap { x =>
+            if (classOf[AirSpec].isAssignableFrom(x))
+              Some(AirSpecClassFingerPrint)
+            else {
+              None
+            }
+          }
+      }
+  }
+
+  private[airspec] def newInstanceOf(fullyQualifiedName: String, classLoader: ClassLoader): Option[Any] = {
+    Try(classLoader.loadClass(fullyQualifiedName).getDeclaredConstructor().newInstance()) match {
+      case Success(x) => Some(x)
+      case Failure(e: InvocationTargetException) if e.getCause != null =>
+        if (classOf[spi.AirSpecException].isAssignableFrom(e.getCause.getClass)) {
+          // For assertion failrues, throw it as is
+          throw e
+        } else {
+          // For other failures when instantiating the object, throw the cause
+          throw e.getCause
+        }
+      case _ =>
+        // Ignore other types of failures, which should not happen in general
+        None
+    }
+  }
+
+  private[airspec] def withLogScanner[U](block: => U): U = {
+    try {
+      startLogScanner
+      block
+    } finally {
+      stopLogScanner
+    }
+  }
+
+  private[airspec] def startLogScanner: Unit = {}
+  private[airspec] def stopLogScanner: Unit = {}
+
+  private[airspec] def findCause(e: Throwable): Throwable = {
+    e match {
+      case i: InvocationTargetException => findCause(i.getTargetException)
+      case _                            => e
+    }
+  }
+
+  override private[airspec] def getSpecName(cl: Class[_]): String = {
+    var name = cl.getName
+
+    // In Scala.js we cannot use cl.getInterfaces to find the actual type
+    val pos = name.indexOf("$")
+    if (pos > 0) {
+      // Remove trailing $xxx
+      name = name.substring(0, pos)
+    }
+    name
+  }
+
+  private[airspec] def getContextClassLoader: ClassLoader = {
+    // Scala.js doesn't need to use ClassLoader for loading tests
+    null
+  }
+}

--- a/airspec/.native/src/main/scala-3/wvlet/airspec/Compat.scala
+++ b/airspec/.native/src/main/scala-3/wvlet/airspec/Compat.scala
@@ -13,7 +13,6 @@
  */
 package wvlet.airspec
 
-import org.portablescala.reflect.Reflect
 import sbt.testing.Fingerprint
 import wvlet.airframe.surface.MethodSurface
 import wvlet.airspec.Framework.{AirSpecClassFingerPrint, AirSpecObjectFingerPrint}
@@ -37,7 +36,7 @@ private[airspec] object Compat extends CompatApi with LogSupport:
   override private[airspec] val executionContext: ExecutionContext = ExecutionContext.global
 
   private[airspec] def findCompanionObjectOf(fullyQualifiedName: String, classLoader: ClassLoader): Option[Any] =
-    val clsOpt = Reflect.lookupLoadableModuleClass(fullyQualifiedName + "$", classLoader)
+    val clsOpt = scala.scalanative.reflect.Reflect.lookupLoadableModuleClass(fullyQualifiedName + "$")
     clsOpt.map {
       _.loadModule()
     }
@@ -59,10 +58,10 @@ private[airspec] object Compat extends CompatApi with LogSupport:
           }
       }
 
-  private[airspec] def newInstanceOf(fullyQualifiedName: String, classLoader: ClassLoader): Option[Any] =
-    val clsOpt = Reflect.lookupInstantiatableClass(fullyQualifiedName)
+  private[airspec] def newInstanceOf(fullyQualifiedName: String, classLoader: ClassLoader): Option[Any] = {
+    val clsOpt = scala.scalanative.reflect.Reflect.lookupInstantiatableClass(fullyQualifiedName)
     clsOpt.map(_.newInstance())
-
+  }
 
   private[airspec] def withLogScanner[U](block: => U): U =
     try

--- a/airspec/.native/src/main/scala-3/wvlet/airspec/PlatformAirSpec.scala
+++ b/airspec/.native/src/main/scala-3/wvlet/airspec/PlatformAirSpec.scala
@@ -3,4 +3,5 @@ package wvlet.airspec
 /**
   * Platform-specific AirSpecApi implementation
   */
-trait PlatformAirSpec { this: AirSpecSpi => }
+trait PlatformAirSpec:
+  this: AirSpecSpi =>

--- a/airspec/.native/src/main/scala-3/wvlet/airspec/PlatformAirSpec.scala
+++ b/airspec/.native/src/main/scala-3/wvlet/airspec/PlatformAirSpec.scala
@@ -1,6 +1,6 @@
 package wvlet.airspec
 
-import org.portablescala.reflect.annotation.EnableReflectiveInstantiation
+import scala.scalanative.reflect.annotation.EnableReflectiveInstantiation
 
 /**
   * Scala.native platform-specific implementation

--- a/airspec/.native/src/main/scala-3/wvlet/airspec/PlatformAirSpec.scala
+++ b/airspec/.native/src/main/scala-3/wvlet/airspec/PlatformAirSpec.scala
@@ -1,7 +1,12 @@
 package wvlet.airspec
 
+import org.portablescala.reflect.annotation.EnableReflectiveInstantiation
+
 /**
-  * Platform-specific AirSpecApi implementation
+  * Scala.native platform-specific implementation
+  *
+  * EnableReflectiveInstantiation annotation is necessary to support (test class).getInstance() in Scala.native
   */
+@EnableReflectiveInstantiation
 trait PlatformAirSpec:
   this: AirSpecSpi =>

--- a/airspec/.native/src/main/scala-3/wvlet/airspec/PlatformAirSpec.scala
+++ b/airspec/.native/src/main/scala-3/wvlet/airspec/PlatformAirSpec.scala
@@ -1,0 +1,6 @@
+package wvlet.airspec
+
+/**
+  * Platform-specific AirSpecApi implementation
+  */
+trait PlatformAirSpec { this: AirSpecSpi => }

--- a/airspec/build.sbt
+++ b/airspec/build.sbt
@@ -18,7 +18,7 @@ val SCALA_2_13          = "2.13.13"
 val SCALA_3             = "3.3.3"
 val targetScalaVersions = SCALA_3 :: SCALA_2_13 :: SCALA_2_12 :: Nil
 
-val SCALACHECK_VERSION           = "1.17.1"
+val SCALACHECK_VERSION           = "1.18.0"
 val JS_JAVA_LOGGING_VERSION      = "1.0.0"
 val JAVAX_ANNOTATION_API_VERSION = "1.3.2"
 
@@ -192,7 +192,6 @@ val airspecJSBuildSettings = Seq[Setting[?]](
 
 val airspecNativeBuildSettings = Seq[Setting[?]](
   crossScalaVersions := Seq(SCALA_3),
-  nativeLinkStubs    := true,
   Compile / unmanagedSourceDirectories ++= {
     val baseDir = (ThisBuild / baseDirectory).value.getAbsoluteFile
     val sv      = scalaBinaryVersion.value
@@ -370,7 +369,7 @@ lazy val airspec =
       Compile / packageSrc / mappings ++= (airspecDeps.native / Compile / packageSrc / mappings).value,
       libraryDependencies ++= Seq(
         "org.scala-sbt"         % "test-interface"         % "1.0",
-        ("org.portable-scala" %%% "portable-scala-reflect" % "1.1.2").cross(CrossVersion.for3Use2_13)
+        //("org.portable-scala" %%% "portable-scala-reflect" % "1.1.2").cross(CrossVersion.for3Use2_13)
       )
     )
     // This should be Optional dependency, but using Provided dependency for bloop which doesn't support Optional.

--- a/airspec/build.sbt
+++ b/airspec/build.sbt
@@ -192,6 +192,7 @@ val airspecJSBuildSettings = Seq[Setting[?]](
 )
 
 val airspecNativeBuildSettings = Seq[Setting[?]](
+  crossScalaVersions := Seq(SCALA_3),
   Compile / unmanagedSourceDirectories ++= {
     val baseDir = (ThisBuild / baseDirectory).value.getAbsoluteFile
     val sv      = scalaBinaryVersion.value

--- a/airspec/build.sbt
+++ b/airspec/build.sbt
@@ -193,6 +193,7 @@ val airspecJSBuildSettings = Seq[Setting[?]](
 
 val airspecNativeBuildSettings = Seq[Setting[?]](
   crossScalaVersions := Seq(SCALA_3),
+  nativeLinkStubs    := true,
   Compile / unmanagedSourceDirectories ++= {
     val baseDir = (ThisBuild / baseDirectory).value.getAbsoluteFile
     val sv      = scalaBinaryVersion.value

--- a/airspec/build.sbt
+++ b/airspec/build.sbt
@@ -368,7 +368,8 @@ lazy val airspec =
       Compile / packageBin / mappings ++= (airspecDeps.native / Compile / packageBin / mappings).value,
       Compile / packageSrc / mappings ++= (airspecDeps.native / Compile / packageSrc / mappings).value,
       libraryDependencies ++= Seq(
-        "org.scala-sbt" % "test-interface" % "1.0"
+        "org.scala-sbt"         % "test-interface"         % "1.0",
+        ("org.portable-scala" %%% "portable-scala-reflect" % "1.1.2").cross(CrossVersion.for3Use2_13)
       )
     )
     // This should be Optional dependency, but using Provided dependency for bloop which doesn't support Optional.

--- a/airspec/build.sbt
+++ b/airspec/build.sbt
@@ -191,8 +191,20 @@ val airspecJSBuildSettings = Seq[Setting[?]](
   }
 )
 
+val airspecNativeBuildSettings = Seq[Setting[?]](
+  Compile / unmanagedSourceDirectories ++= {
+    val baseDir = (ThisBuild / baseDirectory).value.getAbsoluteFile
+    val sv      = scalaBinaryVersion.value
+    val sourceDirs =
+      for (m <- airspecDependsOn.value; folder <- Seq(".native")) yield {
+        crossBuildSources(sv, s"${baseDir}/../${m}/${folder}")
+      }
+    sourceDirs.flatten
+  }
+)
+
 lazy val airspecLog =
-  crossProject(JSPlatform, JVMPlatform)
+  crossProject(JSPlatform, JVMPlatform, NativePlatform)
     .crossType(CrossType.Pure)
     .in(file("airspec-log"))
     .settings(buildSettings)
@@ -224,9 +236,12 @@ lazy val airspecLog =
         ("org.scala-js" %%% "scalajs-java-logging" % JS_JAVA_LOGGING_VERSION).cross(CrossVersion.for3Use2_13)
       )
     )
+    .nativeSettings(
+      airspecNativeBuildSettings
+    )
 
 lazy val airspecCore =
-  crossProject(JSPlatform, JVMPlatform)
+  crossProject(JSPlatform, JVMPlatform, NativePlatform)
     .crossType(CrossType.Pure)
     .in(file("airspec-core"))
     .settings(buildSettings)
@@ -259,10 +274,15 @@ lazy val airspecCore =
         .filter(x => x._2 != "JS_DEPENDENCIES"),
       Compile / packageSrc / mappings ++= (airspecLog.js / Compile / packageSrc / mappings).value
     )
+    .nativeSettings(
+      airspecNativeBuildSettings,
+      Compile / packageBin / mappings ++= (airspecLog.native / Compile / packageBin / mappings).value,
+      Compile / packageSrc / mappings ++= (airspecLog.native / Compile / packageSrc / mappings).value
+    )
     .dependsOn(airspecLog)
 
 lazy val airspecDeps =
-  crossProject(JSPlatform, JVMPlatform)
+  crossProject(JSPlatform, JVMPlatform, NativePlatform)
     .crossType(CrossType.Pure)
     .in(file("airspec-deps"))
     .settings(buildSettings)
@@ -291,10 +311,15 @@ lazy val airspecDeps =
         "org.scala-js" %%% "scala-js-macrotask-executor" % "1.1.1"
       )
     )
+    .nativeSettings(
+      airspecNativeBuildSettings,
+      Compile / packageBin / mappings ++= (airspecCore.native / Compile / packageBin / mappings).value,
+      Compile / packageSrc / mappings ++= (airspecCore.native / Compile / packageSrc / mappings).value
+    )
     .dependsOn(airspecCore)
 
 lazy val airspec =
-  crossProject(JSPlatform, JVMPlatform)
+  crossProject(JSPlatform, JVMPlatform, NativePlatform)
     .crossType(CrossType.Pure)
     .in(file("."))
     .settings(buildSettings)
@@ -336,6 +361,14 @@ lazy val airspec =
         ("org.portable-scala" %%% "portable-scala-reflect" % "1.1.2").cross(CrossVersion.for3Use2_13),
         // Needed to be explicitly included here for running Scala.js tests successfully
         "org.scala-js" %%% "scala-js-macrotask-executor" % "1.1.1"
+      )
+    )
+    .nativeSettings(
+      // Embed dependent project codes to make airspec a single jar
+      Compile / packageBin / mappings ++= (airspecDeps.native / Compile / packageBin / mappings).value,
+      Compile / packageSrc / mappings ++= (airspecDeps.native / Compile / packageSrc / mappings).value,
+      libraryDependencies ++= Seq(
+        "org.scala-sbt" % "test-interface" % "1.0"
       )
     )
     // This should be Optional dependency, but using Provided dependency for bloop which doesn't support Optional.

--- a/airspec/project/plugin.sbt
+++ b/airspec/project/plugin.sbt
@@ -19,7 +19,7 @@ libraryDependencies ++= (
 
 // For Scala native
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
-addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.4.16")
+addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.5.1")
 
 // For setting explicit versions for each commit
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.0.1")

--- a/airspec/project/plugin.sbt
+++ b/airspec/project/plugin.sbt
@@ -17,6 +17,10 @@ libraryDependencies ++= (
   Seq("org.scala-js" %% "scalajs-env-jsdom-nodejs" % "1.1.0")
 )
 
+// For Scala native
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
+addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.4.16")
+
 // For setting explicit versions for each commit
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.0.1")
 

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -30,6 +30,10 @@ libraryDependencies ++= (
 // For Scala.js + Playwright test
 libraryDependencies += "io.github.gmkumar2005" %% "scala-js-env-playwright" % "0.1.12"
 
+// For Scala native
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
+addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.4.16")
+
 // For setting explicit versions for each commit
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.0.1")
 


### PR DESCRIPTION
To support Scala Native, airspec needs to support Scala Native as airspec is used for testing airframe modules.

- Target only for Scala 3 for reducing the maintenance overhead
- Compilation passed, but need to check why no test class is found 

Challenges:
- No java.util.logging, which is necessary for airframe-log
- No java.util.concurrent.Executor 