### PR TITLE
Update CI to test with JDK 25 (Latest LTS)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,7 +131,7 @@ jobs:
           annotate_only: true
           detailed_summary: true
   test_3_latest_jdk:
-    name: Scala 3 / JDK17
+    name: Scala 3 / JDK Latest LTS
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.tests == 'true'
@@ -140,7 +140,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
-          java-version: '17'
+          java-version: '25'
       - name: Scala 3 test
         # Test only Scala 3 supported projects
         run: ./sbt "++ 3; projectDotty/test; dottyTest/run"
@@ -149,7 +149,7 @@ jobs:
         if: always() # always run even if the previous step fails
         with:
           report_paths: '**/target/test-reports/TEST-*.xml'
-          check_name: Test Report Scala 3 / JDK17
+          check_name: Test Report Scala 3 / JDK Latest LTS
           annotate_only: true
           detailed_summary: true
   test_integration:


### PR DESCRIPTION
## Summary
- Updated the CI test job to use JDK 25 instead of JDK 17
- Renamed test job to "Scala 3 / JDK Latest LTS" for better clarity
- JDK 25 is the new LTS release, replacing JDK 17 as the latest LTS

## Test plan
- [x] Verify YAML syntax is valid
- [ ] CI will test JDK 25 compatibility with Scala 3 projects
- [ ] Monitor first CI run to ensure JDK 25 setup works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)