### PR TITLE
fix: Add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -11,6 +11,10 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  # Push to gh-pages happens via the GIT_DEPLOY_KEY SSH key, not GITHUB_TOKEN
+  contents: read
+
 jobs:
   doc:
     name: Update docs

--- a/.github/workflows/package-test.yml
+++ b/.github/workflows/package-test.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   changes:
     name: Detect Changes

--- a/.github/workflows/release-airspec.yml
+++ b/.github/workflows/release-airspec.yml
@@ -6,6 +6,9 @@ on:
       - v*
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   publish_jvm:
     name: Publish AirSpec

--- a/.github/workflows/release-js.yml
+++ b/.github/workflows/release-js.yml
@@ -6,6 +6,9 @@ on:
       - v*
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   publish_js:
     name: Publish Scala.js

--- a/.github/workflows/release-native.yml
+++ b/.github/workflows/release-native.yml
@@ -6,6 +6,9 @@ on:
       - v*
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   publish_js:
     name: Publish Scala Native

--- a/.github/workflows/release-note.yml
+++ b/.github/workflows/release-note.yml
@@ -4,7 +4,11 @@ on:
   push:
     tags:
       - v*
-  workflow_dispatch:      
+  workflow_dispatch:
+
+permissions:
+  # Required by `gh release create` to publish a GitHub release
+  contents: write
 
 jobs:
   release:

--- a/.github/workflows/release-sbt-plugin.yml
+++ b/.github/workflows/release-sbt-plugin.yml
@@ -6,6 +6,9 @@ on:
       - v*
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   publish_jvm:
     name: Publish sbt-airframe plugin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
       - v*
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   publish_jvm:
     name: Publish Scala JVM

--- a/.github/workflows/sbt-integration.yml
+++ b/.github/workflows/sbt-integration.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   changes:
     name: Detect Changes

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -12,6 +12,9 @@ on:
     tag:
       - '!v*'
 
+permissions:
+  contents: read
+
 jobs:
   publish_snapshots:
     name: Publish snapshots

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,11 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  # Required by mikepenz/action-junit-report to publish check annotations
+  checks: write
+
 jobs:
   changes:
     name: Detect Changes


### PR DESCRIPTION
## Summary
- Adds least-privilege `permissions` blocks to all GitHub Actions workflows that were missing them, resolving the 25 open `actions/missing-workflow-permissions` alerts at https://github.com/wvlet/airframe/security/code-scanning
- Most workflows get `contents: read` only
- `test.yml` also gets `checks: write` (required by `mikepenz/action-junit-report` for check annotations)
- `release-note.yml` gets `contents: write` (required by `gh release create`)
- `doc.yml` stays read-only — the gh-pages push uses the `GIT_DEPLOY_KEY` SSH key, not `GITHUB_TOKEN`

## Test plan
- [ ] CI workflow runs and `Publish Test Report` annotations still appear on PRs
- [ ] After merge, confirm the 25 open alerts on the Security tab are auto-closed
- [ ] Next tag push: `release-note.yml` still successfully creates a release
- [ ] Next tag push: release/snapshot publishing to Sonatype still works