### PR TITLE
surface (fix): Fixed a bug in getting a surface of inner opaque type

### DIFF
--- a/airframe-surface/src/test/scala-3/wvlet/airframe/surface/Scala3NewTypeTest.scala
+++ b/airframe-surface/src/test/scala-3/wvlet/airframe/surface/Scala3NewTypeTest.scala
@@ -70,3 +70,10 @@ object Scala3NewTypeTest extends AirSpec:
     m shouldBe defined
     m.get.args(0).surface.name shouldBe "MyEnv"
   }
+
+  object O:
+    opaque type InnerOpaque = Double
+
+  test("Opaque types from inner object") {
+    val s = Surface.of[O.InnerOpaque]
+  }


### PR DESCRIPTION
The PR contains a failing test demonstrating issue. Following code fails:

```scala
  object O:
    opaque type InnerOpaque = Double

  test("Opaque types from inner object") {
    val s = Surface.of[O.InnerOpaque]
  }
```

The error is:

> java.util.NoSuchElementException: key not found: wvlet.airframe.surface.Scala3NewTypeTest.O.InnerOpaque

I will try to create a fix.