### PR TITLE
http (feature): Add OpenAPI schema support for Rx return types

### DIFF
--- a/airframe-http-codegen/src/main/scala/wvlet/airframe/http/openapi/OpenAPIGenerator.scala
+++ b/airframe-http-codegen/src/main/scala/wvlet/airframe/http/openapi/OpenAPIGenerator.scala
@@ -21,6 +21,7 @@ import wvlet.airframe.json.JSON.JSONValue
 import wvlet.airframe.json.Json
 import wvlet.airframe.metrics.{Count, DataSize, ElapsedTime}
 import wvlet.airframe.msgpack.spi.{MsgPack, Value}
+import wvlet.airframe.rx.Rx
 import wvlet.airframe.surface.*
 import wvlet.airframe.surface.reflect.*
 import wvlet.airframe.ulid.ULID
@@ -489,6 +490,8 @@ class OpenAPIGenerator(config: OpenAPIGeneratorConfig) extends LogSupport {
               Schema(`type` = "string")
             case o: OptionSurface =>
               getOpenAPISchemaOfSurface(o.elementSurface, seen + s)
+            case s: Surface if classOf[Rx[_]].isAssignableFrom(s.rawType) =>
+              getOpenAPISchemaOfSurface(s.typeArgs(0), seen + s)
             case s: Surface if Router.isFuture(s) =>
               getOpenAPISchemaOfSurface(Router.unwrapFuture(s), seen + s)
             case s: Surface if Router.isFinagleReader(s) =>

--- a/airframe-http-codegen/src/test/scala/wvlet/airframe/http/openapi/SimpleOpenAPITest.scala
+++ b/airframe-http-codegen/src/test/scala/wvlet/airframe/http/openapi/SimpleOpenAPITest.scala
@@ -14,6 +14,7 @@
 package wvlet.airframe.http.openapi
 import wvlet.airframe.http.openapi.OpenAPI.Schema
 import wvlet.airframe.http.{RPC, Router, description}
+import wvlet.airframe.rx.Rx
 import wvlet.airframe.ulid.ULID
 import wvlet.airspec.AirSpec
 
@@ -193,4 +194,20 @@ object SimpleOpenAPITest extends AirSpec {
     val schema = openapi.components.get.schemas.head.head._2.asInstanceOf[Schema]
     schema.required shouldBe empty
   }
+
+  case class HelloRet(p: String = "hello")
+  @RPC
+  trait RxTestApi {
+    def hello(): Rx[HelloRet]
+  }
+
+  test("Rx return type") {
+    val r    = Router.of[RxTestApi]
+    val yaml = openApiGenerator(r).toYAML
+    debug(yaml)
+    yaml.contains("type: object") shouldBe true
+    yaml.contains("properties:") shouldBe true
+    yaml.contains("#/components/schemas/HelloRet") shouldBe true
+  }
+
 }


### PR DESCRIPTION
- Update OpenAPIGenerator to handle Rx[_] return types
- Add test case for Rx[HelloRet] return type in SimpleOpenAPITest
- Ensure Rx[_] types are correctly represented in OpenAPI schema
