### PR TITLE
airspec (fix): Enable -l,-L loglevel options in forked JVM tests

### DIFF
--- a/airspec/build.sbt
+++ b/airspec/build.sbt
@@ -130,7 +130,8 @@ def excludePomDependency(excludes: Seq[String]) = { node: XmlNode =>
   }).transform(node).head
 }
 
-/** AirSpec build definitions.
+/**
+  * AirSpec build definitions.
   *
   * To make AirSpec a standalone library without any cyclic project references, AirSpec embeds the source code of
   * airframe-log, di, surface, etc.
@@ -167,6 +168,7 @@ val airspecBuildSettings = Seq[Setting[?]](
 )
 
 val airspecJVMBuildSettings = Seq[Setting[?]](
+  Test / fork := true,
   Compile / unmanagedSourceDirectories ++= {
     val baseDir = (ThisBuild / baseDirectory).value.getAbsoluteFile
     val sv      = scalaBinaryVersion.value

--- a/airspec/src/main/scala/wvlet/airspec/AirSpecLauncher.scala
+++ b/airspec/src/main/scala/wvlet/airspec/AirSpecLauncher.scala
@@ -16,7 +16,7 @@ package wvlet.airspec
 import sbt.testing.*
 import wvlet.airspec.runner.AirSpecSbtRunner.AirSpecConfig
 import wvlet.airspec.runner.{AirSpecEventHandler, AirSpecLogger, AirSpecTaskRunner}
-import wvlet.log.LogSupport
+import wvlet.log.{LogSupport, LogLevel}
 
 import scala.concurrent.Future
 

--- a/airspec/src/main/scala/wvlet/airspec/runner/AirSpecTaskRunner.scala
+++ b/airspec/src/main/scala/wvlet/airspec/runner/AirSpecTaskRunner.scala
@@ -90,6 +90,7 @@ private[airspec] class AirSpecTaskRunner(
     val startTimeNanos = System.nanoTime()
     val prevLogLevel   = Map.newBuilder[String, LogLevel]
     prevLogLevel += testClassName -> Logger(testClassName).getLogLevel
+
     Future
       .apply {
         // Set the default log level for the class


### PR DESCRIPTION
Fixes #3523 