### PR TITLE
airspec (deprecated): Require a space in -L (pattern)=(loglevel) option

### DIFF
--- a/docs/airspec.md
+++ b/docs/airspec.md
@@ -173,7 +173,7 @@ $ sbt
 
 # Configure log levels of airframe-log
 > testOnly -- -l (level)                 # Set the log level for the test target classes
-> testOnly -- -L(package)=(level)        # Set log level for a specific package or class
+> testOnly -- -L (package)=(level)       # Set log level for a specific package or class
 
 # sbt's default test functionalities:
 > testQuick                              # Run only previously failed test specs
@@ -257,17 +257,17 @@ AirSpec natively supports [airframe-log](https://wvlet.org/airframe/docs/airfram
 This will set the log level to debug for all test classes.
 
 
-To change the log level only for a specific package or a class, use `-L(package or class)=(log level)` option:
+To change the log level only for a specific package or a class, use `-L (package or class)=(log level)` option:
 
 ```scala
-> testOnly -- -Lorg.mydomain.myapp=debug
+> testOnly -- -L org.mydomain.myapp=debug
 ```
 You can use multiple `-L` options to set different log levels for multiple packages.
 
 You can also use wildcard `*` with `-L` option for the ease of setting log levels for specific classes:
 ```scala
-> testOnly -- -Lmyapp.*=debug
-> testOnly -- -L*.MyClass=debug
+> testOnly -- -L myapp.*=debug
+> testOnly -- -L *.MyClass=debug
 ```
 
 ### Configure Log Levels in log-test.properties


### PR DESCRIPTION
Closes #3617
