### PR TITLE
http (fix, breaking): RPCContext.current.getThreadLocal interface change to avoid unsafe type cast

### DIFF
--- a/airframe-http-finagle/src/main/scala/wvlet/airframe/http/finagle/FinagleRPCContext.scala
+++ b/airframe-http-finagle/src/main/scala/wvlet/airframe/http/finagle/FinagleRPCContext.scala
@@ -24,8 +24,12 @@ case class FinagleRPCContext(request: Request) extends RPCContext {
     FinagleBackend.setThreadLocal(key, value)
   }
 
-  override def getThreadLocal[A](key: String): Option[A] = {
+  override def getThreadLocal(key: String): Option[Any] = {
     FinagleBackend.getThreadLocal(key)
+  }
+
+  override def getThreadLocalUnsafe[A](key: String): Option[A] = {
+    getThreadLocal(key).map(_.asInstanceOf[A])
   }
 
   override def httpRequest: HttpMessage.Request = {

--- a/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/ThreadLocalStorageTest.scala
+++ b/airframe-http-finagle/src/test/scala/wvlet/airframe/http/finagle/ThreadLocalStorageTest.scala
@@ -40,7 +40,7 @@ class ThreadLocalStorageTest extends AirSpec {
 
     @Endpoint(path = "/rpc-context")
     def rpcContext: String = {
-      RPCContext.current.getThreadLocal[String]("client_id").getOrElse("unknown")
+      RPCContext.current.getThreadLocal("client_id").map(_.toString).getOrElse("unknown")
     }
 
     @Endpoint(path = "/rpc-header")

--- a/airframe-http-grpc/src/main/scala/wvlet/airframe/http/grpc/GrpcContext.scala
+++ b/airframe-http-grpc/src/main/scala/wvlet/airframe/http/grpc/GrpcContext.scala
@@ -82,8 +82,8 @@ case class GrpcContext(
     storage.put(key, value)
   }
 
-  override def getThreadLocal[A](key: String): Option[A] = {
-    storage.get(key).asInstanceOf[Option[A]]
+  override def getThreadLocal(key: String): Option[Any] = {
+    storage.get(key)
   }
 
   override def httpRequest: HttpMessage.Request = {

--- a/airframe-http-grpc/src/test/scala/wvlet/airframe/http/grpc/example/DemoApi.scala
+++ b/airframe-http-grpc/src/test/scala/wvlet/airframe/http/grpc/example/DemoApi.scala
@@ -47,7 +47,7 @@ trait DemoApi extends LogSupport {
 
   def getRPCContext: Option[String] = {
     val ctx = RPCContext.current
-    ctx.getThreadLocal[String]("client_id")
+    ctx.getThreadLocal("client_id").map(_.toString)
   }
 
   def getRequest: Request = {

--- a/airframe-http-netty/src/main/scala/wvlet/airframe/http/netty/NettyBackend.scala
+++ b/airframe-http-netty/src/main/scala/wvlet/airframe/http/netty/NettyBackend.scala
@@ -15,6 +15,7 @@ package wvlet.airframe.http.netty
 
 import wvlet.airframe.http.HttpMessage.{Request, Response}
 import wvlet.airframe.http.*
+import wvlet.airframe.http.internal.TLSSupport
 import wvlet.airframe.rx.Rx
 import wvlet.log.LogSupport
 
@@ -22,7 +23,7 @@ import scala.collection.mutable
 import scala.concurrent.{Await, ExecutionContext, Future, Promise}
 import scala.util.{Failure, Success}
 
-object NettyBackend extends HttpBackend[Request, Response, Rx] with TLS with LogSupport { self =>
+object NettyBackend extends HttpBackend[Request, Response, Rx] with TLSSupport with LogSupport { self =>
   private val rxBackend = new RxNettyBackend
 
   override protected implicit val httpRequestAdapter: HttpRequestAdapter[Request] =

--- a/airframe-http-netty/src/main/scala/wvlet/airframe/http/netty/NettyBackend.scala
+++ b/airframe-http-netty/src/main/scala/wvlet/airframe/http/netty/NettyBackend.scala
@@ -22,7 +22,7 @@ import scala.collection.mutable
 import scala.concurrent.{Await, ExecutionContext, Future, Promise}
 import scala.util.{Failure, Success}
 
-object NettyBackend extends HttpBackend[Request, Response, Rx] with LogSupport { self =>
+object NettyBackend extends HttpBackend[Request, Response, Rx] with TLS with LogSupport { self =>
   private val rxBackend = new RxNettyBackend
 
   override protected implicit val httpRequestAdapter: HttpRequestAdapter[Request] =
@@ -89,21 +89,16 @@ object NettyBackend extends HttpBackend[Request, Response, Rx] with LogSupport {
     f.toRx.map(body)
   }
 
-  private lazy val tls =
-    ThreadLocal.withInitial[collection.mutable.Map[String, Any]](() => mutable.Map.empty[String, Any])
-
-  private def storage: collection.mutable.Map[String, Any] = tls.get()
-
   override def withThreadLocalStore(request: => Rx[Response]): Rx[Response] = {
     //
     request
   }
 
   override def setThreadLocal[A](key: String, value: A): Unit = {
-    storage.put(key, value)
+    setTLS(key, value)
   }
 
   override def getThreadLocal[A](key: String): Option[A] = {
-    storage.get(key).asInstanceOf[Option[A]]
+    getTLS(key).map(_.asInstanceOf[A])
   }
 }

--- a/airframe-http-netty/src/test/scala/wvlet/airframe/http/netty/NettyBackendTest.scala
+++ b/airframe-http-netty/src/test/scala/wvlet/airframe/http/netty/NettyBackendTest.scala
@@ -22,25 +22,25 @@ class NettyBackendTest extends AirSpec {
     val key = ULID.newULIDString
 
     test("must be None by default") {
-      NettyBackend.getThreadLocal[Int](key) shouldBe None
+      NettyBackend.getThreadLocal(key) shouldBe None
     }
 
     test("store different content for each thread") {
-      NettyBackend.setThreadLocal[Int](key, 123)
+      NettyBackend.setThreadLocal(key, 123)
 
       var valueInThread: Option[Int] = None
 
       val t = new Thread {
         override def run(): Unit = {
-          NettyBackend.getThreadLocal[Int](key) shouldBe None
-          NettyBackend.setThreadLocal[Int](key, 456)
-          valueInThread = NettyBackend.getThreadLocal[Int](key)
+          NettyBackend.getThreadLocal(key) shouldBe None
+          NettyBackend.setThreadLocal(key, 456)
+          valueInThread = NettyBackend.getThreadLocal(key)
         }
       }
       t.start()
       t.join()
 
-      NettyBackend.getThreadLocal[Int](key) shouldBe Some(123)
+      NettyBackend.getThreadLocal(key) shouldBe Some(123)
       valueInThread shouldBe Some(456)
     }
   }

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/Compat.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/Compat.scala
@@ -23,10 +23,7 @@ import scala.concurrent.ExecutionContext
 
 /**
   */
-object 
-
-
-Compat extends CompatApi {
+object Compat extends CompatApi {
   override def urlEncode(s: String): String = {
     URLEncoder.encode(s, "UTF-8")
   }
@@ -65,7 +62,7 @@ Compat extends CompatApi {
     // There is no notion of host server in JVM
     ServerAddress.empty
   }
-  
+
   override def currentRPCContext: RPCContext                     = LocalRPCContext.current
   override def attachRPCContext(context: RPCContext): RPCContext = LocalRPCContext.attach(context)
   override def detachRPCContext(previous: RPCContext): Unit      = LocalRPCContext.detach(previous)

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/Compat.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/Compat.scala
@@ -23,7 +23,10 @@ import scala.concurrent.ExecutionContext
 
 /**
   */
-object Compat extends CompatApi {
+object 
+
+
+Compat extends CompatApi {
   override def urlEncode(s: String): String = {
     URLEncoder.encode(s, "UTF-8")
   }
@@ -62,7 +65,7 @@ object Compat extends CompatApi {
     // There is no notion of host server in JVM
     ServerAddress.empty
   }
-
+  
   override def currentRPCContext: RPCContext                     = LocalRPCContext.current
   override def attachRPCContext(context: RPCContext): RPCContext = LocalRPCContext.attach(context)
   override def detachRPCContext(previous: RPCContext): Unit      = LocalRPCContext.detach(previous)

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/internal/LocalRPCContext.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/internal/LocalRPCContext.scala
@@ -32,7 +32,7 @@ object LocalRPCContext {
     prev
   }
   def detach(previousContext: RPCContext): Unit = {
-    if (previousContext eq rootContext) {
+    if (previousContext != rootContext) {
       localContext.set(previousContext)
     } else {
       // Avoid preserving the root thread information in the TLS

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/internal/LocalRPCContext.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/internal/LocalRPCContext.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.airframe.http.internal
 
-import wvlet.airframe.http.{RPCContext, EmptyRPCContext}
+import wvlet.airframe.http.{EmptyRPCContext, RPCContext}
 
 object LocalRPCContext {
   private val localContext = new ThreadLocal[RPCContext]()
@@ -32,7 +32,7 @@ object LocalRPCContext {
     prev
   }
   def detach(previousContext: RPCContext): Unit = {
-    if (previousContext != rootContext) {
+    if (previousContext eq rootContext) {
       localContext.set(previousContext)
     } else {
       // Avoid preserving the root thread information in the TLS

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/internal/TLSSupport.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/internal/TLSSupport.scala
@@ -11,15 +11,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.airframe.http.netty
-
-import wvlet.airframe.http.HttpMessage.Request
-import wvlet.airframe.http.RPCContext
-import wvlet.airframe.http.internal.TLSSupport
+package wvlet.airframe.http.internal
 
 import scala.collection.mutable
 
-class NettyRPCContext(val httpRequest: Request) extends RPCContext with TLSSupport {
-  override def setThreadLocal[A](key: String, value: A): Unit = setTLS(key, value)
-  override def getThreadLocal(key: String): Option[Any]       = getTLS(key)
+/**
+  * Thread-local storage support
+  */
+private[http] trait TLSSupport {
+  private lazy val tls = ThreadLocal.withInitial[mutable.Map[String, Any]](() => mutable.Map.empty[String, Any])
+  private def tlsStorage(): mutable.Map[String, Any] = tls.get()
+
+  def setTLS(key: String, value: Any): Unit = tlsStorage().put(key, value)
+  def getTLS(key: String): Option[Any]      = tlsStorage().get(key)
 }

--- a/airframe-http/src/main/scala/wvlet/airframe/http/RPCContext.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/RPCContext.scala
@@ -58,7 +58,7 @@ trait RPCContext {
     * @return
     */
   @deprecated("Use getThreadLocal(key: String): Any instead", "24.5.0")
-  def getThreadLocaUnsafe[A](key: String): Option[A] = {
+  def getThreadLocalUnsafe[A](key: String): Option[A] = {
     getThreadLocal(key).map(_.asInstanceOf[A])
   }
 

--- a/airframe-http/src/main/scala/wvlet/airframe/http/RPCContext.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/RPCContext.scala
@@ -37,7 +37,10 @@ trait RPCContext {
   def httpRequest: HttpMessage.Request
 
   def rpcCallContext: Option[RPCCallContext] = {
-    getThreadLocal[RPCCallContext](HttpBackend.TLS_KEY_RPC)
+    getThreadLocal(HttpBackend.TLS_KEY_RPC) match {
+      case Some(c: RPCCallContext) => Some(c)
+      case _                       => None
+    }
   }
 
   /**
@@ -52,10 +55,19 @@ trait RPCContext {
     * Get a thread-local variable that is available only within the request scope. The type must be specified
     * explicitly.
     * @param key
-    * @tparam A
     * @return
     */
-  def getThreadLocal[A](key: String): Option[A]
+  @deprecated("Use getThreadLocal(key: String): Any instead", "24.5.0")
+  def getThreadLocaUnsafe[A](key: String): Option[A] = {
+    getThreadLocal(key).map(_.asInstanceOf[A])
+  }
+
+  /**
+    * Get a thread-local variable that is available only within the request scope.
+    * @param key
+    * @return
+    */
+  def getThreadLocal(key: String): Option[Any]
 }
 
 /**
@@ -65,7 +77,7 @@ object EmptyRPCContext extends RPCContext {
   override def setThreadLocal[A](key: String, value: A): Unit = {
     // no-op
   }
-  override def getThreadLocal[A](key: String): Option[A] = {
+  override def getThreadLocal(key: String): Option[Any] = {
     // no-op
     None
   }

--- a/docs/airframe-http.md
+++ b/docs/airframe-http.md
@@ -150,14 +150,14 @@ val server = Netty.server
     // Add a custom log entry
     m += "application_version" -> "1.0"
     // Add a thread-local parameter to the log
-    RPCContext.current.getThreadLocal[String]("user_id").map { uid =>
+    RPCContext.current.getThreadLocal("user_id").map { uid =>
       m += "user_id" -> uid
     }
     m.result
   }
   // [optional] Disable server-side logging (log/http_server.json)
   .noLogging
-  // Add a custom MessageCodec mapping
+  // [optional] Add a custom MessageCodec mapping
   .withCustomCodec{ case s: Surface.of[MyClass] => ... }
 
 server.start { server =>
@@ -372,7 +372,7 @@ object AuthLogFilter extends RxHttpFilter with LogSupport {
   def apply(request: Request, next: RxHttpEndpoint): Rx[Response] = {
     next(request).map { response =>
       // Read the thread-local parameter set in the context(request)
-      RPCContext.current.getThreadLocal[String]("user_id").map { uid =>
+      RPCContext.current.getThreadLocal("user_id").map { uid =>
         info(s"user_id: ${uid}")
       }
       response

--- a/docs/airframe-rpc.md
+++ b/docs/airframe-rpc.md
@@ -447,7 +447,7 @@ String "100" will be translated into an Int value `100` automatically.
 
 ### RPCContext
 
-Since Airframe 22.8.0, airframe-rpc introduced `RPCContext` for reading and writing the thread-local storage, and referencing the original HTTP request: 
+Since Airframe 22.8.0, airframe-rpc introduced `RPCContext.current` for reading and writing the thread-local storage, and referencing the original HTTP request: 
 
 ```scala
 import wvlet.airframe.http._
@@ -456,7 +456,7 @@ import wvlet.airframe.http._
 trait MyAPI {
   def hello: String = {
     // Read the thread-local storage
-    val userName = RPCContext.current.getThreadLocal[String]("context_user")
+    val userName = RPCContext.current.getThreadLocal("context_user")
     s"Hello ${userName}"
   } 
   


### PR DESCRIPTION
- Breaking change: `RPCContext.current.getThreadLocal[A](key: String): A`  -> `RPCContext.current.getThreadLocal(key: String): Any` to avoid type cast error
- Also, fixed a bug of getting the previous thread-local values
