### PR TITLE
internal: Migrate build to sbt 2.0.1

### DIFF
--- a/.github/actions/bootstrap-sbt-airframe/action.yml
+++ b/.github/actions/bootstrap-sbt-airframe/action.yml
@@ -1,7 +1,7 @@
 name: Bootstrap sbt-airframe
 description: >
   Publish the in-repo sbt-airframe plugin to the local Ivy repo so the main build's
-  metabuild can resolve it. Temporary: remove once sbt-airframe 2026.1.8 is published
+  metabuild can resolve it. Temporary: remove once sbt-airframe 2026.2.0 is published
   to Maven Central (the main build then resolves it normally via SBT_AIRFRAME_VERSION).
 runs:
   using: composite
@@ -9,4 +9,4 @@ runs:
     - name: Publish sbt-airframe locally
       shell: bash
       # Pin the version to the SBT_AIRFRAME_VERSION default in project/plugin.sbt.
-      run: cd sbt-airframe && ../sbt 'set every version := "2026.1.8"' publishLocal
+      run: cd sbt-airframe && ../sbt 'set every version := "2026.2.0"' publishLocal

--- a/.github/actions/bootstrap-sbt-airframe/action.yml
+++ b/.github/actions/bootstrap-sbt-airframe/action.yml
@@ -1,0 +1,12 @@
+name: Bootstrap sbt-airframe
+description: >
+  Publish the in-repo sbt-airframe plugin to the local Ivy repo so the main build's
+  metabuild can resolve it. Temporary: remove once sbt-airframe 2026.1.8 is published
+  to Maven Central (the main build then resolves it normally via SBT_AIRFRAME_VERSION).
+runs:
+  using: composite
+  steps:
+    - name: Publish sbt-airframe locally
+      shell: bash
+      # Pin the version to the SBT_AIRFRAME_VERSION default in project/plugin.sbt.
+      run: cd sbt-airframe && ../sbt 'set every version := "2026.1.8"' publishLocal

--- a/.github/workflows/release-sbt-plugin.yml
+++ b/.github/workflows/release-sbt-plugin.yml
@@ -32,8 +32,10 @@ jobs:
         run: echo "AIRFRAME_VERSION=$(./scripts/dynver.sh)" >> $GITHUB_ENV
       - name: Check Airframe version
         run: echo ${AIRFRAME_VERSION}
+      # sbt-airframe is a Scala 3 sbt 2.x plugin, so it depends on the _3 variants
+      # of airframe-control/codec/log/http-codegen at the release version.
       - name: Create Airframe artifacts locally
-        run: ./sbt ++2.12 "projectJVM/publishLocal; projectJS/publishLocal"
+        run: ./sbt "projectJVM/publishLocal"
       - name: Build sbt-airframe bundle
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}

--- a/.github/workflows/sbt-integration.yml
+++ b/.github/workflows/sbt-integration.yml
@@ -44,6 +44,8 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '21'
+      # The root build's metabuild needs the (not-yet-released) sbt-airframe plugin to load.
+      - uses: ./.github/actions/bootstrap-sbt-airframe
       - name: Get Airframe version
         run: echo "AIRFRAME_VERSION=$(./scripts/dynver.sh)" >> $GITHUB_ENV
       - name: Check Airframe version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,7 @@ jobs:
     if: needs.changes.outputs.tests == 'true'
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/bootstrap-sbt-airframe
       - name: scalafmt in Scala 2.x
         run: ./sbt "++ 2.13; scalafmtCheckAll"
       - name: scalafmt in Scala 3
@@ -63,6 +64,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '21'
+      - uses: ./.github/actions/bootstrap-sbt-airframe
       - name: Scala 2.12 test
         run: ./sbt "++2.12; projectJVM/test"
       - name: Publish Test Report
@@ -84,6 +86,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '21'
+      - uses: ./.github/actions/bootstrap-sbt-airframe
       - name: Scala 2.13 test
         run: ./sbt "++2.13; projectJVM/test"
       - name: Publish Test Report
@@ -105,6 +108,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '21'
+      - uses: ./.github/actions/bootstrap-sbt-airframe
       - name: Scala 3.x test
         # Test only Scala 3 supported projects
         run: ./sbt "++ 3; projectDotty/test; dottyTest/run"
@@ -127,6 +131,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '21'
+      - uses: ./.github/actions/bootstrap-sbt-airframe
       - name: Scala 3.7.x test
         # Test only Scala 3 supported projects
         run: SCALA_VERSION=3.7.1 ./sbt "projectDotty/test; dottyTest/run"
@@ -149,6 +154,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '25'
+      - uses: ./.github/actions/bootstrap-sbt-airframe
       - name: Scala 3 test
         # Test only Scala 3 supported projects
         run: ./sbt "++ 3; projectDotty/test; dottyTest/run"
@@ -180,6 +186,7 @@ jobs:
           cache: 'pnpm'
       - name: Node.js setup
         run: ./scripts/setup-scalajs.sh
+      - uses: ./.github/actions/bootstrap-sbt-airframe
       - name: Integration Test
         run: ./sbt "++ 3; projectIt/test"
       - name: Publish Test Report
@@ -210,6 +217,7 @@ jobs:
           cache: 'pnpm'
       - name: Node.js setup
         run: ./scripts/setup-scalajs.sh
+      - uses: ./.github/actions/bootstrap-sbt-airframe
       - name: Scala.js test
         run: JVM_OPTS=-Xmx4g ./sbt "++ 2.12; projectJS/test"
       - name: Publish Test Report
@@ -240,6 +248,7 @@ jobs:
           cache: 'pnpm'
       - name: Node.js setup
         run: ./scripts/setup-scalajs.sh
+      - uses: ./.github/actions/bootstrap-sbt-airframe
       - name: Scala.js test
         run: JVM_OPTS=-Xmx4g ./sbt "++ 2.13; projectJS/test"
       - name: Publish Test Report
@@ -270,6 +279,7 @@ jobs:
           cache: 'pnpm'
       - name: Node.js setup
         run: ./scripts/setup-scalajs.sh
+      - uses: ./.github/actions/bootstrap-sbt-airframe
       - name: Scala.js test
         run: JVM_OPTS=-Xmx4g ./sbt "++ 3; projectJS/test"
       - name: Publish Test Report
@@ -293,6 +303,7 @@ jobs:
           java-version: '21'
       - name: Install native dependencies
         run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
+      - uses: ./.github/actions/bootstrap-sbt-airframe
       - name: Scala Native test
         run: JVM_OPTS=-Xmx4g ./sbt "++ 3; projectNative/test"
       - name: Publish Test Report

