### PR TITLE
rx-html (breaking): RxElement.onMount(...) requires a node argument

### DIFF
--- a/airframe-log/src/main/scala/wvlet/log/Logger.scala
+++ b/airframe-log/src/main/scala/wvlet/log/Logger.scala
@@ -268,7 +268,7 @@ object Logger {
       }.foreach { level =>
         l.setLogLevel(level)
       }
-    l
+    ()
   }
 
   def getDefaultLogLevel: LogLevel = rootLogger.getLogLevel

--- a/airframe-rx-html/.js/src/main/scala/wvlet/airframe/rx/html/DOMRenderer.scala
+++ b/airframe-rx-html/.js/src/main/scala/wvlet/airframe/rx/html/DOMRenderer.scala
@@ -188,7 +188,7 @@ object DOMRenderer extends LogSupport {
               val c1   = renderToInternal(localContext, node, r)
               val elem = node.lastChild
               val c2   = rx.traverseModifiers(m => renderToInternal(localContext, elem, m))
-              if (rx.onMount ne RxElement.NoOp) {
+              if ((rx.onMount _) ne RxElement.NoOp) {
                 val observer: MutationObserver = new MutationObserver({ (mut, obs) =>
                   mut.foreach { m =>
                     m.addedNodes.find(_ eq elem).foreach { n =>

--- a/airframe-rx-html/.js/src/test/scala/wvlet/airframe/http/rx/html/RxOnMountTest.scala
+++ b/airframe-rx-html/.js/src/test/scala/wvlet/airframe/http/rx/html/RxOnMountTest.scala
@@ -43,7 +43,7 @@ class RxOnMountTest extends AirSpec {
         a += 1
       }
 
-      override def onMount(n: dom.Node) = {
+      override def onMount(n: Any) = {
         afterRenderCount += 1
       }
 
@@ -91,7 +91,7 @@ class RxOnMountTest extends AirSpec {
         a1 = true
       }
 
-      override def onMount(n: dom.Node) = {
+      override def onMount(n: Any) = {
         debug("afterMount: nested")
         afterRenderFlag = true
         rendered := true
@@ -111,7 +111,7 @@ class RxOnMountTest extends AirSpec {
         a = true
       }
 
-      override def onMount(n: dom.Node) = {
+      override def onMount(n: Any) = {
         debug(s"afterMount: r")
         afterRenderFlag1 = true
       }

--- a/airframe-rx-html/.js/src/test/scala/wvlet/airframe/http/rx/html/RxOnMountTest.scala
+++ b/airframe-rx-html/.js/src/test/scala/wvlet/airframe/http/rx/html/RxOnMountTest.scala
@@ -1,0 +1,144 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.http.rx.html
+
+import org.scalajs.dom
+import org.scalajs.dom.HTMLElement
+import wvlet.airframe.rx.{Cancelable, Rx}
+import wvlet.airframe.rx.html.{DOMRenderer, RxElement}
+import wvlet.airframe.rx.html.all.*
+import wvlet.airspec.AirSpec
+
+class RxOnMountTest extends AirSpec {
+
+  private def render(v: Any): (HTMLElement, Cancelable) = {
+    val (n, c) = v match {
+      case rx: Rx[RxElement] @unchecked =>
+        DOMRenderer.createNode(div(rx))
+      case other: RxElement =>
+        DOMRenderer.createNode(other)
+    }
+    (n.asInstanceOf[HTMLElement], c)
+  }
+
+  test("beforeRender/beforeUnmount") {
+    var a                = 0
+    var b                = 0
+    var afterRenderCount = 0
+
+    val v = Rx.variable(1)
+    val r = new RxElement {
+      override def beforeRender: Unit = {
+        a += 1
+      }
+
+      override def onMount(n: dom.Node) = {
+        afterRenderCount += 1
+      }
+
+      override def beforeUnmount: Unit = {
+        b += 1
+        afterRenderCount shouldBe 1
+      }
+
+      override def render: RxElement = span(v.map { x => s"hello ${x}" })
+    }
+
+    a shouldBe 0
+    afterRenderCount shouldBe 0
+    val (n, c) = render(r)
+    n.outerHTML shouldBe "<span>hello 1</span>"
+    a shouldBe 1
+    b shouldBe 0
+
+    // Updating inner element should not trigger on render
+    v := 2
+    a shouldBe 1
+    afterRenderCount shouldBe 1
+    b shouldBe 0
+    n.outerHTML shouldBe "<span>hello 2</span>"
+
+    // unmounting
+    c.cancel
+    a shouldBe 1
+    b shouldBe 1
+  }
+
+  test("nested beforeRender/beforeUnmount") {
+    var a               = false
+    var b               = false
+    var afterRenderFlag = false
+
+    var a1               = false
+    var b1               = false
+    var afterRenderFlag1 = false
+
+    var rendered = Rx.variable(false)
+
+    val nested = new RxElement {
+      override def beforeRender: Unit = {
+        a1 = true
+      }
+
+      override def onMount(n: dom.Node) = {
+        debug("afterMount: nested")
+        afterRenderFlag = true
+        rendered := true
+        rendered.stop()
+      }
+
+      override def beforeUnmount: Unit = {
+        debug(s"beforeUnmount: nested")
+        b1 = true
+      }
+
+      override def render: RxElement = span("initial")
+    }
+
+    val r = new RxElement {
+      override def beforeRender: Unit = {
+        a = true
+      }
+
+      override def onMount(n: dom.Node) = {
+        debug(s"afterMount: r")
+        afterRenderFlag1 = true
+      }
+
+      override def beforeUnmount: Unit = {
+        debug(s"beforeUnmount: r")
+        b = true
+      }
+
+      override def render: RxElement = span(nested)
+    }
+
+    afterRenderFlag shouldBe false
+    afterRenderFlag1 shouldBe false
+    val (n, c) = render(r)
+
+    rendered.lastOption.map { isFullyRendered =>
+      isFullyRendered shouldBe true
+      afterRenderFlag shouldBe true
+      afterRenderFlag1 shouldBe true
+      a shouldBe true
+      b shouldBe false
+      a1 shouldBe true
+      b1 shouldBe false
+      c.cancel
+      b shouldBe true
+      b1 shouldBe true
+    }
+  }
+}

--- a/airframe-rx-html/.js/src/test/scala/wvlet/airframe/http/rx/html/RxRenderingTest.scala
+++ b/airframe-rx-html/.js/src/test/scala/wvlet/airframe/http/rx/html/RxRenderingTest.scala
@@ -79,7 +79,7 @@ object RxRenderingTest extends AirSpec {
         a += 1
       }
 
-      override def onMount(node: dom.Node): Unit = {
+      override def onMount(node: Any): Unit = {
         afterRenderCount += 1
       }
       override def beforeUnmount: Unit = {
@@ -121,7 +121,7 @@ object RxRenderingTest extends AirSpec {
         a += 1
       }
 
-      override def onMount(n: dom.Node): Unit = {
+      override def onMount(n: Any): Unit = {
         afterRenderCount += 1
       }
       override def beforeUnmount: Unit = {
@@ -230,7 +230,7 @@ object RxRenderingTest extends AirSpec {
     def findSpan000 = Option(document.getElementById("span000"))
 
     val label = new RxElement() {
-      override def onMount(n: dom.Node): Unit = {
+      override def onMount(n: Any): Unit = {
         logger.debug(s"onRender span: ${findSpan000}")
         findSpan000.foreach { e =>
           e.setAttribute("class", "active")
@@ -245,7 +245,7 @@ object RxRenderingTest extends AirSpec {
     }
 
     val main = new RxElement {
-      override def onMount(n: dom.Node): Unit = {
+      override def onMount(n: Any): Unit = {
         logger.debug("onRender main")
       }
 
@@ -271,7 +271,7 @@ object RxRenderingTest extends AirSpec {
     val foundElement             = Rx.variable(false)
 
     object infoPage extends RxElement {
-      override def onMount(n: dom.Node): Unit = {
+      override def onMount(n: Any): Unit = {
         nestedOnMountCallCount += 1
         Option(org.scalajs.dom.document.getElementById("id001")).collect { case e: HTMLElement =>
           foundElement := true
@@ -282,7 +282,7 @@ object RxRenderingTest extends AirSpec {
     }
 
     object nestedPage extends RxElement() {
-      override def onMount(n: dom.Node): Unit = {
+      override def onMount(n: Any): Unit = {
         topLevelOnMountCallCount += 1
       }
 

--- a/airframe-rx-html/src/main/scala/wvlet/airframe/rx/html/RxElement.scala
+++ b/airframe-rx-html/src/main/scala/wvlet/airframe/rx/html/RxElement.scala
@@ -16,6 +16,7 @@ package wvlet.airframe.rx.html
 import wvlet.airframe.rx.{Cancelable, Rx}
 import wvlet.log.LogSupport
 import wvlet.airframe.rx.html.RxEmbedding.*
+import org.scalajs.dom
 
 /**
   */
@@ -38,7 +39,7 @@ abstract class RxElement(val modifiers: List[Seq[HtmlNode]] = List.empty) extend
     * Called right after mounting this RxElement to the document. Override this method to define a custom event hook
     * after rendering.
     */
-  def onMount: Unit = {}
+  def onMount(node: dom.Node): Unit = RxElement.NoOp
 
   /**
     * Called right before unmounting (deleting) this RxElement from DOM.
@@ -88,6 +89,9 @@ object RxElement {
     new RxElement() {
       override def render: RxElement = LazyRxElement(() => a)
     }
+
+  private[html] val NoOp = { (n: dom.Node) => () }
+
 }
 
 case class LazyRxElement[A: EmbeddableNode](v: () => A) extends RxElement() with LogSupport {

--- a/airframe-rx-html/src/main/scala/wvlet/airframe/rx/html/RxElement.scala
+++ b/airframe-rx-html/src/main/scala/wvlet/airframe/rx/html/RxElement.scala
@@ -16,7 +16,6 @@ package wvlet.airframe.rx.html
 import wvlet.airframe.rx.{Cancelable, Rx}
 import wvlet.log.LogSupport
 import wvlet.airframe.rx.html.RxEmbedding.*
-import org.scalajs.dom
 
 /**
   */
@@ -39,7 +38,7 @@ abstract class RxElement(val modifiers: List[Seq[HtmlNode]] = List.empty) extend
     * Called right after mounting this RxElement to the document. Override this method to define a custom event hook
     * after rendering.
     */
-  def onMount(node: dom.Node): Unit = RxElement.NoOp
+  def onMount(node: Any): Unit = RxElement.NoOp
 
   /**
     * Called right before unmounting (deleting) this RxElement from DOM.
@@ -90,7 +89,7 @@ object RxElement {
       override def render: RxElement = LazyRxElement(() => a)
     }
 
-  private[html] val NoOp = { (n: dom.Node) => () }
+  private[html] val NoOp = { (n: Any) => }
 
 }
 

--- a/airframe-rx-html/src/main/scala/wvlet/airframe/rx/html/RxElement.scala
+++ b/airframe-rx-html/src/main/scala/wvlet/airframe/rx/html/RxElement.scala
@@ -37,6 +37,9 @@ abstract class RxElement(val modifiers: List[Seq[HtmlNode]] = List.empty) extend
   /**
     * Called right after mounting this RxElement to the document. Override this method to define a custom event hook
     * after rendering.
+    *
+    * @param node
+    *   the mounted DOM node (org.scalajs.dom.Node in Scala.js)
     */
   def onMount(node: Any): Unit = RxElement.NoOp
 


### PR DESCRIPTION
- **rx-html (breaking): RxElement.onMount(n: dom.Node) now takes a node argument**
- This is a fix for correctly calling onMount hook after the node is rendered to the document (using MutationObserver https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver)
- **Fix message**
