### PR TITLE
Revert "Update sbt-jmh to 0.4.8"

### DIFF
--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -38,7 +38,7 @@ addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.8.0")
 addSbtPlugin("com.simplytyped" % "sbt-antlr4" % "0.8.3")
 
 // For JMH benchmark
-addSbtPlugin("pl.project13.scala" % "sbt-jmh"  % "0.4.8")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh"  % "0.4.7")
 addSbtPlugin("org.xerial.sbt"     % "sbt-pack" % "0.22")
 
 scalacOptions ++= Seq("-deprecation", "-feature")


### PR DESCRIPTION
Reverts wvlet/airframe#4051

This caused scala 2.x test failures 