### PR TITLE
internal: Update examples to airframe 2026.2.2 on sbt 2

### DIFF
--- a/examples/rpc-examples/hello-rpc/build.sbt
+++ b/examples/rpc-examples/hello-rpc/build.sbt
@@ -1,5 +1,5 @@
-val AIRFRAME_VERSION = "2026.1.1"
-ThisBuild / scalaVersion := "3.2.2"
+val AIRFRAME_VERSION = "2026.2.2"
+ThisBuild / scalaVersion := "3.3.7"
 
 // RPC API definition. This project should contain only RPC interfaces
 lazy val api =

--- a/examples/rpc-examples/rpc-scalajs/build.sbt
+++ b/examples/rpc-examples/rpc-scalajs/build.sbt
@@ -1,7 +1,7 @@
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
-val AIRFRAME_VERSION = "2026.1.1"
-ThisBuild / scalaVersion := "3.2.2"
+val AIRFRAME_VERSION = "2026.2.2"
+ThisBuild / scalaVersion := "3.3.7"
 
 lazy val rpcExample =
   project

--- a/examples/rx-demo/gallery/build.sbt
+++ b/examples/rx-demo/gallery/build.sbt
@@ -1,7 +1,7 @@
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
-val AIRFRAME_VERSION = "2026.1.1"
-ThisBuild / scalaVersion := "2.13.18"
+val AIRFRAME_VERSION = "2026.2.2"
+ThisBuild / scalaVersion := "3.3.7"
 
 lazy val gallery =
   project
@@ -9,10 +9,6 @@ lazy val gallery =
     .in(file("."))
     .settings(
       scalaJSUseMainModuleInitializer := false,
-      scalacOptions ++= Seq(
-        // Necessary for tracking source code range in airframe-rx demo
-        "-Yrangepos"
-      ),
       libraryDependencies ++= Seq(
         "org.wvlet.airframe" %% "airframe-rx-html" % AIRFRAME_VERSION
       )

--- a/examples/rx-demo/gallery/src/main/scala/Gallery.scala
+++ b/examples/rx-demo/gallery/src/main/scala/Gallery.scala
@@ -165,7 +165,7 @@ object Gallery extends LogSupport {
       div(
         button(
           cls -> "btn btn-primary",
-          onclick { e: dom.Event =>
+          onclick { (e: dom.Event) =>
             v.update(_ + 1)
           },
           "Increment"


### PR DESCRIPTION
## Summary

Finishes the sbt 2.0.1 migration for the example projects (not covered by CI) now that `airframe 2026.2.2` is on Maven Central.

- Bump the examples' airframe **library** dependency `2026.1.1` → `2026.2.2`, matching their `sbt-airframe 2026.2.2` plugin.
- Move the Scala 3 examples (`rpc-scalajs`, `hello-rpc`) to **Scala 3.3.7**: the `2026.2.2` `_3` artifacts are built with 3.3.7, whose TASTy a 3.2.2 consumer can't read.
- Move `gallery` to Scala 3.3.7 as well (its source already uses Scala 3 `import ...all.*`), drop the Scala-2-only `-Yrangepos`, and parenthesize one single-arg lambda for Scala 3.

## Verified

All three examples compile against the published `2026.2.2` artifacts. `hello-rpc` and `rpc-scalajs` also exercise the `AirframeHttpPlugin` RPC client codegen end-to-end (generated `GreeterRPC.scala` / `ServiceRPC.scala`, downloading `airframe-http-codegen 2026.2.2`).

## Docs

No changes needed: `docs/mdoc` compiles cleanly under sbt 2.0.1 (30 files, 0 errors — the one warning is a pre-existing broken link). The `docusaurusPublishGhpages` step is node-side tooling, unaffected by the sbt migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)