### PR TITLE
internal: Bootstrap sbt-airframe in release workflows (release 2026.2.1)

### DIFF
--- a/.github/actions/bootstrap-sbt-airframe/action.yml
+++ b/.github/actions/bootstrap-sbt-airframe/action.yml
@@ -1,7 +1,7 @@
 name: Bootstrap sbt-airframe
 description: >
   Publish the in-repo sbt-airframe plugin to the local Ivy repo so the main build's
-  metabuild can resolve it. Temporary: remove once sbt-airframe 2026.2.0 is published
+  metabuild can resolve it. Temporary: remove once sbt-airframe 2026.2.1 is published
   to Maven Central (the main build then resolves it normally via SBT_AIRFRAME_VERSION).
 runs:
   using: composite
@@ -9,4 +9,4 @@ runs:
     - name: Publish sbt-airframe locally
       shell: bash
       # Pin the version to the SBT_AIRFRAME_VERSION default in project/plugin.sbt.
-      run: cd sbt-airframe && ../sbt 'set every version := "2026.2.0"' publishLocal
+      run: cd sbt-airframe && ../sbt 'set every version := "2026.2.1"' publishLocal

--- a/.github/workflows/release-js.yml
+++ b/.github/workflows/release-js.yml
@@ -27,6 +27,8 @@ jobs:
         env:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
         run: echo $PGP_SECRET | base64 --decode | gpg --import --batch --yes
+      # The root build's metabuild needs the (not-yet-released) sbt-airframe plugin to load.
+      - uses: ./.github/actions/bootstrap-sbt-airframe
       - name: Build for Scala.js
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}

--- a/.github/workflows/release-native.yml
+++ b/.github/workflows/release-native.yml
@@ -29,6 +29,8 @@ jobs:
         env:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
         run: echo $PGP_SECRET | base64 --decode | gpg --import --batch --yes
+      # The root build's metabuild needs the (not-yet-released) sbt-airframe plugin to load.
+      - uses: ./.github/actions/bootstrap-sbt-airframe
       - name: Build for Scala Native
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}

--- a/.github/workflows/release-sbt-plugin.yml
+++ b/.github/workflows/release-sbt-plugin.yml
@@ -28,6 +28,11 @@ jobs:
         env:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
         run: echo $PGP_SECRET | base64 --decode | gpg --import --batch --yes
+      # Break the release-time circular dependency: the root build's metabuild needs the
+      # sbt-airframe plugin to load, but sbt-airframe is what we're releasing. Publish it locally
+      # FIRST, before AIRFRAME_VERSION is set, so its own deps resolve from the last released
+      # airframe on Maven Central rather than the (not-yet-built) release version.
+      - uses: ./.github/actions/bootstrap-sbt-airframe
       - name: Get Airframe version
         run: echo "AIRFRAME_VERSION=$(./scripts/dynver.sh)" >> $GITHUB_ENV
       - name: Check Airframe version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,8 @@ jobs:
         env:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
         run: echo $PGP_SECRET | base64 --decode | gpg --import --batch --yes
+      # The root build's metabuild needs the (not-yet-released) sbt-airframe plugin to load.
+      - uses: ./.github/actions/bootstrap-sbt-airframe
       - name: Build bundle
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}

--- a/examples/rpc-examples/hello-rpc/project/plugins.sbt
+++ b/examples/rpc-examples/hello-rpc/project/plugins.sbt
@@ -1,4 +1,4 @@
-val SBT_AIRFRAME_VERSION = sys.env.getOrElse("SBT_AIRFRAME_VERSION", "2026.2.0")
+val SBT_AIRFRAME_VERSION = sys.env.getOrElse("SBT_AIRFRAME_VERSION", "2026.2.1")
 addSbtPlugin("org.xerial.sbt"     % "sbt-pack"     % "1.0.0")
 addSbtPlugin("org.wvlet.airframe" % "sbt-airframe" % SBT_AIRFRAME_VERSION)
 addSbtPlugin("org.scalameta"      % "sbt-scalafmt" % "2.5.6")

--- a/examples/rpc-examples/rpc-scalajs/project/plugins.sbt
+++ b/examples/rpc-examples/rpc-scalajs/project/plugins.sbt
@@ -1,4 +1,4 @@
-val SBT_AIRFRAME_VERSION = sys.env.getOrElse("SBT_AIRFRAME_VERSION", "2026.2.0")
+val SBT_AIRFRAME_VERSION = sys.env.getOrElse("SBT_AIRFRAME_VERSION", "2026.2.1")
 addSbtPlugin("org.wvlet.airframe" % "sbt-airframe"         % SBT_AIRFRAME_VERSION)
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"          % "1.22.0")
 addSbtPlugin("org.wvlet.uni"      % "sbt-uni-crossproject" % "2026.1.14")

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -45,7 +45,7 @@ libraryDependencies += "org.antlr" % "antlr4" % "4.13.2"
 // build sbt-airframe locally and point this at the snapshot:
 //   (cd sbt-airframe && ../sbt publishLocal)
 //   export SBT_AIRFRAME_VERSION=$(./scripts/dynver.sh)
-val SBT_AIRFRAME_VERSION = sys.env.getOrElse("SBT_AIRFRAME_VERSION", "2026.2.0")
+val SBT_AIRFRAME_VERSION = sys.env.getOrElse("SBT_AIRFRAME_VERSION", "2026.2.1")
 addSbtPlugin("org.wvlet.airframe" % "sbt-airframe" % SBT_AIRFRAME_VERSION)
 
 scalacOptions ++= Seq("-deprecation", "-feature")


### PR DESCRIPTION
## Why

The `v2026.2.0` release **partially failed**. Every release workflow that loads the root build — `Release Scala JVM` / `Scala.js` / `Scala Native` / `sbt-airframe` — couldn't resolve `sbt-airframe_sbt2_3:2026.2.0`, because the root metabuild depends on the very plugin being released (the same bootstrap deadlock, now in the release path). Only the standalone `Release AirSpec` (no sbt-airframe dependency) succeeded — so `airspec 2026.2.0` is live on Central, but the rest of the suite is not.

## What this does

- Adds the existing `bootstrap-sbt-airframe` composite action to the four release workflows so the root build can load.
- In `release-sbt-plugin.yml`, the bootstrap runs **before** `AIRFRAME_VERSION` is set, so the plugin's own `airframe-*` deps resolve from the last released version on Maven Central rather than the not-yet-built release version — breaking the circular dependency. The subsequent `projectJVM/publishLocal` then produces the real `2026.2.1` libs, and the authoritative `publishSigned` builds sbt-airframe against them.
- Bumps `SBT_AIRFRAME_VERSION` defaults and the bootstrap version to **`2026.2.1`**.

## Recovery plan

`airspec 2026.2.0` is already published and Central versions are immutable, so instead of rewriting the released tag we cut a fresh patch. After merge: tag `v2026.2.1` → all release workflows publish the complete `2026.2.1` suite. `2026.2.0` remains a harmless partial (only `airspec`, which the main build doesn't depend on — it pins `AIRSPEC_VERSION=24.12.1`).

Once `2026.2.1` is confirmed on Central, the temporary CI + release bootstrap can be removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)