### PR TITLE
Skip CI tests when there are no relevant changes using dorny/paths-filter

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -2,28 +2,34 @@ name: Coverage
 
 on:
   pull_request:
-    paths:
-      - '**.scala'
-      - '**.java'
-      - '**.sbt'
-      - '**/codecov.yml'
-      - '.scalafmt.conf'
-      - 'project/build.properties'
   push:
     branches:
       - main
-    paths:
-      - '**.scala'
-      - '**.java'
-      - '**.sbt'
-      - '**/codecov.yml'
-      - '.scalafmt.conf'
-      - 'project/build.properties'
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      coverage: ${{ steps.filter.outputs.coverage }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            coverage:
+              - '**.scala'
+              - '**.java'
+              - '**.sbt'
+              - '**/codecov.yml'
+              - '.scalafmt.conf'
+              - 'project/build.properties'
   coverage:
     name: Coverage test
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.coverage == 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4

--- a/.github/workflows/package-test.yml
+++ b/.github/workflows/package-test.yml
@@ -4,16 +4,29 @@ on:
   push:
     branches:
       - main
-    paths:
-      - '**.scala'
-      - '**.java'
-      - '**.sbt'
-      - '.github/workflows/package-test.yml'
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      packaging: ${{ steps.filter.outputs.packaging }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            packaging:
+              - '**.scala'
+              - '**.java'
+              - '**.sbt'
+              - '.github/workflows/package-test.yml'
   test_packaging:
     name: Packaging Test
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.packaging == 'true'
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/sbt-integration.yml
+++ b/.github/workflows/sbt-integration.yml
@@ -2,30 +2,35 @@ name: sbt-integration
 
 on:
   pull_request:
-    paths:
-      - '**.scala'
-      - '**.java'
-      - '**.sbt'
-      - '.scalafmt.conf'
-      - '.github/workflows/sbt-integration.yml'
-      - 'project/build.properties'
-      - AIRSPEC_VERSION
   push:
     branches:
       - main
-    paths:
-      - '**.scala'
-      - '**.java'
-      - '**.sbt'
-      - '.scalafmt.conf'
-      - '.github/workflows/sbt-integration.yml'
-      - 'project/build.properties'
-      - AIRSPEC_VERSION
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      sbt-integration: ${{ steps.filter.outputs.sbt-integration }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            sbt-integration:
+              - '**.scala'
+              - '**.java'
+              - '**.sbt'
+              - '.scalafmt.conf'
+              - '.github/workflows/sbt-integration.yml'
+              - 'project/build.properties'
+              - AIRSPEC_VERSION
   sbt_airframe:
     name: sbt-airframe
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.sbt-integration == 'true'
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,30 +2,36 @@ name: CI
 
 on:
   pull_request:
-    paths:
-      - '**.scala'
-      - '**.java'
-      - '**.sbt'
-      - '.scalafmt.conf'
-      - '.github/workflows/test.yml'
-      - 'project/build.properties'
-      - AIRSPEC_VERSION
   push:
     branches:
       - main
-    paths:
-      - '**.scala'
-      - '**.java'
-      - '**.sbt'
-      - '.scalafmt.conf'
-      - '.github/workflows/test.yml'
-      - 'project/build.properties'
-      - AIRSPEC_VERSION
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      tests: ${{ steps.filter.outputs.tests }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            tests:
+              - '**.scala'
+              - '**.java'
+              - '**.sbt'
+              - '.scalafmt.conf'
+              - '.github/workflows/test.yml'
+              - 'project/build.properties'
+              - AIRSPEC_VERSION
+
   code_format:
     name: Code format
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.tests == 'true'
     steps:
       - uses: actions/checkout@v4
       - name: scalafmt in Scala 2.x
@@ -41,6 +47,8 @@ jobs:
   test_2_12:
     name: Scala 2.12
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.tests == 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -60,6 +68,8 @@ jobs:
   test_2_13:
     name: Scala 2.13
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.tests == 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -79,6 +89,8 @@ jobs:
   test_3:
     name: Scala 3
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.tests == 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -99,6 +111,8 @@ jobs:
   test_3_latest:
     name: Scala 3.7.x
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.tests == 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -119,6 +133,8 @@ jobs:
   test_3_latest_jdk:
     name: Scala 3 / JDK17
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.tests == 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -139,6 +155,8 @@ jobs:
   test_integration:
     name: Scala 3 / Integration Test
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.tests == 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -163,6 +181,8 @@ jobs:
   test_js:
     name: Scala.js / Scala 2.12
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.tests == 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -187,6 +207,8 @@ jobs:
   test_js_2_13:
     name: Scala.js / Scala 2.13
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.tests == 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -211,6 +233,8 @@ jobs:
   test_js_3:
     name: Scala.js / Scala 3
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.tests == 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -235,6 +259,8 @@ jobs:
   test_native_3:
     name: Scala Native / Scala 3
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.tests == 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -254,6 +280,8 @@ jobs:
   test_airspec:
     name: AirSpec
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.tests == 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4


### PR DESCRIPTION
## Summary
- Add `dorny/paths-filter` action to detect changes in relevant files
- Make all test jobs conditional based on detected changes
- Preserve existing path filters while using dorny/paths-filter for better control

## Test plan
- [ ] Verify CI workflows run successfully when code changes are made
- [ ] Verify CI workflows are skipped when only non-relevant files (e.g., markdown docs) are changed
- [ ] Check that all test jobs properly depend on the changes detection job

🤖 Generated with [Claude Code](https://claude.ai/code)