### PR TITLE
internal: Fix sbt-airframe release (projectDotty); release 2026.2.2

### DIFF
--- a/.github/actions/bootstrap-sbt-airframe/action.yml
+++ b/.github/actions/bootstrap-sbt-airframe/action.yml
@@ -1,7 +1,7 @@
 name: Bootstrap sbt-airframe
 description: >
   Publish the in-repo sbt-airframe plugin to the local Ivy repo so the main build's
-  metabuild can resolve it. Temporary: remove once sbt-airframe 2026.2.1 is published
+  metabuild can resolve it. Temporary: remove once sbt-airframe 2026.2.2 is published
   to Maven Central (the main build then resolves it normally via SBT_AIRFRAME_VERSION).
 runs:
   using: composite
@@ -9,4 +9,4 @@ runs:
     - name: Publish sbt-airframe locally
       shell: bash
       # Pin the version to the SBT_AIRFRAME_VERSION default in project/plugin.sbt.
-      run: cd sbt-airframe && ../sbt 'set every version := "2026.2.1"' publishLocal
+      run: cd sbt-airframe && ../sbt 'set every version := "2026.2.2"' publishLocal

--- a/.github/workflows/release-sbt-plugin.yml
+++ b/.github/workflows/release-sbt-plugin.yml
@@ -39,8 +39,10 @@ jobs:
         run: echo ${AIRFRAME_VERSION}
       # sbt-airframe is a Scala 3 sbt 2.x plugin, so it depends on the _3 variants
       # of airframe-control/codec/log/http-codegen at the release version.
+      # Use projectDotty (the Scala 3 JVM aggregate) rather than projectJVM, which also
+      # includes the Scala-2-only finagle module that cannot compile on Scala 3.
       - name: Create Airframe artifacts locally
-        run: ./sbt "projectJVM/publishLocal"
+        run: ./sbt "projectDotty/publishLocal"
       - name: Build sbt-airframe bundle
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}

--- a/examples/rpc-examples/hello-rpc/project/plugins.sbt
+++ b/examples/rpc-examples/hello-rpc/project/plugins.sbt
@@ -1,4 +1,4 @@
-val SBT_AIRFRAME_VERSION = sys.env.getOrElse("SBT_AIRFRAME_VERSION", "2026.2.1")
+val SBT_AIRFRAME_VERSION = sys.env.getOrElse("SBT_AIRFRAME_VERSION", "2026.2.2")
 addSbtPlugin("org.xerial.sbt"     % "sbt-pack"     % "1.0.0")
 addSbtPlugin("org.wvlet.airframe" % "sbt-airframe" % SBT_AIRFRAME_VERSION)
 addSbtPlugin("org.scalameta"      % "sbt-scalafmt" % "2.5.6")

--- a/examples/rpc-examples/rpc-scalajs/project/plugins.sbt
+++ b/examples/rpc-examples/rpc-scalajs/project/plugins.sbt
@@ -1,4 +1,4 @@
-val SBT_AIRFRAME_VERSION = sys.env.getOrElse("SBT_AIRFRAME_VERSION", "2026.2.1")
+val SBT_AIRFRAME_VERSION = sys.env.getOrElse("SBT_AIRFRAME_VERSION", "2026.2.2")
 addSbtPlugin("org.wvlet.airframe" % "sbt-airframe"         % SBT_AIRFRAME_VERSION)
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"          % "1.22.0")
 addSbtPlugin("org.wvlet.uni"      % "sbt-uni-crossproject" % "2026.1.14")

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -45,7 +45,7 @@ libraryDependencies += "org.antlr" % "antlr4" % "4.13.2"
 // build sbt-airframe locally and point this at the snapshot:
 //   (cd sbt-airframe && ../sbt publishLocal)
 //   export SBT_AIRFRAME_VERSION=$(./scripts/dynver.sh)
-val SBT_AIRFRAME_VERSION = sys.env.getOrElse("SBT_AIRFRAME_VERSION", "2026.2.1")
+val SBT_AIRFRAME_VERSION = sys.env.getOrElse("SBT_AIRFRAME_VERSION", "2026.2.2")
 addSbtPlugin("org.wvlet.airframe" % "sbt-airframe" % SBT_AIRFRAME_VERSION)
 
 scalacOptions ++= Seq("-deprecation", "-feature")


### PR DESCRIPTION
## Why

Follow-up to the `2026.2.1` release attempt. The bootstrap fix worked (releases got past plugin resolution), but the `sbt-airframe` release then failed: `release-sbt-plugin.yml` built the airframe dependency libs with `projectJVM/publishLocal` on Scala 3, and `projectJVM` includes the **Scala-2-only `finagle`** module, which can't compile on Scala 3 (98 errors).

Fix: use **`projectDotty`** (the Scala 3 JVM aggregate that excludes finagle) — a one-line change.

## Why a new version (`2026.2.2`)

`Release Scala Native` for `2026.2.1` completed and published `airframe-*_native0.5_3:2026.2.1` before the other jobs were cancelled. Central versions are immutable, so `2026.2.1` can't be reused for a complete release. Cutting `2026.2.2` gives one consistent version for the whole suite; the `2026.2.0` (airspec) and `2026.2.1` (native) partials remain harmless orphans (nothing depends on them — the main build pins `AIRSPEC_VERSION=24.12.1`).

## Validation

Dry-ran the full sbt-airframe release chain locally (no Central):
1. Bootstrap `publishLocal` sbt-airframe `2026.2.2` (deps resolve from released `24.12.1`) — ✅
2. `projectDotty/publishLocal` → `airframe-*:2026.2.2`, 0 errors, no finagle — ✅
3. Build sbt-airframe against the local `2026.2.2` libs + `publishLocal` — ✅

## After merge

Tag `v2026.2.2` → all six release workflows publish the complete suite. Then remove the temporary CI + release bootstrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)