--- a/airframe-di/.jvm/src/main/scala/wvlet/airframe/tracing/ChromeTracer.scala
+++ b/airframe-di/.jvm/src/main/scala/wvlet/airframe/tracing/ChromeTracer.scala
@@ -153,7 +153,9 @@ object ChromeTracer {
     * @return
     */
   def newTracer(fileName: String): ChromeTracer = {
-    new ChromeTracer(new BufferedOutputStream(new FileOutputStream(fileName)))
+    val file = new File(fileName)
+    Option(file.getParentFile).foreach(_.mkdirs())
+    new ChromeTracer(new BufferedOutputStream(new FileOutputStream(file)))
   }
 
   /**

--- a/airframe-rx-html/.js/src/test/scala/wvlet/airframe/http/rx/html/RxRenderingTest.scala
+++ b/airframe-rx-html/.js/src/test/scala/wvlet/airframe/http/rx/html/RxRenderingTest.scala
@@ -218,9 +218,13 @@ object RxRenderingTest extends AirSpec {
     }
 
     val (n, c) = render(e)
-    n.outerHTML shouldBe """<div style="color: white;" class="color-white"></div>"""
+    // Attribute serialization order in outerHTML is JS-environment dependent, so assert per attribute.
+    def htmlContains(fragments: String*): Unit = fragments.foreach { f =>
+      assert(n.outerHTML.contains(f), s"${n.outerHTML} should contain ${f}")
+    }
+    htmlContains("""style="color: white;"""", """class="color-white"""")
     color := "black"
-    n.outerHTML shouldBe """<div style="color: black;" class="color-black"></div>"""
+    htmlContains("""style="color: black;"""", """class="color-black"""")
     c.cancel
   }
 

--- a/airspec/build.sbt
+++ b/airspec/build.sbt
@@ -42,7 +42,7 @@ ThisBuild / publishTo := {
 }
 
 // Share
-ThisBuild / scalafmtConfig := file("../.scalafmt.conf")
+ThisBuild / scalafmtConfig := Def.uncached(file("../.scalafmt.conf"))
 
 val noPublish = Seq(
   publish / skip  := true,
@@ -93,7 +93,7 @@ val buildSettings = Seq[Setting[?]](
     if (scalaVersion.value.startsWith("3."))
       Seq.empty
     else
-      Seq("org.scala-lang.modules" %%% "scala-collection-compat" % "2.14.0")
+      Seq("org.scala-lang.modules" %% "scala-collection-compat" % "2.14.0")
   }
 )
 
@@ -111,7 +111,7 @@ import sbt.ThisBuild
 import scala.xml.{Comment, Elem, Node => XmlNode, NodeSeq => XmlNodeSeq}
 import scala.xml.transform.{RewriteRule, RuleTransformer}
 
-def excludePomDependency(excludes: Seq[String]) = { node: XmlNode =>
+def excludePomDependency(excludes: Seq[String]) = { (node: XmlNode) =>
   def isExcludeTarget(artifactId: String): Boolean =
     excludes.exists(artifactId.startsWith(_))
 
@@ -235,7 +235,7 @@ lazy val airspecLog =
     .jsSettings(
       airspecJSBuildSettings,
       libraryDependencies ++= Seq(
-        ("org.scala-js" %%% "scalajs-java-logging" % JS_JAVA_LOGGING_VERSION).cross(CrossVersion.for3Use2_13)
+        ("org.scala-js" %% "scalajs-java-logging" % JS_JAVA_LOGGING_VERSION).cross(CrossVersion.for3Use2_13)
       )
     )
     .nativeSettings(
@@ -310,7 +310,7 @@ lazy val airspecDeps =
       Compile / packageSrc / mappings ++= (airspecCore.js / Compile / packageSrc / mappings).value,
       libraryDependencies ++= Seq(
         // Necessary for async testing
-        "org.scala-js" %%% "scala-js-macrotask-executor" % "1.1.1"
+        "org.scala-js" %% "scala-js-macrotask-executor" % "1.1.1"
       )
     )
     .nativeSettings(
@@ -334,7 +334,7 @@ lazy val airspec =
       name        := "airspec",
       description := "AirSpec: A Functional Testing Framework for Scala",
       libraryDependencies ++= Seq(
-        "org.scalacheck" %%% "scalacheck" % SCALACHECK_VERSION
+        "org.scalacheck" %% "scalacheck" % SCALACHECK_VERSION
       ),
       // A workaround for bloop, which cannot resolve Optional dependencies
       pomPostProcess := excludePomDependency(Seq("airspec-deps", "airspec_2.12", "airspec_2.13"))
@@ -365,11 +365,11 @@ lazy val airspec =
       Compile / packageSrc / mappings ++= (airspecDeps.js / Compile / packageSrc / mappings).value,
       libraryDependencies ++= Seq(
         ("org.scala-js"        %% "scalajs-test-interface" % scalaJSVersion).cross(CrossVersion.for3Use2_13),
-        ("org.portable-scala" %%% "portable-scala-reflect" % "1.1.3").cross(CrossVersion.for3Use2_13),
+        ("org.portable-scala" %% "portable-scala-reflect" % "1.1.3").cross(CrossVersion.for3Use2_13),
         // Needed to be explicitly included here for running Scala.js tests successfully
-        "org.scala-js" %%% "scala-js-macrotask-executor" % "1.1.1",
+        "org.scala-js" %% "scala-js-macrotask-executor" % "1.1.1",
         // Required by embedded airframe-log code that uses java.util.logging
-        ("org.scala-js" %%% "scalajs-java-logging" % JS_JAVA_LOGGING_VERSION).cross(CrossVersion.for3Use2_13)
+        ("org.scala-js" %% "scalajs-java-logging" % JS_JAVA_LOGGING_VERSION).cross(CrossVersion.for3Use2_13)
       )
     )
     .nativeSettings(
@@ -378,7 +378,7 @@ lazy val airspec =
       Compile / packageBin / mappings ++= (airspecDeps.native / Compile / packageBin / mappings).value,
       Compile / packageSrc / mappings ++= (airspecDeps.native / Compile / packageSrc / mappings).value,
       libraryDependencies ++= Seq(
-        "org.scala-native" %%% "test-interface" % "0.5.10"
+        "org.scala-native" %% "test-interface" % "0.5.12"
       )
     )
     // This should be Optional dependency, but using Provided dependency for bloop which doesn't support Optional.

--- a/airspec/build.sbt
+++ b/airspec/build.sbt
@@ -364,7 +364,12 @@ lazy val airspec =
         .filter(x => x._2 != "JS_DEPENDENCIES"),
       Compile / packageSrc / mappings ++= (airspecDeps.js / Compile / packageSrc / mappings).value,
       libraryDependencies ++= Seq(
-        ("org.scala-js"        %% "scalajs-test-interface" % scalaJSVersion).cross(CrossVersion.for3Use2_13),
+        // scalajs-test-interface is a plain Scala-versioned (non-Scala.js) artifact published only for
+        // 2.12/2.13. In a Scala.js project sbt 2.x would append the nonexistent _sjs1_ suffix, so pin the
+        // Scala binary suffix explicitly (Scala 3 uses the 2.13 build).
+        "org.scala-js" % s"scalajs-test-interface_${
+            if (scalaVersion.value.startsWith("3.")) "2.13" else scalaBinaryVersion.value
+          }" % scalaJSVersion,
         ("org.portable-scala" %% "portable-scala-reflect" % "1.1.3").cross(CrossVersion.for3Use2_13),
         // Needed to be explicitly included here for running Scala.js tests successfully
         "org.scala-js" %% "scala-js-macrotask-executor" % "1.1.1",

--- a/airspec/project/build.properties
+++ b/airspec/project/build.properties
@@ -1,14 +1,1 @@
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-sbt.version=1.12.2
+sbt.version=2.0.1

--- a/airspec/project/plugin.sbt
+++ b/airspec/project/plugin.sbt
@@ -1,23 +1,21 @@
-addSbtPlugin("com.github.sbt"     % "sbt-pgp"                  % "2.3.1")
-addSbtPlugin("org.scalameta"      % "sbt-scalafmt"             % "2.4.5")
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")
-addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"            % "0.13.1")
+addSbtPlugin("com.github.sbt" % "sbt-pgp"       % "2.3.1")
+addSbtPlugin("org.scalameta"  % "sbt-scalafmt"  % "2.5.6")
+addSbtPlugin("com.eed3si9n"   % "sbt-buildinfo" % "0.13.1")
 
 addDependencyTreePlugin
 
+// For Scala.js and Scala Native cross-building (sbt 2.x native)
+addSbtPlugin("org.wvlet.uni" % "sbt-uni-crossproject" % "2026.1.14")
+
 // For Scala.js
-val SCALAJS_VERSION = sys.env.getOrElse("SCALAJS_VERSION", "1.20.2")
-addSbtPlugin("org.scala-js"  % "sbt-scalajs"         % SCALAJS_VERSION)
-addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.21.1")
-libraryDependencies ++= (
-  Seq("org.scala-js" %% "scalajs-env-jsdom-nodejs" % "1.1.1")
-)
+val SCALAJS_VERSION = sys.env.getOrElse("SCALAJS_VERSION", "1.22.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % SCALAJS_VERSION)
 
 // For Scala native
-addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
-addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.5.10")
+val SCALA_NATIVE_VERSION = sys.env.getOrElse("SCALA_NATIVE_VERSION", "0.5.12")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % SCALA_NATIVE_VERSION)
 
 // For setting explicit versions for each commit
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.1.1")
 
-scalacOptions ++= Seq("-deprecation", "-feature", "-Xsource:3")
+scalacOptions ++= Seq("-deprecation", "-feature")

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
-import scalajsbundler.JSDOMNodeJSEnv
 import xerial.sbt.pack.PackPlugin.{projectSettings, publishPackArchiveTgz}
+import wvlet.uni.jsenv.playwright.PlaywrightJSEnv
 
 val SCALA_2_12          = "2.12.21"
 val SCALA_2_13          = "2.13.18"
@@ -78,6 +78,11 @@ Global / excludeLintKeys ++= Set(ideSkipProject)
 // Disable the pipelining available since sbt-1.4.0. It caused compilation failure
 ThisBuild / usePipelining := false
 
+// sbt 2.x promotes dependency eviction conflicts to errors by default. Restore the sbt 1.x
+// behavior (warn), as Scala Native modules mix ABI-compatible test-interface 0.5.x patch
+// versions from the published airspec/scalacheck artifacts.
+ThisBuild / evictionErrorLevel := sbt.util.Level.Warn
+
 // Use Scala 3 by default as scala-2 specific source code is relatively small now
 ThisBuild / scalaVersion := SCALA_3
 
@@ -106,7 +111,7 @@ val buildSettings = Seq[Setting[?]](
   crossScalaVersions    := targetScalaVersions,
   crossPaths            := true,
   publishMavenStyle     := true,
-  mimaPreviousArtifacts := Set("org.wvlet.airframe" %%% s"${name.value}" % AIRFRAME_BINARY_COMPAT_VERSION),
+  mimaPreviousArtifacts := Set("org.wvlet.airframe" %% s"${name.value}" % AIRFRAME_BINARY_COMPAT_VERSION),
   mimaFailOnNoPrevious  := false,
   mimaBinaryIssueFilters ++= {
     import com.typesafe.tools.mima.core.*
@@ -134,13 +139,13 @@ val buildSettings = Seq[Setting[?]](
   },
   testFrameworks += new TestFramework("wvlet.airspec.Framework"),
   libraryDependencies ++= Seq(
-    "org.wvlet.airframe" %%% "airspec"    % AIRSPEC_VERSION    % Test,
-    "org.scalacheck"     %%% "scalacheck" % SCALACHECK_VERSION % Test
+    "org.wvlet.airframe" %% "airspec"    % AIRSPEC_VERSION    % Test,
+    "org.scalacheck"     %% "scalacheck" % SCALACHECK_VERSION % Test
   ) ++ {
     if (scalaVersion.value.startsWith("3."))
       Seq.empty
     else
-      Seq("org.scala-lang.modules" %%% "scala-collection-compat" % "2.14.0")
+      Seq("org.scala-lang.modules" %% "scala-collection-compat" % "2.14.0")
   }
 )
 
@@ -166,9 +171,9 @@ ThisBuild / publishTo := {
 val jsBuildSettings = Seq[Setting[?]](
   // #2117 For using java.util.UUID.randomUUID() in Scala.js
   libraryDependencies ++= Seq(
-    ("org.scala-js" %%% "scalajs-java-securerandom" % "1.0.0" % Test).cross(CrossVersion.for3Use2_13),
+    ("org.scala-js" %% "scalajs-java-securerandom" % "1.0.0" % Test).cross(CrossVersion.for3Use2_13),
     // TODO It should be included in AirSpec
-    "org.scala-js" %%% "scala-js-macrotask-executor" % "1.1.1" % Test
+    "org.scala-js" %% "scala-js-macrotask-executor" % "1.1.1" % Test
   )
 )
 
@@ -202,7 +207,7 @@ lazy val root =
     .settings(name := "airframe-root")
     .settings(buildSettings)
     .settings(noPublish)
-    .aggregate((jvmProjects ++ jsProjects ++ itProjects): _*)
+    .aggregate((jvmProjects ++ jsProjects ++ itProjects)*)
 
 // JVM projects for scala-community build. This should have no tricky setup and should support Scala 2.12 and Scala 3
 lazy val communityBuildProjects: Seq[ProjectReference] = Seq(
@@ -290,7 +295,7 @@ lazy val communityBuild =
       // Skip importing aggregated projects in IntelliJ IDEA
       ideSkipProject := true
     )
-    .aggregate(communityBuildProjects: _*)
+    .aggregate(communityBuildProjects*)
 
 // For Scala 2.12
 lazy val projectJVM =
@@ -300,7 +305,7 @@ lazy val projectJVM =
       // Skip importing aggregated projects in IntelliJ IDEA
       ideSkipProject := true
     )
-    .aggregate(jvmProjects: _*)
+    .aggregate(jvmProjects*)
 
 lazy val projectJS =
   project
@@ -309,7 +314,7 @@ lazy val projectJS =
       // Skip importing aggregated projects in IntelliJ IDEA
       ideSkipProject := true
     )
-    .aggregate(jsProjects: _*)
+    .aggregate(jsProjects*)
 
 lazy val projectNative =
   project
@@ -318,7 +323,7 @@ lazy val projectNative =
       // Skip importing aggregated projects in IntelliJ IDEA
       ideSkipProject := true
     )
-    .aggregate(nativeProjects: _*)
+    .aggregate(nativeProjects*)
 
 lazy val projectIt =
   project
@@ -327,7 +332,7 @@ lazy val projectIt =
       // Skip importing aggregated projects in IntelliJ IDEA
       ideSkipProject := true
     )
-    .aggregate(itProjects: _*)
+    .aggregate(itProjects*)
 
 // A scoped project only for Dotty (Scala 3).
 // This is a workaround as projectJVM/test shows compile errors for non Scala 3 ready projects
@@ -395,7 +400,7 @@ def parallelCollection(scalaVersion: String) = {
 import scala.xml.{Node => XmlNode, NodeSeq => XmlNodeSeq, *}
 import scala.xml.transform.{RewriteRule, RuleTransformer}
 
-def excludePomDependency(excludes: Seq[String]) = { node: XmlNode =>
+def excludePomDependency(excludes: Seq[String]) = { (node: XmlNode) =>
   def isExcludeTarget(artifactId: String): Boolean =
     excludes.exists(artifactId.startsWith(_))
 
@@ -505,7 +510,7 @@ lazy val diMacros =
 // // To use airframe in other airframe modules, we need to reference airframeMacros project
 // lazy val airframeMacrosJVMRef = airframeMacrosJVM % Optional
 // lazy val airframeMacrosRef    = airframeMacros    % Optional
-val surfaceDependencies = { scalaVersion: String =>
+val surfaceDependencies = { (scalaVersion: String) =>
   scalaVersion match {
     case s if s.startsWith("3.") =>
       Seq.empty
@@ -584,7 +589,7 @@ lazy val ulid =
     .jsSettings(
       jsBuildSettings,
       // For using SecureRandom (requires `crypto` package)
-      libraryDependencies += ("org.scala-js" %%% "scalajs-java-securerandom" % "1.0.0").cross(CrossVersion.for3Use2_13)
+      libraryDependencies += ("org.scala-js" %% "scalajs-java-securerandom" % "1.0.0").cross(CrossVersion.for3Use2_13)
     )
     .nativeSettings(nativeBuildSettings)
     .dependsOn(log % Test)
@@ -611,7 +616,7 @@ lazy val launcher =
     )
     .dependsOn(surface.jvm, control.jvm, codec.jvm)
 
-val logDependencies = { scalaVersion: String =>
+val logDependencies = { (scalaVersion: String) =>
   scalaVersion match {
     case s if s.startsWith("3.") =>
       Seq.empty
@@ -626,7 +631,7 @@ val logJVMDependencies = Seq(
 )
 
 // airframe-log should have minimum dependencies
-lazy val log: sbtcrossproject.CrossProject =
+lazy val log: wvlet.uni.sbt.crossproject.CrossProject =
   crossProject(JVMPlatform, JSPlatform, NativePlatform)
     .crossType(CrossType.Pure)
     .in(file("airframe-log"))
@@ -647,7 +652,7 @@ lazy val log: sbtcrossproject.CrossProject =
     .jsSettings(
       jsBuildSettings,
       libraryDependencies ++= Seq(
-        ("org.scala-js" %%% "scalajs-java-logging" % JS_JAVA_LOGGING_VERSION).cross(CrossVersion.for3Use2_13)
+        ("org.scala-js" %% "scalajs-java-logging" % JS_JAVA_LOGGING_VERSION).cross(CrossVersion.for3Use2_13)
       )
     )
     .nativeSettings(
@@ -682,12 +687,12 @@ lazy val msgpack =
     .jsSettings(
       jsBuildSettings,
       libraryDependencies +=
-        ("org.scala-js" %%% "scalajs-java-time" % JS_JAVA_TIME_VERSION).cross(CrossVersion.for3Use2_13)
+        ("org.scala-js" %% "scalajs-java-time" % JS_JAVA_TIME_VERSION).cross(CrossVersion.for3Use2_13)
     )
     .nativeSettings(
       nativeBuildSettings,
       // For using java.time libraries
-      libraryDependencies += "org.ekrich" %%% "sjavatime" % "1.3.0"
+      libraryDependencies += "org.ekrich" %% "sjavatime" % "1.3.0"
     )
     .dependsOn(log, json)
 
@@ -750,7 +755,7 @@ lazy val rx =
     .jsSettings(
       jsBuildSettings,
       // For addressing the fairness issue of the global ExecutorContext https://github.com/scala-js/scala-js/issues/4129
-      libraryDependencies += "org.scala-js" %%% "scala-js-macrotask-executor" % "1.1.1"
+      libraryDependencies += "org.scala-js" %% "scala-js-macrotask-executor" % "1.1.1"
     )
     .nativeSettings(nativeBuildSettings)
     .dependsOn(log)
@@ -781,9 +786,9 @@ lazy val http =
     )
     .jsSettings(
       jsBuildSettings,
-      Test / jsEnv := new org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv(),
+      Test / jsEnv := Def.uncached(new PlaywrightJSEnv("chromium", headless = true)),
       libraryDependencies ++= Seq(
-        "org.scala-js" %%% "scalajs-dom" % SCALAJS_DOM_VERSION
+        "org.scala-js" %% "scalajs-dom" % SCALAJS_DOM_VERSION
       )
     )
     .nativeSettings(
@@ -933,10 +938,10 @@ lazy val benchmark =
       // java.lang.RuntimeException: ERROR: Unable to find the resource: /META-INF/BenchmarkList
       turbo := false,
       // Generate JMH benchmark cord before packaging and testing
-      Compile / pack        := (Compile / pack).dependsOn(Test / compile).value,
+      Compile / pack        := Def.uncached((Compile / pack).dependsOn(Test / compile).value),
       Jmh / sourceDirectory := (Compile / sourceDirectory).value,
-      Jmh / compile         := (Jmh / compile).triggeredBy(Compile / compile).value,
-      Test / compile        := ((Test / compile).dependsOn(Jmh / compile)).value,
+      Jmh / compile         := Def.uncached((Jmh / compile).triggeredBy(Compile / compile).value),
+      Test / compile        := Def.uncached(((Test / compile).dependsOn(Jmh / compile)).value),
       // Need to fork JVM so that sbt can set the classpass properly for running JMH
       run / fork := true,
       libraryDependencies ++= Seq(
@@ -984,7 +989,7 @@ lazy val fluentd =
     )
     .dependsOn(codec.jvm, di.jvm)
 
-def sqlRefLib = { scalaVersion: String =>
+def sqlRefLib = { (scalaVersion: String) =>
   if (scalaVersion.startsWith("2.13")) {
     Seq(
       // Include Spark just as a reference implementation
@@ -1040,23 +1045,43 @@ lazy val parquet =
     )
     .dependsOn(codec.jvm, sql)
 
+val ANTLR4_VERSION      = "4.13.2"
+val ANTLR4_PACKAGE_NAME = "wvlet.airframe.sql.parser"
+
 lazy val sql =
   project
-    .enablePlugins(Antlr4Plugin)
     .in(file("airframe-sql"))
     .settings(buildSettings)
     .settings(
-      name                       := "airframe-sql",
-      description                := "SQL parser & analyzer",
-      Antlr4 / antlr4Version     := "4.13.2",
-      Antlr4 / antlr4PackageName := Some("wvlet.airframe.sql.parser"),
-      Antlr4 / antlr4GenListener := true,
-      Antlr4 / antlr4GenVisitor  := true,
+      name        := "airframe-sql",
+      description := "SQL parser & analyzer",
       libraryDependencies ++= Seq(
+        "org.antlr" % "antlr4-runtime" % ANTLR4_VERSION,
         // For parsing DataType strings
         "org.scala-lang.modules"   %% "scala-parser-combinators" % SCALA_PARSER_COMBINATOR_VERSION,
         "com.github.vertical-blank" % "sql-formatter"            % "2.0.5"
-      ) ++ sqlRefLib(scalaVersion.value)
+      ) ++ sqlRefLib(scalaVersion.value),
+      // Generate ANTLR4 Lexer/Parser sources. sbt-antlr4 has no sbt 2.x build, so the
+      // ANTLR4 tool (added to the meta-build classpath in project/plugin.sbt) is invoked directly.
+      Compile / sourceGenerators += Def.uncached(Def.task {
+        val grammarDir   = baseDirectory.value / "src" / "main" / "antlr4"
+        val outDir       = (Compile / sourceManaged).value / "antlr4"
+        val grammarFiles = (grammarDir ** "*.g4").get()
+        val gen = FileFunction.cached(streams.value.cacheDirectory / "antlr4") { (_: Set[File]) =>
+          IO.createDirectory(outDir)
+          val args = Array(
+            "-o",
+            outDir.getAbsolutePath,
+            "-package",
+            ANTLR4_PACKAGE_NAME,
+            "-visitor",
+            "-listener"
+          ) ++ grammarFiles.map(_.getAbsolutePath)
+          new org.antlr.v4.Tool(args).processGrammarsOnCommandLine()
+          (outDir ** "*.java").get().toSet
+        }
+        gen(grammarFiles.toSet).toSeq
+      }).taskValue
     )
     .dependsOn(msgpack.jvm, surface.jvm, config, launcher)
 
@@ -1077,9 +1102,9 @@ lazy val rxHtml =
     )
     .jsSettings(
       jsBuildSettings,
-      Test / jsEnv := new org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv(),
+      Test / jsEnv := Def.uncached(new PlaywrightJSEnv("chromium", headless = true)),
       libraryDependencies ++= Seq(
-        "org.scala-js" %%% "scalajs-dom" % SCALAJS_DOM_VERSION
+        "org.scala-js" %% "scalajs-dom" % SCALAJS_DOM_VERSION
       )
     )
     .dependsOn(log, rx, surface)
@@ -1093,7 +1118,7 @@ lazy val widgetJS =
       name        := "airframe-rx-widget",
       description := "Reactive Widget library for Scala.js",
       jsBuildSettings,
-      Test / jsEnv := new org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv()
+      Test / jsEnv := Def.uncached(new PlaywrightJSEnv("chromium", headless = true))
       // npmDependencies in Compile += "monaco-editor" -> "0.21.3",
       // useYarn := true
       //      npmDependencies in Test += "node" -> "12.14.1"
@@ -1182,10 +1207,6 @@ lazy val integrationTestJs =
       ideSkipProject := true,
       name           := "airframe-integration-test-js",
       description    := "browser integration test for Scala.js",
-      Test / jsEnv := new jsenv.playwright.PWEnv(
-        browserName = "chrome",
-        headless = true,
-        showLogs = false
-      )
+      Test / jsEnv := Def.uncached(new PlaywrightJSEnv("chromium", headless = true))
     )
     .dependsOn(integrationTestApi.js)

--- a/build.sbt
+++ b/build.sbt
@@ -83,6 +83,10 @@ ThisBuild / usePipelining := false
 // versions from the published airspec/scalacheck artifacts.
 ThisBuild / evictionErrorLevel := sbt.util.Level.Warn
 
+// sbt 2.x defaults exportJars to true, which puts (test) resources inside jars. Some code loads
+// resources as plain files (e.g. YamlReader), so restore the sbt 1.x class-directory classpath.
+ThisBuild / exportJars := false
+
 // Use Scala 3 by default as scala-2 specific source code is relatively small now
 ThisBuild / scalaVersion := SCALA_3
 

--- a/examples/rpc-examples/hello-rpc/project/build.properties
+++ b/examples/rpc-examples/hello-rpc/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.2
+sbt.version=2.0.1

--- a/examples/rpc-examples/hello-rpc/project/plugins.sbt
+++ b/examples/rpc-examples/hello-rpc/project/plugins.sbt
@@ -1,5 +1,6 @@
-ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % "always"
-
-addSbtPlugin("org.xerial.sbt"     % "sbt-pack"     % "0.23")
-addSbtPlugin("org.wvlet.airframe" % "sbt-airframe" % "2026.1.1")
+val SBT_AIRFRAME_VERSION = sys.env.getOrElse("SBT_AIRFRAME_VERSION", "2026.1.7-0-938ab3b9-20260701-0115-SNAPSHOT")
+addSbtPlugin("org.xerial.sbt"     % "sbt-pack"     % "1.0.0")
+addSbtPlugin("org.wvlet.airframe" % "sbt-airframe" % SBT_AIRFRAME_VERSION)
 addSbtPlugin("org.scalameta"      % "sbt-scalafmt" % "2.5.6")
+
+conflictWarning := ConflictWarning.disable

--- a/examples/rpc-examples/hello-rpc/project/plugins.sbt
+++ b/examples/rpc-examples/hello-rpc/project/plugins.sbt
@@ -1,4 +1,4 @@
-val SBT_AIRFRAME_VERSION = sys.env.getOrElse("SBT_AIRFRAME_VERSION", "2026.1.7-0-938ab3b9-20260701-0115-SNAPSHOT")
+val SBT_AIRFRAME_VERSION = sys.env.getOrElse("SBT_AIRFRAME_VERSION", "2026.1.8")
 addSbtPlugin("org.xerial.sbt"     % "sbt-pack"     % "1.0.0")
 addSbtPlugin("org.wvlet.airframe" % "sbt-airframe" % SBT_AIRFRAME_VERSION)
 addSbtPlugin("org.scalameta"      % "sbt-scalafmt" % "2.5.6")

--- a/examples/rpc-examples/hello-rpc/project/plugins.sbt
+++ b/examples/rpc-examples/hello-rpc/project/plugins.sbt
@@ -1,4 +1,4 @@
-val SBT_AIRFRAME_VERSION = sys.env.getOrElse("SBT_AIRFRAME_VERSION", "2026.1.8")
+val SBT_AIRFRAME_VERSION = sys.env.getOrElse("SBT_AIRFRAME_VERSION", "2026.2.0")
 addSbtPlugin("org.xerial.sbt"     % "sbt-pack"     % "1.0.0")
 addSbtPlugin("org.wvlet.airframe" % "sbt-airframe" % SBT_AIRFRAME_VERSION)
 addSbtPlugin("org.scalameta"      % "sbt-scalafmt" % "2.5.6")

--- a/examples/rpc-examples/rpc-scalajs/build.sbt
+++ b/examples/rpc-examples/rpc-scalajs/build.sbt
@@ -14,7 +14,7 @@ lazy val api =
     .in(file("api"))
     .settings(
       libraryDependencies ++= Seq(
-        "org.wvlet.airframe" %%% "airframe-http" % AIRFRAME_VERSION
+        "org.wvlet.airframe" %% "airframe-http" % AIRFRAME_VERSION
       )
     )
 
@@ -24,9 +24,10 @@ lazy val apiJS  = api.js
 lazy val server =
   project
     .in(file("server"))
+    .enablePlugins(UniPlugin)
     .settings(
-      // For using the project root as a working folder
-      reStart / baseDirectory := (ThisBuild / baseDirectory).value,
+      // For using the project root as a working folder (background fork-run via sbt-uni)
+      uniRestart / baseDirectory := (ThisBuild / baseDirectory).value,
       libraryDependencies ++= Seq(
         "org.wvlet.airframe" %% "airframe-http-netty" % AIRFRAME_VERSION,
         "org.wvlet.airframe" %% "airframe-launcher"   % AIRFRAME_VERSION
@@ -43,7 +44,7 @@ lazy val ui =
       scalaJSUseMainModuleInitializer := true,
       airframeHttpClients             := Seq("example.api:rpc"),
       libraryDependencies ++= Seq(
-        "org.wvlet.airframe" %%% "airframe-rx-html" % AIRFRAME_VERSION
+        "org.wvlet.airframe" %% "airframe-rx-html" % AIRFRAME_VERSION
       )
     )
     .dependsOn(apiJS)

--- a/examples/rpc-examples/rpc-scalajs/project/build.properties
+++ b/examples/rpc-examples/rpc-scalajs/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.2
+sbt.version=2.0.1

--- a/examples/rpc-examples/rpc-scalajs/project/plugins.sbt
+++ b/examples/rpc-examples/rpc-scalajs/project/plugins.sbt
@@ -1,4 +1,4 @@
-val SBT_AIRFRAME_VERSION = sys.env.getOrElse("SBT_AIRFRAME_VERSION", "2026.1.8")
+val SBT_AIRFRAME_VERSION = sys.env.getOrElse("SBT_AIRFRAME_VERSION", "2026.2.0")
 addSbtPlugin("org.wvlet.airframe" % "sbt-airframe"         % SBT_AIRFRAME_VERSION)
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"          % "1.22.0")
 addSbtPlugin("org.wvlet.uni"      % "sbt-uni-crossproject" % "2026.1.14")

--- a/examples/rpc-examples/rpc-scalajs/project/plugins.sbt
+++ b/examples/rpc-examples/rpc-scalajs/project/plugins.sbt
@@ -1,6 +1,8 @@
-ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % "always"
+val SBT_AIRFRAME_VERSION = sys.env.getOrElse("SBT_AIRFRAME_VERSION", "2026.1.7-0-938ab3b9-20260701-0115-SNAPSHOT")
+addSbtPlugin("org.wvlet.airframe" % "sbt-airframe"         % SBT_AIRFRAME_VERSION)
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"          % "1.22.0")
+addSbtPlugin("org.wvlet.uni"      % "sbt-uni-crossproject" % "2026.1.14")
+// Background fork-run (sbt-revolver replacement)
+addSbtPlugin("org.wvlet.uni" % "sbt-uni" % "2026.1.14")
 
-addSbtPlugin("org.wvlet.airframe" % "sbt-airframe"             % "2026.1.1")
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.20.2")
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")
-addSbtPlugin("io.spray"           % "sbt-revolver"             % "0.10.0")
+conflictWarning := ConflictWarning.disable

--- a/examples/rpc-examples/rpc-scalajs/project/plugins.sbt
+++ b/examples/rpc-examples/rpc-scalajs/project/plugins.sbt
@@ -1,4 +1,4 @@
-val SBT_AIRFRAME_VERSION = sys.env.getOrElse("SBT_AIRFRAME_VERSION", "2026.1.7-0-938ab3b9-20260701-0115-SNAPSHOT")
+val SBT_AIRFRAME_VERSION = sys.env.getOrElse("SBT_AIRFRAME_VERSION", "2026.1.8")
 addSbtPlugin("org.wvlet.airframe" % "sbt-airframe"         % SBT_AIRFRAME_VERSION)
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"          % "1.22.0")
 addSbtPlugin("org.wvlet.uni"      % "sbt-uni-crossproject" % "2026.1.14")

--- a/examples/rx-demo/gallery/build.sbt
+++ b/examples/rx-demo/gallery/build.sbt
@@ -14,6 +14,6 @@ lazy val gallery =
         "-Yrangepos"
       ),
       libraryDependencies ++= Seq(
-        "org.wvlet.airframe" %%% "airframe-rx-html" % AIRFRAME_VERSION
+        "org.wvlet.airframe" %% "airframe-rx-html" % AIRFRAME_VERSION
       )
     )

--- a/examples/rx-demo/gallery/project/build.properties
+++ b/examples/rx-demo/gallery/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.2
+sbt.version=2.0.1

--- a/examples/rx-demo/gallery/project/plugins.sbt
+++ b/examples/rx-demo/gallery/project/plugins.sbt
@@ -1,3 +1,3 @@
 ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % "always"
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.20.2")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.22.0")

--- a/project/build.properties
+++ b/project/build.properties
@@ -11,4 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-sbt.version=1.12.2
+sbt.version=2.0.1

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -1,32 +1,29 @@
-addSbtPlugin("com.github.sbt"      % "sbt-pgp"                  % "2.3.1")
-addSbtPlugin("org.scalameta"       % "sbt-scalafmt"             % "2.5.6")
-addSbtPlugin("org.portable-scala"  % "sbt-scalajs-crossproject" % "1.3.2")
-addSbtPlugin("com.eed3si9n"        % "sbt-buildinfo"            % "0.13.1")
-addSbtPlugin("org.jetbrains.scala" % "sbt-ide-settings"         % "1.1.3")
+addSbtPlugin("com.github.sbt"      % "sbt-pgp"          % "2.3.1")
+addSbtPlugin("org.scalameta"       % "sbt-scalafmt"     % "2.5.6")
+addSbtPlugin("com.eed3si9n"        % "sbt-buildinfo"    % "0.13.1")
+addSbtPlugin("org.jetbrains.scala" % "sbt-ide-settings" % "1.1.4")
 
 // For auto-code rewrite
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.5")
 
-// For integration testing
-val SBT_AIRFRAME_VERSION = sys.env.getOrElse("SBT_AIRFRAME_VERSION", "24.12.2")
-addSbtPlugin("org.wvlet.airframe" % "sbt-airframe" % SBT_AIRFRAME_VERSION)
-
 addDependencyTreePlugin
 
-// For Scala.js
-val SCALAJS_VERSION = sys.env.getOrElse("SCALAJS_VERSION", "1.20.2")
-addSbtPlugin("org.scala-js"  % "sbt-scalajs"         % SCALAJS_VERSION)
-addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.21.1")
-libraryDependencies ++= (
-  Seq("org.scala-js" %% "scalajs-env-jsdom-nodejs" % "1.1.1")
-)
+// For Scala.js and Scala Native cross-building (sbt 2.x native)
+addSbtPlugin("org.wvlet.uni" % "sbt-uni-crossproject" % "2026.1.14")
 
-// For Scala.js + Playwright test
-libraryDependencies += "io.github.gmkumar2005" %% "scala-js-env-playwright" % "0.1.18"
+// For background fork-run (sbt-revolver replacement) and HTTP/RPC client code generation
+addSbtPlugin("org.wvlet.uni" % "sbt-uni" % "2026.1.14")
+
+// For Scala.js + Playwright test (also replaces scalajs-env-jsdom-nodejs, which has no Scala 3 build)
+addSbtPlugin("org.wvlet.uni" % "sbt-uni-playwright" % "2026.1.14")
+
+// For Scala.js
+val SCALAJS_VERSION = sys.env.getOrElse("SCALAJS_VERSION", "1.22.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % SCALAJS_VERSION)
 
 // For Scala native
-addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
-addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.5.10")
+val SCALA_NATIVE_VERSION = sys.env.getOrElse("SCALA_NATIVE_VERSION", "0.5.12")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % SCALA_NATIVE_VERSION)
 
 // For setting explicit versions for each commit
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.1.1")
@@ -34,12 +31,17 @@ addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.1.1")
 // Documentation
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.8.2")
 
-// For generating Lexer/Parser from ANTLR4 grammar (.g4)
-addSbtPlugin("com.simplytyped" % "sbt-antlr4" % "0.8.3")
-
 // For JMH benchmark
-addSbtPlugin("pl.project13.scala" % "sbt-jmh"  % "0.4.7")
-addSbtPlugin("org.xerial.sbt"     % "sbt-pack" % "0.23")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh"  % "0.4.8")
+addSbtPlugin("org.xerial.sbt"     % "sbt-pack" % "1.0.0")
+
+// For generating Lexer/Parser from ANTLR4 grammar (.g4) via a custom sourceGenerators task,
+// as sbt-antlr4 has no sbt 2.x build
+libraryDependencies += "org.antlr" % "antlr4" % "4.13.2"
+
+// For integration testing
+val SBT_AIRFRAME_VERSION = sys.env.getOrElse("SBT_AIRFRAME_VERSION", "2026.1.7-0-938ab3b9-20260701-0115-SNAPSHOT")
+addSbtPlugin("org.wvlet.airframe" % "sbt-airframe" % SBT_AIRFRAME_VERSION)
 
 scalacOptions ++= Seq("-deprecation", "-feature")
 
@@ -48,4 +50,6 @@ scalacOptions ++= Seq("-deprecation", "-feature")
 //libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.10.8"
 
 // Binary compatibility checker
-addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.4")
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.6")
+
+conflictWarning := ConflictWarning.disable

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -39,8 +39,12 @@ addSbtPlugin("org.xerial.sbt"     % "sbt-pack" % "1.0.0")
 // as sbt-antlr4 has no sbt 2.x build
 libraryDependencies += "org.antlr" % "antlr4" % "4.13.2"
 
-// For integration testing
-val SBT_AIRFRAME_VERSION = sys.env.getOrElse("SBT_AIRFRAME_VERSION", "2026.1.7-0-938ab3b9-20260701-0115-SNAPSHOT")
+// For integration testing.
+// Defaults to the next sbt-airframe release. Until that is published to Maven Central,
+// build sbt-airframe locally and point this at the snapshot:
+//   (cd sbt-airframe && ../sbt publishLocal)
+//   export SBT_AIRFRAME_VERSION=$(./scripts/dynver.sh)
+val SBT_AIRFRAME_VERSION = sys.env.getOrElse("SBT_AIRFRAME_VERSION", "2026.1.8")
 addSbtPlugin("org.wvlet.airframe" % "sbt-airframe" % SBT_AIRFRAME_VERSION)
 
 scalacOptions ++= Seq("-deprecation", "-feature")

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -14,7 +14,8 @@ addSbtPlugin("org.wvlet.uni" % "sbt-uni-crossproject" % "2026.1.14")
 // For background fork-run (sbt-revolver replacement) and HTTP/RPC client code generation
 addSbtPlugin("org.wvlet.uni" % "sbt-uni" % "2026.1.14")
 
-// For Scala.js + Playwright test (also replaces scalajs-env-jsdom-nodejs, which has no Scala 3 build)
+// For Scala.js DOM tests. Replaces scalajs-env-jsdom-nodejs, which has no Scala 3 build and is
+// no longer binary-compatible with current Scala.js jsenv APIs. Provides PlaywrightJSEnv.
 addSbtPlugin("org.wvlet.uni" % "sbt-uni-playwright" % "2026.1.14")
 
 // For Scala.js

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -45,7 +45,7 @@ libraryDependencies += "org.antlr" % "antlr4" % "4.13.2"
 // build sbt-airframe locally and point this at the snapshot:
 //   (cd sbt-airframe && ../sbt publishLocal)
 //   export SBT_AIRFRAME_VERSION=$(./scripts/dynver.sh)
-val SBT_AIRFRAME_VERSION = sys.env.getOrElse("SBT_AIRFRAME_VERSION", "2026.1.8")
+val SBT_AIRFRAME_VERSION = sys.env.getOrElse("SBT_AIRFRAME_VERSION", "2026.2.0")
 addSbtPlugin("org.wvlet.airframe" % "sbt-airframe" % SBT_AIRFRAME_VERSION)
 
 scalacOptions ++= Seq("-deprecation", "-feature")

--- a/sbt-airframe/.scalafmt.conf
+++ b/sbt-airframe/.scalafmt.conf
@@ -1,5 +1,5 @@
-runner.dialect = scala212
-version = 3.3.3
+runner.dialect = scala3
+version = 3.9.4
 maxColumn = 120
 style = defaultWithAlign
 optIn.breaksInsideChains = true

--- a/sbt-airframe/build.sbt
+++ b/sbt-airframe/build.sbt
@@ -3,7 +3,8 @@ Global / onChangedBuildSource := ReloadOnSourceChanges
 
 val AIRFRAME_VERSION = sys.env.getOrElse("AIRFRAME_VERSION", "24.12.1")
 val AIRSPEC_VERSION  = sys.env.getOrElse("AIRSPEC_VERSION", "24.12.1")
-val SCALA_2_12       = "2.12.21"
+// sbt 2.x plugins run on Scala 3
+val PLUGIN_SCALA_VERSION = "3.8.3"
 
 ThisBuild / organization := "org.wvlet.airframe"
 
@@ -36,9 +37,7 @@ val buildSettings = Seq[Setting[?]](
   javacOptions ++= Seq("-source", "11", "-target", "11"),
   scalacOptions ++= Seq(
     "-feature",
-    "-deprecation",
-    // For using import * syntax
-    "-Xsource:3"
+    "-deprecation"
   ),
   testFrameworks += new TestFramework("wvlet.airspec.Framework"),
   libraryDependencies ++= Seq(
@@ -63,10 +62,16 @@ lazy val sbtAirframe =
       buildInfoPackage := "wvlet.airframe.sbt",
       name             := "sbt-airframe",
       description      := "sbt plugin for helping programming with Airframe",
-      scalaVersion     := SCALA_2_12,
+      scalaVersion     := PLUGIN_SCALA_VERSION,
       libraryDependencies ++= Seq(
-        "io.get-coursier"    %% "coursier"              % "2.1.24",
-        "org.apache.commons"  % "commons-compress"      % "1.28.0",
+        // coursier has no Scala 3 build yet. Its scala-xml/scala-collection-compat (_2.13) transitive
+        // deps conflict with the _3 variants pulled in natively, so exclude and re-add them for Scala 3.
+        ("io.get-coursier" %% "coursier" % "2.1.24")
+          .cross(CrossVersion.for3Use2_13)
+          .excludeAll(ExclusionRule(organization = "org.scala-lang.modules")),
+        "org.scala-lang.modules" %% "scala-xml"               % "2.3.0",
+        "org.scala-lang.modules" %% "scala-collection-compat" % "2.14.0",
+        "org.apache.commons" % "commons-compress" % "1.28.0",
         "org.wvlet.airframe" %% "airframe-control"      % AIRFRAME_VERSION,
         "org.wvlet.airframe" %% "airframe-codec"        % AIRFRAME_VERSION,
         "org.wvlet.airframe" %% "airframe-log"          % AIRFRAME_VERSION,

--- a/sbt-airframe/project/build.properties
+++ b/sbt-airframe/project/build.properties
@@ -11,4 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-sbt.version=1.12.2
+sbt.version=2.0.1

--- a/sbt-airframe/project/plugin.sbt
+++ b/sbt-airframe/project/plugin.sbt
@@ -9,7 +9,6 @@ addDependencyTreePlugin
 // For setting explicit versions for each commit
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.1.1")
 
-// For sbt-airframe
-libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
+// ScriptedPlugin is bundled with sbt 2.x itself, no separate scripted-plugin dependency needed
 
 scalacOptions ++= Seq("-deprecation", "-feature")

--- a/sbt-airframe/src/main/scala/wvlet/airframe/sbt/http/AirframeHttpPlugin.scala
+++ b/sbt-airframe/src/main/scala/wvlet/airframe/sbt/http/AirframeHttpPlugin.scala
@@ -102,7 +102,7 @@ object AirframeHttpPlugin extends AutoPlugin with LogSupport {
         val classpaths =
           ((Compile / dependencyClasspath).value.files :+ (Compile / classDirectory).value)
             .map {
-              case f: File           => f
+              case f: File               => f
               case p: java.nio.file.Path => p.toFile
             }
             .map { p =>

--- a/sbt-airframe/src/main/scala/wvlet/airframe/sbt/http/AirframeHttpPlugin.scala
+++ b/sbt-airframe/src/main/scala/wvlet/airframe/sbt/http/AirframeHttpPlugin.scala
@@ -25,6 +25,7 @@ import wvlet.airframe.codec.MessageCodec
 import wvlet.airframe.control.OS
 import wvlet.log.LogSupport
 import wvlet.log.io.IOUtil.withResource
+import xsbti.FileConverter
 
 import scala.sys.process.*
 
@@ -93,12 +94,17 @@ object AirframeHttpPlugin extends AutoPlugin with LogSupport {
     import sbt.Keys.*
     Seq(
       airframeHttpClients := Seq.empty,
-      airframeHttpClasspass := {
+      airframeHttpClasspass := Def.uncached {
+        given FileConverter = fileConverter.value
         // Compile all dependent projects
         val compileResults = (Compile / compile).all(dependentProjects).value
         val baseDir        = (ThisBuild / baseDirectory).value
         val classpaths =
           ((Compile / dependencyClasspath).value.files :+ (Compile / classDirectory).value)
+            .map {
+              case f: File           => f
+              case p: java.nio.file.Path => p.toFile
+            }
             .map { p =>
               p.relativeTo(baseDir).getOrElse(p).getPath
             }
@@ -113,7 +119,7 @@ object AirframeHttpPlugin extends AutoPlugin with LogSupport {
         }
       },
       airframeHttpVersion := wvlet.airframe.sbt.BuildInfo.airframeVersion,
-      airframeHttpBinaryDir := {
+      airframeHttpBinaryDir := Def.uncached {
         // This task is for downloading airframe-http library to parse Airframe HTTP/RPC interfaces using a forked JVM.
         // Without forking JVM, sbt's class loader cannot load @RPC and @Endpoint annotations.
         val airframeVersion        = airframeHttpVersion.value
@@ -182,20 +188,22 @@ object AirframeHttpPlugin extends AutoPlugin with LogSupport {
         airframeHttpPackageDir
       },
       airframeHttpGeneratorOption := "",
-      airframeHttpReload := Def
-        .sequential(
-          Def.task {
-            // Need to run the clean task first to avoid ClassNotFound error when using Scala 2.13 with sbt (running in Scala 2.12)
-            val cleanTask       = clean.value
-            val targetDir: File = airframeHttpWorkDir.value
-            val cacheFile       = targetDir / cacheFileName
-            IO.delete(cacheFile)
-          },
-          airframeHttpGenerateClient
-        )
-        .value,
-      airframeHttpOutDir := (Compile / sourceManaged).value,
-      airframeHttpGenerateClient := {
+      airframeHttpReload := Def.uncached {
+        Def
+          .sequential(
+            Def.task {
+              // Need to run the clean task first to avoid ClassNotFound error when using Scala 2.13 with sbt (running in Scala 2.12)
+              val cleanTask       = clean.value
+              val targetDir: File = airframeHttpWorkDir.value
+              val cacheFile       = targetDir / cacheFileName
+              IO.delete(cacheFile)
+            },
+            airframeHttpGenerateClient
+          )
+          .value
+      },
+      airframeHttpOutDir := Def.uncached((Compile / sourceManaged).value),
+      airframeHttpGenerateClient := Def.uncached {
         val targetDir = airframeHttpWorkDir.value
         val baseDir   = targetDir.relativeTo(file(".")).getOrElse(targetDir)
         val binDir    = airframeHttpBinaryDir.value
@@ -230,48 +238,52 @@ object AirframeHttpPlugin extends AutoPlugin with LogSupport {
       ),
       airframeHttpOpenAPITargetDir := target.value,
       airframeHttpOpenAPIPackages  := Seq.empty,
-      airframeHttpOpenAPIGenerate := Def
-        .task {
-          val config             = airframeHttpOpenAPIConfig.value
-          val workDir            = airframeHttpWorkDir.value
-          val baseDir            = workDir.relativeTo(file(".")).getOrElse(workDir)
-          val formatType: String = config.format
-          val outFile: File      = airframeHttpOpenAPITargetDir.value / s"${config.filePrefix}.${formatType}"
-          val binDir: File       = airframeHttpBinaryDir.value
-          val cp                 = airframeHttpClasspass.value
-          val packages           = airframeHttpOpenAPIPackages.value
-          val opts               = airframeHttpOpts.value
+      airframeHttpOpenAPIGenerate := Def.uncached {
+        Def
+          .task {
+            val config             = airframeHttpOpenAPIConfig.value
+            val workDir            = airframeHttpWorkDir.value
+            val baseDir            = workDir.relativeTo(file(".")).getOrElse(workDir)
+            val formatType: String = config.format
+            val outFile: File      = airframeHttpOpenAPITargetDir.value / s"${config.filePrefix}.${formatType}"
+            val binDir: File       = airframeHttpBinaryDir.value
+            val cp                 = airframeHttpClasspass.value
+            val packages           = airframeHttpOpenAPIPackages.value
+            val opts               = airframeHttpOpts.value
 
-          val cmdOpts = OpenAPIGeneratorOption(
-            classpath = cp,
-            outFile = outFile,
-            formatType = formatType,
-            title = config.title,
-            version = config.version,
-            packageNames = packages
-          )
-          val optFile = baseDir / "openapi-opts.json"
-          if (packages.isEmpty) {
-            Seq.empty
-          } else {
-            val optJson = MessageCodec.of[OpenAPIGeneratorOption].toJson(cmdOpts)
-            trace(s"OpenAPI schema generator option:\n${optJson}")
-            IO.write(optFile, optJson)
+            val cmdOpts = OpenAPIGeneratorOption(
+              classpath = cp,
+              outFile = outFile,
+              formatType = formatType,
+              title = config.title,
+              version = config.version,
+              packageNames = packages
+            )
+            val optFile = baseDir / "openapi-opts.json"
+            if (packages.isEmpty) {
+              Seq.empty
+            } else {
+              val optJson = MessageCodec.of[OpenAPIGeneratorOption].toJson(cmdOpts)
+              trace(s"OpenAPI schema generator option:\n${optJson}")
+              IO.write(optFile, optJson)
 
-            val cmd = s"${binDir}/bin/${generatorName} openapiFromJson ${opts} ${optFile}"
-            debug(cmd)
-            Process(cmd).!!
-            Seq(outFile)
+              val cmd = s"${binDir}/bin/${generatorName} openapiFromJson ${opts} ${optFile}"
+              debug(cmd)
+              Process(cmd).!!
+              Seq(outFile)
+            }
           }
-        }
-        .dependsOn(Compile / compile)
-        .value,
+          .dependsOn(Compile / compile)
+          .value
+      },
       // Generate HTTP clients before compilation
       Compile / sourceGenerators += airframeHttpGenerateClient,
       // Generate OpenAPI doc when generating package
-      Compile / `package` := (Compile / `package`)
-        .dependsOn(airframeHttpOpenAPIGenerate)
-        .value
+      Compile / `package` := Def.uncached {
+        (Compile / `package`)
+          .dependsOn(airframeHttpOpenAPIGenerate)
+          .value
+      }
     )
   }
 

--- a/sbt-airframe/src/main/scala/wvlet/airframe/sbt/http/AirframeHttpPlugin.scala
+++ b/sbt-airframe/src/main/scala/wvlet/airframe/sbt/http/AirframeHttpPlugin.scala
@@ -236,7 +236,9 @@ object AirframeHttpPlugin extends AutoPlugin with LogSupport {
         title = name.value,
         version = version.value
       ),
-      airframeHttpOpenAPITargetDir := target.value,
+      // Use the base target directory (sbt 1.x target.value location). In sbt 2.x target.value
+      // resolves to a versioned target/out/... path, which would change the output location.
+      airframeHttpOpenAPITargetDir := baseDirectory.value / "target",
       airframeHttpOpenAPIPackages  := Seq.empty,
       airframeHttpOpenAPIGenerate := Def.uncached {
         Def

--- a/sbt-airframe/src/sbt-test/sbt-airframe/js-client/build.sbt
+++ b/sbt-airframe/src/sbt-test/sbt-airframe/js-client/build.sbt
@@ -10,7 +10,7 @@ lazy val spi =
     .crossType(CrossType.Pure)
     .in(file("spi"))
     .settings(
-      libraryDependencies += "org.wvlet.airframe" %%% "airframe-http" % sys.props("airframe.version")
+      libraryDependencies += "org.wvlet.airframe" %% "airframe-http" % sys.props("airframe.version")
     )
 
 lazy val client =
@@ -24,7 +24,7 @@ lazy val client =
     )
     .jsSettings(
       libraryDependencies ++= Seq(
-        "org.scala-js" %%% "scalajs-dom" % "2.8.1"
+        "org.scala-js" %% "scalajs-dom" % "2.8.1"
       )
     )
     .dependsOn(spi)

--- a/sbt-airframe/src/sbt-test/sbt-airframe/js-client/project/plugins.sbt
+++ b/sbt-airframe/src/sbt-test/sbt-airframe/js-client/project/plugins.sbt
@@ -6,6 +6,6 @@ sys.props.get("plugin.version") match {
 }
 
 // For Scala.js
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")
-val SCALAJS_VERSION = sys.env.getOrElse("SCALAJS_VERSION", "1.20.2")
+addSbtPlugin("org.wvlet.uni" % "sbt-uni-crossproject" % "2026.1.14")
+val SCALAJS_VERSION = sys.env.getOrElse("SCALAJS_VERSION", "1.22.0")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % SCALAJS_VERSION)

--- a/sbt-airframe/src/sbt-test/sbt-airframe/openapi/build.sbt
+++ b/sbt-airframe/src/sbt-test/sbt-airframe/openapi/build.sbt
@@ -14,7 +14,7 @@ libraryDependencies ++= Seq(
 )
 
 TaskKey[Unit]("check") := {
-  val yaml = IO.read(target.value / "openapi.yaml")
+  val yaml = IO.read(baseDirectory.value / "target" / "openapi.yaml")
   val expected = Seq(
     "title: 'Open API Test'",
     "version: '1.0.0'",


### PR DESCRIPTION
## Summary

Migrates the entire repository build from **sbt 1.12.2 → sbt 2.0.1**. sbt 2.x runs its build DSL on Scala 3 and changes several defaults (all tasks cached, dependency eviction promoted to errors, platform-aware `%%`, `exportJars` default), so this touches build tooling across all six sub-builds: root, `sbt-airframe`, `airspec`, and the three example projects.

## Plugin replacements

| Old | New |
|-----|-----|
| `sbt-scalajs-crossproject` + `sbt-scala-native-crossproject` | [`org.wvlet.uni:sbt-uni-crossproject`](https://wvlet.org/uni/build/sbt-uni-crossproject) `2026.1.14` |
| `sbt-revolver` (`reStart`) | [`org.wvlet.uni:sbt-uni`](https://wvlet.org/uni/build/sbt-uni) `2026.1.14` — `uniRestart` background fork-run |
| `scalajs-env-jsdom-nodejs` / `PWEnv` (no Scala 3 build) | `sbt-uni-playwright` → `PlaywrightJSEnv` |
| `sbt-antlr4` (no sbt 2.x build) | ANTLR4 tool invoked directly from a `sourceGenerators` task in `airframe-sql` |
| `sbt-pack` 0.23→1.0.0, `sbt-mima` 1.1.4→1.1.6, `sbt-jmh` 0.4.7→0.4.8, `sbt-scalajs`→1.22.0, `sbt-scala-native`→0.5.12, `sbt-ide-settings`→1.1.4 | sbt2 builds |

## Source-level fixes for the Scala 3 build DSL

- Vararg splices `xs: _*` → `xs*`; parenthesized single-arg lambdas `{ x: T => }` → `{ (x: T) => }`
- `PathFinder.get` → `.get()`; `%%%` → `%%`
- `Def.uncached(...)` wrapping for `File`/`JSEnv`/`CompileAnalysis`-typed tasks (now cached by default)
- `evictionErrorLevel := Warn` (sbt 2.x promotes eviction conflicts to errors) and `exportJars := false` (sbt 2.x defaults it to true, which broke file-based resource loading e.g. `YamlReader`)
- `ConflictWarning.disable` in metabuilds (sbt-airframe → coursier pulls `_2.13` scala-xml vs `_3`)

## `sbt-airframe` — migrated in-repo, sbt-2-only, released as `2026.2.0`

`sbt-airframe` has no published sbt 2.x artifact, so it is migrated in-repo (Scala 3.8.3; `FileConverter` + `Def.uncached` fixes in `AirframeHttpPlugin.scala`; coursier `for3Use2_13` + module exclusions). **It now supports only sbt 2.x (drops sbt 1.x / Scala 2.12)**, so the whole airframe suite is bumped a minor to **`2026.2.0`** to signal that. The root build, `integrationTest`, and the RPC examples consume it via `SBT_AIRFRAME_VERSION` (default `2026.2.0`). Its release workflow now publishes the `_3` (not `_2.12`) airframe libraries it depends on.

`integrationTest` deliberately **keeps `AirframeHttpPlugin`** (not sbt-uni) because its purpose is to test that plugin's own client codegen.

### CI bootstrap (temporary)

The root metabuild needs `sbt-airframe 2026.2.0` to load, but that can only be released from `main` after this merges — a release deadlock. A temporary `bootstrap-sbt-airframe` composite action `publishLocal`s it in the jobs that load the root build. **Remove it once `sbt-airframe 2026.2.0` is on Maven Central.**

## Ship order

1. Merge this PR.
2. `ruby ./scripts/release.rb` on `main`, entering `2026.2.0` at the prompt → tag `v2026.2.0` → publishes `org.wvlet.airframe:sbt-airframe_sbt2_3:2026.2.0` (and the rest of the suite) to Maven Central.
3. Remove the temporary CI bootstrap action/steps (the default `SBT_AIRFRAME_VERSION=2026.2.0` then resolves from Central).

## Validation

All 13 CI checks green: Code format; Scala 2.12/2.13/3/3.7.x/JDK25; Scala 3 Integration Test; Scala.js 2.12/2.13/3; Scala Native; AirSpec; sbt-airframe (scripted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)