### PR TITLE
Update Scala 3.6.x CI test to 3.7.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,7 +97,7 @@ jobs:
           annotate_only: true
           detailed_summary: true
   test_3_latest:
-    name: Scala 3.6.x
+    name: Scala 3.7.x
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -105,15 +105,15 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '21'
-      - name: Scala 3.6.x test
+      - name: Scala 3.7.x test
         # Test only Scala 3 supported projects
-        run: SCALA_VERSION=3.6.2 ./sbt "projectDotty/test; dottyTest/run"
+        run: SCALA_VERSION=3.7.1 ./sbt "projectDotty/test; dottyTest/run"
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v5
         if: always() # always run even if the previous step fails
         with:
           report_paths: '**/target/test-reports/TEST-*.xml'
-          check_name: Test Report Scala 3.6.x
+          check_name: Test Report Scala 3.7.x
           annotate_only: true
           detailed_summary: true
   test_3_latest_jdk:


### PR DESCRIPTION
## Summary
- Update the Scala 3.6.x CI test to use Scala 3.7.1 instead of 3.6.2
- Update job and step names to reflect the new Scala 3.7.x version

## Test plan
- [ ] CI tests pass with Scala 3.7.1

🤖 Generated with [Claude Code](https://claude.ai/code)