### PR TITLE
surface: Simplify extractSymbol - avoid .tree to make library working with Scala 3.4.2

### DIFF
--- a/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
+++ b/airframe-surface/src/main/scala-3/wvlet/airframe/surface/CompileTimeSurfaceFactory.scala
@@ -173,14 +173,22 @@ private[surface] class CompileTimeSurfaceFactory[Q <: Quotes](using quotes: Q):
 
   private def extractSymbol(t: TypeRepr) =
     val dealiased = t.dealias
-    if t != dealiased then surfaceOf(dealiased)
+
+    println(s"dealiased ${dealiased.show} of ${t.show}")
+    println(s"  maybeOwner.declarations ${t.typeSymbol.maybeOwner.declarations.map(_.name).mkString(",")}")
+
+    if t != dealiased then
+      println(s"dealiased as ${dealiased.show}")
+      surfaceOf(dealiased)
     else
       // t.dealias does not dealias for path dependent types, so try to find a matching inner type
       val symbolInOwner = t.typeSymbol.maybeOwner.declarations.find(_.name.toString == t.typeSymbol.name.toString)
       symbolInOwner match
         case Some(sym) =>
+          println(s"Match 1 $sym in $symbolInOwner as ${sym.typeRef.show} -> ${sym.typeRef.dealias.show}")
           surfaceOf(sym.typeRef.dealias)
         case _ =>
+          println(s"Match 2 $symbolInOwner as ${t.simplified.show}")
           surfaceOf(t.simplified)
 
   private def aliasFactory: Factory = {

--- a/airframe-surface/src/test/scala/wvlet/airframe/surface/PathDependentTypeTest.scala
+++ b/airframe-surface/src/test/scala/wvlet/airframe/surface/PathDependentTypeTest.scala
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.surface
+
+import wvlet.airspec.AirSpec
+
+// extracted from wvlet.airframe.di.PathDependentTypeTest
+
+class PathDependentTypeTest extends AirSpec {
+  test("pass dependent types") {
+    import PathDependentType.*
+    val s = Surface.of[MyProfile#Backend#Database]
+    assert(s.name == "Database")
+    assert(s.toString == "Database:=DatabaseDef")
+  }
+}
+
+object PathDependentType {
+  object MyBackend extends MyBackend
+
+  class MyService(val p: MyProfile#Backend#Database)
+
+  trait MyProfile {
+    type Backend = MyBackend
+  }
+
+  trait MyBackend {
+    type Database = DatabaseDef
+    class DatabaseDef {
+      def hello = "hello my"
+    }
+  }
+}


### PR DESCRIPTION
Followup to #3521

The method `extractSymbol` used to dealias inner types for both opaque types and type aliases does not work when the library is used from Scala 3.4.2 application. The reason is infamous `.tree` method again, which is known and documented to be unreliable.

I am not sure why it was used, the code seems simpler without it, but maybe I am missing something. After the simplification all tests still pass.
