### PR TITLE
fix: Preserve inner filter chain when composing RxRouter filters

### DIFF
--- a/airframe-http/src/main/scala/wvlet/airframe/http/RxRouter.scala
+++ b/airframe-http/src/main/scala/wvlet/airframe/http/RxRouter.scala
@@ -140,7 +140,13 @@ object RxRouter extends RxRouterObjectBase {
     def name: String = filterSurface.name
 
     def andThen(next: FilterNode): FilterNode = {
-      next.copy(parent = Some(this))
+      // Attach `this` at the top of next's existing parent chain so composing
+      // chains (filter[A].andThen(filter[B].andThen[C])) does not drop B.
+      val newParent = next.parent match {
+        case None    => this
+        case Some(p) => this.andThen(p)
+      }
+      next.copy(parent = Some(newParent))
     }
     def andThenOpt(next: Option[FilterNode]): Option[FilterNode] = {
       next match {

--- a/airframe-http/src/test/scala/wvlet/airframe/http/RxRouterTest.scala
+++ b/airframe-http/src/test/scala/wvlet/airframe/http/RxRouterTest.scala
@@ -51,6 +51,12 @@ object RxRouterTest extends AirSpec {
     }
   }
 
+  trait MetricFilter extends RxHttpFilter {
+    override def apply(request: HttpMessage.Request, next: RxHttpEndpoint): Rx[HttpMessage.Response] = {
+      next.apply(request)
+    }
+  }
+
   test("create a single route RxRouter") {
     val r = RxRouter.of[MyApi]
     r.children shouldBe empty
@@ -230,5 +236,66 @@ object RxRouterTest extends AirSpec {
       methodSurfaces(0).name shouldBe "hello2"
       methodSurfaces(1).name shouldBe "hello3"
     }
+  }
+
+  test("Preserve the outer filter when wrapping a pre-filtered router") {
+    // Simple 2-filter composition: outer filter must remain as parent of inner filter.
+    val r = RxRouter
+      .filter[AuthFilter]
+      .andThen(
+        RxRouter
+          .filter[LogFilter]
+          .andThen(MyApi.router)
+      )
+
+    r.filter shouldBe defined
+    r.filter.get.filterSurface shouldBe Surface.of[LogFilter]
+    r.filter.get.parent shouldBe defined
+    r.filter.get.parent.get.filterSurface shouldBe Surface.of[AuthFilter]
+
+    r.routes.size shouldBe 1
+    r.routes(0) shouldMatch { case RxRoute(Some(filter), controllerSurface, _) =>
+      filter.filterSurface shouldBe Surface.of[LogFilter]
+      filter.parent shouldBe defined
+      filter.parent.get.filterSurface shouldBe Surface.of[AuthFilter]
+      filter.parent.get.parent shouldBe empty
+      controllerSurface shouldBe Surface.of[MyApi]
+    }
+  }
+
+  test("Preserve the full inner filter chain when wrapped by an outer filter") {
+    // Regression test for silently dropped filters when composing filter chains.
+    // The inner router already has chain AuthFilter -> LogFilter.
+    // Wrapping with MetricFilter must yield MetricFilter -> AuthFilter -> LogFilter
+    // (not MetricFilter -> LogFilter, which would silently drop AuthFilter).
+    val composed = RxRouter
+      .filter[MetricFilter]
+      .andThen(
+        RxRouter
+          .filter[AuthFilter]
+          .andThen[LogFilter]
+          .andThen(MyApi.router)
+      )
+
+    // Expected to match a flat chain construction
+    val expected = RxRouter
+      .filter[MetricFilter]
+      .andThen[AuthFilter]
+      .andThen[LogFilter]
+      .andThen(MyApi.router)
+
+    composed.routes.size shouldBe 1
+    composed.routes(0) shouldMatch { case RxRoute(Some(filter), controllerSurface, _) =>
+      filter.filterSurface shouldBe Surface.of[LogFilter]
+      filter.parent shouldBe defined
+      filter.parent.get.filterSurface shouldBe Surface.of[AuthFilter]
+      filter.parent.get.parent shouldBe defined
+      filter.parent.get.parent.get.filterSurface shouldBe Surface.of[MetricFilter]
+      filter.parent.get.parent.get.parent shouldBe empty
+      controllerSurface shouldBe Surface.of[MyApi]
+    }
+
+    // Both constructions must produce equivalent chains
+    composed.routes shouldBe expected.routes
   }
 }

--- a/airframe-http/src/test/scala/wvlet/airframe/http/RxRouterTest.scala
+++ b/airframe-http/src/test/scala/wvlet/airframe/http/RxRouterTest.scala
@@ -284,18 +284,30 @@ object RxRouterTest extends AirSpec {
       .andThen[LogFilter]
       .andThen(MyApi.router)
 
+    // Flatten a FilterNode chain into the list of applied filter surfaces
+    // ordered outer-to-inner (the order in which filters are invoked).
+    def chain(f: RxRouter.FilterNode): List[Surface] = {
+      f.parent.map(chain).getOrElse(Nil) :+ f.filterSurface
+    }
+
     composed.routes.size shouldBe 1
     composed.routes(0) shouldMatch { case RxRoute(Some(filter), controllerSurface, _) =>
-      filter.filterSurface shouldBe Surface.of[LogFilter]
-      filter.parent shouldBe defined
-      filter.parent.get.filterSurface shouldBe Surface.of[AuthFilter]
-      filter.parent.get.parent shouldBe defined
-      filter.parent.get.parent.get.filterSurface shouldBe Surface.of[MetricFilter]
-      filter.parent.get.parent.get.parent shouldBe empty
+      chain(filter) shouldBe List(
+        Surface.of[MetricFilter],
+        Surface.of[AuthFilter],
+        Surface.of[LogFilter]
+      )
       controllerSurface shouldBe Surface.of[MyApi]
     }
 
-    // Both constructions must produce equivalent chains
-    composed.routes shouldBe expected.routes
+    // The nested composition must produce the same filter chain as the flat form.
+    expected.routes.size shouldBe 1
+    expected.routes(0) shouldMatch { case RxRoute(Some(filter), _, _) =>
+      chain(filter) shouldBe List(
+        Surface.of[MetricFilter],
+        Surface.of[AuthFilter],
+        Surface.of[LogFilter]
+      )
+    }
   }
 }


