### PR TITLE
http (fix): Fix a bug in HttpMultiMap.add() when more than 3 values are added with the same key

### DIFF
--- a/airframe-http/src/main/scala/wvlet/airframe/http/HttpMultiMap.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/HttpMultiMap.scala
@@ -105,7 +105,7 @@ case class HttpMultiMap(private val underlying: Map[String, Any] = Map.empty) {
         .map { entry =>
           val newValue = entry._2 match {
             case s: String                   => Seq(s, value)
-            case lst: Seq[String @unchecked] => lst +: value
+            case lst: Seq[String @unchecked] => lst :+ value
           }
           // Use the already existing key for avoid case-insensitive key duplication
           underlying + (entry._1 -> newValue)


### PR DESCRIPTION
```scala
val m = HttpMultiMap.empty
  .add("key", "value1")
  .add("key", "value2")
  .add("key", "value3")

println(m.getAll("key")) // Vector(List(value1, value2), v, a, l, u, e, 3)
```