### PR TITLE
Fix issue 4008 in airframe

### DIFF
--- a/airframe-log/src/test/scala/wvlet/airframe/log/LogTest.scala
+++ b/airframe-log/src/test/scala/wvlet/airframe/log/LogTest.scala
@@ -29,14 +29,16 @@ class LogTest extends Spec {
   }
 
   test("Test setting root log level") {
-    val p            = new Properties()
-    val rootLogLevel = Logger.getDefaultLogLevel
-    try {
-      p.load(new StringReader("_root_ = trace"))
-      Logger.setLogLevels(p)
-      Logger.getDefaultLogLevel shouldBe LogLevel.TRACE
-    } finally {
-      Logger.setDefaultLogLevel(rootLogLevel)
+    Logger.synchronized {
+      val p            = new Properties()
+      val rootLogLevel = Logger.getDefaultLogLevel
+      try {
+        p.load(new StringReader("_root_ = trace"))
+        Logger.setLogLevels(p)
+        Logger.getDefaultLogLevel shouldBe LogLevel.TRACE
+      } finally {
+        Logger.setDefaultLogLevel(rootLogLevel)
+      }
     }
   }
 }


### PR DESCRIPTION
The test was flaky because multiple tests could concurrently access and modify the shared global rootLogger without synchronization, causing intermittent failures where the test expected TRACE but received INFO.

Wrapping the test body in Logger.synchronized ensures that only one test can access the root logger at a time, preventing the race condition.

Fixes #4008

**Description**

**Related Issue/Task**

**Checklist**

- [ ] This pull request focuses on a single task.
- [ ] The change does not contain security credentials