### PR DESCRIPTION
## Summary

- `RxRouter.FilterNode.andThen(next: FilterNode)` overwrote `next.parent`, silently dropping intermediate filters when composing already-built filter chains.
- Fix: attach `this` on top of `next`'s existing parent chain so the composition is associative.

## Problem

Given:

```scala
RxRouter
  .filter[A]
  .andThen(
    RxRouter
      .filter[B]
      .andThen[C]
      .andThen(routes)
  )
```

The expected chain is `A -> B -> C`, but the previous implementation produced `A -> C`, silently losing `B`. The bug also surfaced inside `StemNode.wrapWithFilter` and `RxRoute.wrapWithFilter`, both of which delegate to `FilterNode.andThen(FilterNode)` via `andThenOpt`, so nested `StemNode`s with their own filter chains were affected too.

## Fix

When composing `this.andThen(next)`, walk to the top of `next.parent` and attach `this` there instead of overwriting `next.parent`.

## Test plan

- [x] `RxRouterTest`: existing tests pass
- [x] New test `Preserve the outer filter when wrapping a pre-filtered router` (simple 2-filter case)
- [x] New test `Preserve the full inner filter chain when wrapped by an outer filter` fails before the fix, passes after; also asserts equivalence with the flat `filter[A].andThen[B].andThen[C].andThen(routes)` form
- [x] `./sbt httpJVM/test` (Scala 3): 195 tests pass
- [x] `./sbt '++ 2.13' 'httpJVM/testOnly *RxRouterTest *RxRouterConverterTest'` passes
- [x] `./sbt netty/test` passes (119)
- [x] `./sbt httpCodeGen/test` passes (43)