### PR TITLE
Upgrade logback-core to 1.5.8

### DIFF
--- a/airframe-log/.jvm/src/main/scala/wvlet/log/LogRotationHandler.scala
+++ b/airframe-log/.jvm/src/main/scala/wvlet/log/LogRotationHandler.scala
@@ -17,10 +17,13 @@ import java.io.{File, Flushable}
 import java.nio.charset.StandardCharsets
 import java.util.logging.ErrorManager
 import java.util.{logging => jl}
-
 import ch.qos.logback.core.ContextBase
 import ch.qos.logback.core.encoder.EncoderBase
-import ch.qos.logback.core.rolling.{RollingFileAppender, SizeAndTimeBasedFNATP, TimeBasedRollingPolicy}
+import ch.qos.logback.core.rolling.{
+  RollingFileAppender,
+  SizeAndTimeBasedFileNamingAndTriggeringPolicy,
+  TimeBasedRollingPolicy
+}
 import ch.qos.logback.core.util.FileSize
 import wvlet.log.LogFormatter.AppLogFormatter
 
@@ -78,7 +81,7 @@ class LogRotationHandler(
 
     val fileAppender     = new RollingFileAppender[String]()
     val rollingPolicy    = new TimeBasedRollingPolicy[String]
-    val triggeringPolicy = new SizeAndTimeBasedFNATP[String]
+    val triggeringPolicy = new SizeAndTimeBasedFileNamingAndTriggeringPolicy[String]
 
     rollingPolicy.setContext(context)
     val fileNameStem =

--- a/airspec/build.sbt
+++ b/airspec/build.sbt
@@ -228,7 +228,7 @@ lazy val airspecLog =
       airspecJVMBuildSettings,
       libraryDependencies ++= Seq(
         // For rotating log files
-        "ch.qos.logback" % "logback-core" % "1.3.14"
+        "ch.qos.logback" % "logback-core" % "1.5.8"
       )
     )
     .jsSettings(

--- a/build.sbt
+++ b/build.sbt
@@ -600,7 +600,7 @@ val logDependencies = { scalaVersion: String =>
 
 val logJVMDependencies = Seq(
   // For rotating log files
-  "ch.qos.logback" % "logback-core" % "1.3.14"
+  "ch.qos.logback" % "logback-core" % "1.5.8"
 )
 
 // airframe-log should have minimum dependencies


### PR DESCRIPTION
SizeAndTimeBasedFNATP of logback-core was deprecated 8 years ago.  This fix will remove its usage https://github.com/qos-ch/logback/blame/42caff87ae6eb553dcbf77e25ba87a9d340357ee/logback-core/src/main/java/ch/qos/logback/core/CoreConstants.java#L240 