### PR TITLE
Support global RxRouter filters for unmatched routes (e.g., CORS preflight)

### DIFF
--- a/airframe-http-netty/src/test/scala/wvlet/airframe/http/netty/CorsControllerTest.scala
+++ b/airframe-http-netty/src/test/scala/wvlet/airframe/http/netty/CorsControllerTest.scala
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.airframe.http.netty
+
+import wvlet.airframe.http.*
+import wvlet.airframe.http.client.SyncClient
+import wvlet.airframe.http.filter.Cors
+import wvlet.airspec.AirSpec
+
+object CorsControllerTest extends AirSpec {
+  @RPC
+  class MyApi {
+    def hello(msg: String): String = s"Hello ${msg}!"
+  }
+
+  private val corsRouter = RxRouter
+    .filter(Cors.newFilter(Cors.unsafePermissivePolicy))
+    .andThen(RxRouter.of[MyApi])
+}
+
+/**
+  * Test that CORS filter works with controller-based routing via RxRouter.filter(...). Previously, OPTIONS preflight
+  * requests would return 404 because the route matcher rejects unmatched HTTP methods before filters run.
+  */
+class CorsControllerTest extends AirSpec {
+  import CorsControllerTest.*
+
+  initDesign { d =>
+    Netty.server.withRouter(corsRouter).designWithSyncClient
+  }
+
+  test("handle OPTIONS preflight for controller routes") { (client: SyncClient) =>
+    val resp = client.send(
+      Http
+        .request(HttpMethod.OPTIONS, "/wvlet.airframe.http.netty.CorsControllerTest.MyApi/hello")
+        .withHeader("Origin", "https://example.com")
+        .withHeader("Access-Control-Request-Method", "POST")
+        .withHeader("Access-Control-Request-Headers", "Content-Type")
+    )
+    resp.statusCode shouldBe 200
+    resp.header.get("access-control-allow-origin") shouldBe Some("https://example.com")
+    resp.header.get("access-control-allow-methods") shouldBe Some("POST")
+    resp.header.get("access-control-allow-headers") shouldBe Some("Content-Type")
+    resp.header.get("access-control-allow-credentials") shouldBe Some("true")
+  }
+
+  test("add CORS headers to normal responses") { (client: SyncClient) =>
+    val resp = client.send(
+      Http
+        .POST("/wvlet.airframe.http.netty.CorsControllerTest.MyApi/hello")
+        .withJson("""{"msg":"World"}""")
+        .withHeader("Origin", "https://example.com")
+    )
+    resp.statusCode shouldBe 200
+    resp.contentString shouldBe "Hello World!"
+    resp.header.get("access-control-allow-origin") shouldBe Some("https://example.com")
+    resp.header.get("access-control-allow-credentials") shouldBe Some("true")
+  }
+}

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/HttpRequestDispatcher.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/HttpRequestDispatcher.scala
@@ -85,10 +85,7 @@ object HttpRequestDispatcher extends LogSupport {
     // Wrap with global filter so it runs before route matching.
     // This allows filters like CORS to intercept requests (e.g., OPTIONS preflight)
     // regardless of whether a route matches.
-    routingTable.globalFilter match {
-      case Some(gf) => gf.andThen(routeDispatcher)
-      case None     => routeDispatcher
-    }
+    routingTable.globalFilter.map(_.andThen(routeDispatcher)).getOrElse(routeDispatcher)
   }
 
   /**
@@ -105,10 +102,7 @@ object HttpRequestDispatcher extends LogSupport {
     def adaptFilter(router: Router): Option[HttpFilter[Req, Resp, F]] =
       router.filterInstance
         .orElse {
-          router.filterSurface
-            .map(fs => controllerProvider.findController(session, fs))
-            .filter(_.isDefined)
-            .map(_.get)
+          router.filterSurface.flatMap(fs => controllerProvider.findController(session, fs))
         }
         .map {
           case rxFilter: RxHttpFilter =>
@@ -128,17 +122,18 @@ object HttpRequestDispatcher extends LogSupport {
           acc: Option[HttpFilter[Req, Resp, F]]
       ): (Option[HttpFilter[Req, Resp, F]], Router) = {
         val localFilter = adaptFilter(r)
-        val newAcc      = localFilter.map(lf => acc.map(_.andThen(lf)).getOrElse(lf)).orElse(acc)
+        val newAcc = (acc, localFilter) match {
+          case (Some(a), Some(lf)) => Some(a.andThen(lf))
+          case (None, Some(lf))    => Some(lf)
+          case (a, None)           => a
+        }
 
-        if (localFilter.isDefined && r.localRoutes.isEmpty && r.children.size == 1) {
-          // Filter-only node with single child — extract and continue
+        if (r.localRoutes.isEmpty && r.children.size == 1) {
+          // Single child with no routes — continue walking
           walk(r.children.head, newAcc)
         } else if (localFilter.isDefined) {
           // Filter with routes or branching — extract filter, return node without it
           (newAcc, r.copy(filterInstance = None, filterSurface = None))
-        } else if (r.localRoutes.isEmpty && !r.isLeafFilter && r.children.size == 1) {
-          // No filter, single child, no routes — skip and continue
-          walk(r.children.head, acc)
         } else {
           (acc, r)
         }

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/HttpRequestDispatcher.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/HttpRequestDispatcher.scala
@@ -18,6 +18,7 @@ import wvlet.airframe.codec.MessageCodecFactory
 import wvlet.airframe.http.*
 import wvlet.log.LogSupport
 
+import scala.annotation.tailrec
 import scala.concurrent.ExecutionContext
 import scala.language.higherKinds
 
@@ -31,9 +32,9 @@ object HttpRequestDispatcher extends LogSupport {
   case class RoutingTable[Req, Resp, F[_]](
       routeToFilterMappings: Map[Route, RouteFilter[Req, Resp, F]],
       leafFilter: Option[HttpFilter[Req, Resp, F]],
-      // Filter chain accumulated from non-leaf filter nodes (e.g., RxRouter.filter(corsFilter).andThen(RxRouter.of[...]))
-      // Used as fallback for unmatched requests so that global filters can intercept them
-      fallbackFilter: Option[HttpFilter[Req, Resp, F]] = None
+      // Global filter chain extracted from the root of the Router tree.
+      // Applied before route matching so filters like CORS can intercept all requests.
+      globalFilter: Option[HttpFilter[Req, Resp, F]] = None
   ) {
     def findFilter(route: Route): RouteFilter[Req, Resp, F] = {
       routeToFilterMappings(route)
@@ -52,7 +53,8 @@ object HttpRequestDispatcher extends LogSupport {
     // Generate a table for Route -> matching HttpFilter
     val routingTable = buildRoutingTable(backend, session, router, backend.defaultFilter, controllerProvider)
 
-    backend.newFilter { (request: Req, context: HttpContext[Req, Resp, F]) =>
+    // Route dispatcher: matches requests to routes and applies route-specific filters
+    val routeDispatcher = backend.newFilter { (request: Req, context: HttpContext[Req, Resp, F]) =>
       router.findRoute(request) match {
         case Some(routeMatch) =>
           // Find a filter for the matched route
@@ -70,16 +72,22 @@ object HttpRequestDispatcher extends LogSupport {
           val currentService = routeFilter.filter.andThen(context)
           currentService.apply(request)
         case None =>
-          // If no matching route is found, use the leaf filter or fallback filter if exists.
-          // The fallback filter allows global filters (e.g., CORS) added via RxRouter.filter(...)
-          // to intercept requests even when route matching fails (e.g., OPTIONS preflight).
-          routingTable.leafFilter.orElse(routingTable.fallbackFilter) match {
+          // If no matching route is found, use the leaf filter if exists
+          routingTable.leafFilter match {
             case Some(f) =>
               f.apply(request, context)
             case None =>
               context.apply(request)
           }
       }
+    }
+
+    // Wrap with global filter so it runs before route matching.
+    // This allows filters like CORS to intercept requests (e.g., OPTIONS preflight)
+    // regardless of whether a route matches.
+    routingTable.globalFilter match {
+      case Some(gf) => gf.andThen(routeDispatcher)
+      case None     => routeDispatcher
     }
   }
 
@@ -93,30 +101,58 @@ object HttpRequestDispatcher extends LogSupport {
       baseFilter: HttpFilter[Req, Resp, F],
       controllerProvider: ControllerProvider
   ): RoutingTable[Req, Resp, F] = {
-    val leafFilters     = Seq.newBuilder[HttpFilter[Req, Resp, F]]
-    val fallbackFilters = Seq.newBuilder[HttpFilter[Req, Resp, F]]
+
+    def adaptFilter(router: Router): Option[HttpFilter[Req, Resp, F]] =
+      router.filterInstance
+        .orElse {
+          router.filterSurface
+            .map(fs => controllerProvider.findController(session, fs))
+            .filter(_.isDefined)
+            .map(_.get)
+        }
+        .map {
+          case rxFilter: RxHttpFilter =>
+            backend.rxFilterAdapter(rxFilter)
+          case legacyFilter: HttpFilter[Req, Resp, F] @unchecked =>
+            backend.filterAdapter(legacyFilter)
+          case other =>
+            throw RPCStatus.UNIMPLEMENTED_U8.newException(s"Invalid filter type: ${other}")
+        }
+
+    // Extract global filters from the root's linear single-child path.
+    // These filters wrap the entire dispatch so they run before route matching.
+    val (globalFilter, routeRoot) = {
+      @tailrec
+      def walk(
+          r: Router,
+          acc: Option[HttpFilter[Req, Resp, F]]
+      ): (Option[HttpFilter[Req, Resp, F]], Router) = {
+        val localFilter = adaptFilter(r)
+        val newAcc      = localFilter.map(lf => acc.map(_.andThen(lf)).getOrElse(lf)).orElse(acc)
+
+        if (localFilter.isDefined && r.localRoutes.isEmpty && r.children.size == 1) {
+          // Filter-only node with single child — extract and continue
+          walk(r.children.head, newAcc)
+        } else if (localFilter.isDefined) {
+          // Filter with routes or branching — extract filter, return node without it
+          (newAcc, r.copy(filterInstance = None, filterSurface = None))
+        } else if (r.localRoutes.isEmpty && !r.isLeafFilter && r.children.size == 1) {
+          // No filter, single child, no routes — skip and continue
+          walk(r.children.head, acc)
+        } else {
+          (acc, r)
+        }
+      }
+      walk(rootRouter, None)
+    }
+
+    val leafFilters = Seq.newBuilder[HttpFilter[Req, Resp, F]]
 
     def buildMappingsFromRouteToFilter(
         router: Router,
         parentFilter: HttpFilter[Req, Resp, F]
     ): Map[Route, RouteFilter[Req, Resp, F]] = {
-      val localFilterOpt: Option[HttpFilter[Req, Resp, F]] =
-        // Use a given filter instance or one created from the DI session
-        router.filterInstance
-          .orElse {
-            router.filterSurface
-              .map(fs => controllerProvider.findController(session, fs))
-              .filter(_.isDefined)
-              .map(_.get)
-          }
-          .map {
-            case rxFilter: RxHttpFilter =>
-              backend.rxFilterAdapter(rxFilter)
-            case legacyFilter: HttpFilter[Req, Resp, F] @unchecked =>
-              backend.filterAdapter(legacyFilter)
-            case other =>
-              throw RPCStatus.UNIMPLEMENTED_U8.newException(s"Invalid filter type: ${other}") //
-          }
+      val localFilterOpt = adaptFilter(router)
 
       val currentFilter: HttpFilter[Req, Resp, F] =
         localFilterOpt
@@ -124,12 +160,6 @@ object HttpRequestDispatcher extends LogSupport {
             parentFilter.andThen(l)
           }
           .getOrElse(parentFilter)
-
-      // Collect filter nodes that wrap actual routes as fallback candidates for unmatched requests.
-      // Only routers with routes in their subtree need a fallback (leaf endpoint chains are handled by leafFilter).
-      if (localFilterOpt.isDefined && router.routes.nonEmpty) {
-        fallbackFilters += currentFilter
-      }
 
       val m = Map.newBuilder[Route, RouteFilter[Req, Resp, F]]
       for (route <- router.localRoutes) {
@@ -151,17 +181,14 @@ object HttpRequestDispatcher extends LogSupport {
       m.result()
     }
 
-    val mappings = buildMappingsFromRouteToFilter(rootRouter, baseFilter)
+    val mappings = buildMappingsFromRouteToFilter(routeRoot, baseFilter)
 
     val lf = leafFilters.result()
     if (lf.size > 1) {
       warn(s"Multiple leaf filters are found in the router. Using the first one: ${lf.head}")
     }
 
-    // Use the deepest fallback filter — it includes all ancestor filters via andThen
-    val ff = fallbackFilters.result()
-
-    RoutingTable(mappings, lf.headOption, ff.lastOption)
+    RoutingTable(mappings, lf.headOption, globalFilter)
   }
 
 }

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/HttpRequestDispatcher.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/HttpRequestDispatcher.scala
@@ -94,7 +94,7 @@ object HttpRequestDispatcher extends LogSupport {
       controllerProvider: ControllerProvider
   ): RoutingTable[Req, Resp, F] = {
     val leafFilters = Seq.newBuilder[HttpFilter[Req, Resp, F]]
-    // Track the accumulated filter chain from non-leaf filter nodes
+    // The deepest non-leaf filter chain, used as fallback for unmatched requests
     var fallbackFilterChain: Option[HttpFilter[Req, Resp, F]] = None
 
     def buildMappingsFromRouteToFilter(
@@ -126,7 +126,7 @@ object HttpRequestDispatcher extends LogSupport {
           }
           .getOrElse(parentFilter)
 
-      // Track non-leaf filter nodes as fallback for unmatched requests
+      // Record the deepest non-leaf filter chain as fallback for unmatched requests
       if (localFilterOpt.isDefined && !router.isLeafFilter) {
         fallbackFilterChain = Some(currentFilter)
       }

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/HttpRequestDispatcher.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/HttpRequestDispatcher.scala
@@ -93,9 +93,8 @@ object HttpRequestDispatcher extends LogSupport {
       baseFilter: HttpFilter[Req, Resp, F],
       controllerProvider: ControllerProvider
   ): RoutingTable[Req, Resp, F] = {
-    val leafFilters = Seq.newBuilder[HttpFilter[Req, Resp, F]]
-    // The deepest non-leaf filter chain, used as fallback for unmatched requests
-    var fallbackFilterChain: Option[HttpFilter[Req, Resp, F]] = None
+    val leafFilters     = Seq.newBuilder[HttpFilter[Req, Resp, F]]
+    val fallbackFilters = Seq.newBuilder[HttpFilter[Req, Resp, F]]
 
     def buildMappingsFromRouteToFilter(
         router: Router,
@@ -126,9 +125,10 @@ object HttpRequestDispatcher extends LogSupport {
           }
           .getOrElse(parentFilter)
 
-      // Record the deepest non-leaf filter chain as fallback for unmatched requests
-      if (localFilterOpt.isDefined && !router.isLeafFilter) {
-        fallbackFilterChain = Some(currentFilter)
+      // Collect filter nodes that wrap actual routes as fallback candidates for unmatched requests.
+      // Only routers with routes in their subtree need a fallback (leaf endpoint chains are handled by leafFilter).
+      if (localFilterOpt.isDefined && router.routes.nonEmpty) {
+        fallbackFilters += currentFilter
       }
 
       val m = Map.newBuilder[Route, RouteFilter[Req, Resp, F]]
@@ -158,7 +158,10 @@ object HttpRequestDispatcher extends LogSupport {
       warn(s"Multiple leaf filters are found in the router. Using the first one: ${lf.head}")
     }
 
-    RoutingTable(mappings, lf.headOption, fallbackFilterChain)
+    // Use the deepest fallback filter — it includes all ancestor filters via andThen
+    val ff = fallbackFilters.result()
+
+    RoutingTable(mappings, lf.headOption, ff.lastOption)
   }
 
 }

--- a/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/HttpRequestDispatcher.scala
+++ b/airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/HttpRequestDispatcher.scala
@@ -30,7 +30,10 @@ object HttpRequestDispatcher extends LogSupport {
 
   case class RoutingTable[Req, Resp, F[_]](
       routeToFilterMappings: Map[Route, RouteFilter[Req, Resp, F]],
-      leafFilter: Option[HttpFilter[Req, Resp, F]]
+      leafFilter: Option[HttpFilter[Req, Resp, F]],
+      // Filter chain accumulated from non-leaf filter nodes (e.g., RxRouter.filter(corsFilter).andThen(RxRouter.of[...]))
+      // Used as fallback for unmatched requests so that global filters can intercept them
+      fallbackFilter: Option[HttpFilter[Req, Resp, F]] = None
   ) {
     def findFilter(route: Route): RouteFilter[Req, Resp, F] = {
       routeToFilterMappings(route)
@@ -67,8 +70,10 @@ object HttpRequestDispatcher extends LogSupport {
           val currentService = routeFilter.filter.andThen(context)
           currentService.apply(request)
         case None =>
-          // If no matching route is found, use the leaf filter if exists
-          routingTable.leafFilter match {
+          // If no matching route is found, use the leaf filter or fallback filter if exists.
+          // The fallback filter allows global filters (e.g., CORS) added via RxRouter.filter(...)
+          // to intercept requests even when route matching fails (e.g., OPTIONS preflight).
+          routingTable.leafFilter.orElse(routingTable.fallbackFilter) match {
             case Some(f) =>
               f.apply(request, context)
             case None =>
@@ -89,6 +94,8 @@ object HttpRequestDispatcher extends LogSupport {
       controllerProvider: ControllerProvider
   ): RoutingTable[Req, Resp, F] = {
     val leafFilters = Seq.newBuilder[HttpFilter[Req, Resp, F]]
+    // Track the accumulated filter chain from non-leaf filter nodes
+    var fallbackFilterChain: Option[HttpFilter[Req, Resp, F]] = None
 
     def buildMappingsFromRouteToFilter(
         router: Router,
@@ -119,6 +126,11 @@ object HttpRequestDispatcher extends LogSupport {
           }
           .getOrElse(parentFilter)
 
+      // Track non-leaf filter nodes as fallback for unmatched requests
+      if (localFilterOpt.isDefined && !router.isLeafFilter) {
+        fallbackFilterChain = Some(currentFilter)
+      }
+
       val m = Map.newBuilder[Route, RouteFilter[Req, Resp, F]]
       for (route <- router.localRoutes) {
         val controllerOpt = router.controllerInstance.orElse {
@@ -146,7 +158,7 @@ object HttpRequestDispatcher extends LogSupport {
       warn(s"Multiple leaf filters are found in the router. Using the first one: ${lf.head}")
     }
 
-    RoutingTable(mappings, lf.headOption)
+    RoutingTable(mappings, lf.headOption, fallbackFilterChain)
   }
 
 }

--- a/docs/airframe-http.md
+++ b/docs/airframe-http.md
@@ -390,6 +390,53 @@ val router = RxRouter
 Using local variables inside filters will not work because the request processing will happen when Future[X] is evaluated, so we must use thead-local parmeter holder, which will be prepared for each request call.
 
 
+### CORS Filter
+
+airframe-http provides a built-in CORS filter for handling [Cross-Origin Resource Sharing](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS). To use it, add the CORS filter to your router with `RxRouter.filter(...)`:
+
+```scala
+import wvlet.airframe.http.*
+import wvlet.airframe.http.filter.Cors
+import wvlet.airframe.http.netty.Netty
+
+@RPC
+class MyApi {
+  def hello(msg: String): String = s"Hello ${msg}!"
+}
+
+// Define a CORS policy
+val corsPolicy = Cors.Policy(
+  allowsOrigin = {
+    case origin if origin.endsWith(".mydomain.com") => Some(origin)
+    case _ => None
+  },
+  allowsMethods = _ => Some(Seq("GET", "POST")),
+  allowsHeaders = headers => Some(headers),
+  supportsCredentials = true
+)
+
+// Add the CORS filter to the router
+val router = RxRouter
+  .filter(Cors.newFilter(corsPolicy))
+  .andThen(RxRouter.of[MyApi])
+
+Netty.server
+  .withRouter(router)
+  .start { server =>
+    // Server handles CORS preflight (OPTIONS) and adds CORS headers to all responses
+  }
+```
+
+The CORS filter placed at the router level intercepts `OPTIONS` preflight requests before route matching, so it works correctly with `@RPC` and `@Endpoint` controller routes. For non-OPTIONS requests, it adds the appropriate CORS headers to responses.
+
+For development or testing, you can use the permissive policy that allows all origins (do not use in production):
+```scala
+val router = RxRouter
+  .filter(Cors.newFilter(Cors.unsafePermissivePolicy))
+  .andThen(RxRouter.of[MyApi])
+```
+
+
 ## Access Logs
 
 airframe-http stores HTTP access logs at `log/http-server.json` by default in JSON format. When the log file becomes large, it will be compressed with gz and rotated automatically.


### PR DESCRIPTION
## Summary

- Fix: When using `RxRouter.filter(corsFilter).andThen(RxRouter.of[Controller])`, OPTIONS preflight requests returned 404 because the route matcher groups routes by HTTP method — unmatched methods fell through to 404 before global filters could run.
- Track accumulated filter chains from non-leaf filter nodes as a `fallbackFilter` in `RoutingTable`. When route matching fails, apply the fallback filter so global filters like CORS can intercept unmatched requests.
- Add integration test verifying OPTIONS preflight and CORS headers work with controller-based routing.

## Test plan

- [x] New `CorsControllerTest` verifies OPTIONS preflight returns CORS headers with controller-based routing
- [x] New test verifies CORS headers are added to normal POST responses
- [x] Existing `CorsFilterTest` (leaf endpoint pattern) still passes — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)