### PR TITLE
fix: Handle HTTP 304 Not Modified as a successful response

### DIFF
--- a/airframe-http/src/main/scala/wvlet/airframe/http/HttpClientException.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/HttpClientException.scala
@@ -89,6 +89,9 @@ object HttpClientException extends LogSupport {
     status match {
       case s if s.isSuccessful =>
         Succeeded
+      case HttpStatus.NotModified_304 =>
+        // 304 Not Modified is a successful response indicating cached content is still valid
+        Succeeded
       case s if s.isServerError =>
         // We should retry on any server side errors
         val f = retryableFailure(requestFailure(response))

--- a/airframe-http/src/test/scala/wvlet/airframe/http/HttpClientExceptionTest.scala
+++ b/airframe-http/src/test/scala/wvlet/airframe/http/HttpClientExceptionTest.scala
@@ -22,8 +22,8 @@ class HttpClientExceptionTest extends AirSpec {
     val result = HttpClientException.classifyHttpResponse(response)
     result match {
       case ResultClass.Failed(isRetryable, _, _) =>
-        withClue(s"For status ${response.status}") {
-          isRetryable shouldBe expected
+        if (isRetryable != expected) {
+          fail(s"For status ${response.status}: expected isRetryable=$expected but got $isRetryable")
         }
       case _ =>
         fail(s"Expected Failed result for ${response.status}")

--- a/airframe-http/src/test/scala/wvlet/airframe/http/HttpClientExceptionTest.scala
+++ b/airframe-http/src/test/scala/wvlet/airframe/http/HttpClientExceptionTest.scala
@@ -1,0 +1,95 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.http
+
+import wvlet.airframe.control.ResultClass
+import wvlet.airspec.AirSpec
+
+class HttpClientExceptionTest extends AirSpec {
+  test("classify 304 Not Modified as success") {
+    val response = HttpMessage.Response(HttpStatus.NotModified_304)
+    val result   = HttpClientException.classifyHttpResponse(response)
+    result shouldBe ResultClass.Succeeded
+  }
+
+  test("classify 2xx responses as success") {
+    val responses = Seq(
+      HttpMessage.Response(HttpStatus.Ok_200),
+      HttpMessage.Response(HttpStatus.Created_201),
+      HttpMessage.Response(HttpStatus.Accepted_202),
+      HttpMessage.Response(HttpStatus.NoContent_204)
+    )
+
+    responses.foreach { response =>
+      val result = HttpClientException.classifyHttpResponse(response)
+      result shouldBe ResultClass.Succeeded
+    }
+  }
+
+  test("classify server errors as retryable") {
+    val responses = Seq(
+      HttpMessage.Response(HttpStatus.InternalServerError_500),
+      HttpMessage.Response(HttpStatus.BadGateway_502),
+      HttpMessage.Response(HttpStatus.ServiceUnavailable_503)
+    )
+
+    responses.foreach { response =>
+      val result = HttpClientException.classifyHttpResponse(response)
+      result match {
+        case ResultClass.Failed(isRetryable, _, _) =>
+          isRetryable shouldBe true
+        case _ =>
+          fail(s"Expected Failed result for ${response.status}")
+      }
+    }
+  }
+
+  test("classify most client errors as non-retryable") {
+    val responses = Seq(
+      HttpMessage.Response(HttpStatus.BadRequest_400),
+      HttpMessage.Response(HttpStatus.Unauthorized_401),
+      HttpMessage.Response(HttpStatus.Forbidden_403),
+      HttpMessage.Response(HttpStatus.NotFound_404)
+    )
+
+    responses.foreach { response =>
+      val result = HttpClientException.classifyHttpResponse(response)
+      result match {
+        case ResultClass.Failed(isRetryable, _, _) =>
+          isRetryable shouldBe false
+        case _ =>
+          fail(s"Expected Failed result for ${response.status}")
+      }
+    }
+  }
+
+  test("classify specific client errors as retryable") {
+    val retryableClientErrors = Seq(
+      HttpMessage.Response(HttpStatus.RequestTimeout_408),
+      HttpMessage.Response(HttpStatus.Gone_410),
+      HttpMessage.Response(HttpStatus.TooManyRequests_429),
+      HttpMessage.Response(HttpStatus.ClientClosedRequest_499)
+    )
+
+    retryableClientErrors.foreach { response =>
+      val result = HttpClientException.classifyHttpResponse(response)
+      result match {
+        case ResultClass.Failed(isRetryable, _, _) =>
+          isRetryable shouldBe true
+        case _ =>
+          fail(s"Expected Failed result for ${response.status}")
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Fixed classification of HTTP 304 (Not Modified) status code to be treated as a successful response
- Previously, 304 was incorrectly falling through to the default case and being treated as a non-retryable failure

## Changes
- Added explicit case for `HttpStatus.NotModified_304` in `classifyHttpResponse` method to return `Succeeded`
- Added comprehensive test coverage in new `HttpClientExceptionTest` class

## Test plan
- [x] Added unit tests to verify 304 is classified as success
- [x] Added tests for other HTTP status codes to ensure comprehensive coverage
- [x] All tests pass: `./sbt "httpJVM/testOnly *HttpClientExceptionTest"`

## Context
The HTTP 304 Not Modified status indicates that the cached version of the requested resource is still valid and can be used. This is a successful response, not an error condition, as it confirms the client's cached data is up-to-date.

🤖 Generated with [Claude Code](https://claude.ai/code)